### PR TITLE
fix(config): isolate local state from target repositories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .starfix
+.reposteward
 .venv
 __pycache__
 *.pyc
@@ -7,3 +8,8 @@ __pycache__
 .ruff_cache
 dist
 build
+notes
+.env
+.env.*
+*.sqlite
+*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 .ruff_cache/
 .starfix/
 .reposteward/
+.reposteward.toml
+reposteward.local.toml
 dist/
 build/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ uv run reposteward repo add owner/repository --mode maintainer
 贡献者模式默认推送到用户 fork；维护者模式默认推送到原仓库的独立分支。提交前会通过 GitHub
 API 验证当前身份确实拥有 push 权限，并继续禁止直接使用默认分支。
 
-命令会创建 `.reposteward.toml`，随后需要填写该仓库允许的安装和验证命令。完整字段可参考
+命令会创建本机专用的 `.reposteward.toml`，并自动加入该仓库的 `.git/info/exclude`，不会修改
+仓库受版本控制的 `.gitignore`，也不会让配置混入后续 PR。随后需要填写该仓库允许的安装和验证命令。完整字段可参考
 [`reposteward.example.toml`](reposteward.example.toml)，现有复杂仓库适配示例位于
 [`examples/tiammomo.toml`](examples/tiammomo.toml)。
 
@@ -111,8 +112,10 @@ API 验证当前身份确实拥有 push 权限，并继续禁止直接使用默�
 ```
 
 旧的 `starfix.toml` 仍可被发现，缺少 `config_version` 的旧配置按版本 1 兼容读取。新配置
-默认把状态隔离到 `<state_dir>/<GitHub host>/<login>/`，避免切换 GitHub 用户时混用运行记录；
-旧配置保持原有状态位置。项目层不能覆盖用户层的 GitHub 身份、Agent executable 或 Runner
+默认把数据库和运行日志隔离到 `~/.local/state/reposteward/<GitHub host>/<login>/`，把临时克隆隔离到
+`~/.local/share/reposteward/workspaces/<GitHub host>/<login>/`；支持 XDG 目录变量，Windows 使用
+`LOCALAPPDATA`。这样不会在被维护的仓库中产生运行文件，也避免切换 GitHub 用户时混用记录。
+旧配置显式指定 `state_dir` 时保持原有工作区布局。项目层不能覆盖用户层的运行目录、GitHub 身份、Agent executable 或 Runner
 image；项目安全设置只能收紧用户限额和默认禁止路径，不能静默放宽它们。
 
 ## 准备 Issue 草稿
@@ -178,7 +181,7 @@ uv run reposteward logs RUN_ID
 uv run reposteward logs RUN_ID --command 1 --tail-chars 12000
 ```
 
-验证日志默认保存在 `.reposteward/runs/RUN_ID/verification/`。通过命令在数据库中保留最后
+验证日志默认保存在用户状态目录的 `runs/RUN_ID/verification/`。通过命令在数据库中保留最后
 2,000 个字符，失败命令保留最后 12,000 个字符；更完整的日志文件有 2,000,000 字符上限，
 并记录原始长度和 SHA-256。
 

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -1,7 +1,8 @@
 config_version = 1
 
 [project]
-state_dir = ".reposteward"
+state_dir = "~/.local/state/reposteward"
+workspace_dir = "~/.local/share/reposteward/workspaces"
 namespace_state = true
 
 [github]

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -70,6 +70,10 @@ class SafetyConfig:
     forbidden_paths: tuple[str, ...] = (
         ".github/workflows/",
         ".git/",
+        ".reposteward/",
+        ".starfix/",
+        ".reposteward.toml",
+        "reposteward.local.toml",
         ".env",
         "credentials",
         "secrets",
@@ -133,6 +137,7 @@ class AppConfig:
     config_version: int
     path: Path
     state_dir: Path
+    workspace_dir: Path
     state_namespace: bool
     github: GitHubConfig
     discovery: DiscoveryConfig
@@ -170,6 +175,29 @@ def default_user_config_path() -> Path:
     base = os.environ.get("XDG_CONFIG_HOME", "").strip()
     root = Path(base).expanduser() if base else Path.home() / ".config"
     return (root / "reposteward" / "config.toml").resolve()
+
+
+def default_state_dir() -> Path:
+    """Return the per-user runtime-state root without creating it."""
+    if os.name == "nt" and os.environ.get("LOCALAPPDATA", "").strip():
+        return (Path(os.environ["LOCALAPPDATA"]).expanduser() / "RepoSteward").resolve()
+    base = os.environ.get("XDG_STATE_HOME", "").strip()
+    root = Path(base).expanduser() if base else Path.home() / ".local" / "state"
+    return (root / "reposteward").resolve()
+
+
+def default_workspace_dir() -> Path:
+    """Return the per-user disposable-workspace root without creating it."""
+    if os.name == "nt" and os.environ.get("LOCALAPPDATA", "").strip():
+        root = Path(os.environ["LOCALAPPDATA"]).expanduser() / "RepoSteward"
+    else:
+        base = os.environ.get("XDG_DATA_HOME", "").strip()
+        root = (
+            Path(base).expanduser() / "reposteward"
+            if base
+            else Path.home() / ".local" / "share" / "reposteward"
+        )
+    return (root / "workspaces").resolve()
 
 
 def discover_project_config(start: Path | None = None) -> Path | None:
@@ -228,6 +256,25 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
     result = _merge(user, project)
     if not user:
         return result
+
+    # Runtime state and disposable clones belong to the user/machine trust layer.
+    # A repository-local config must not redirect them into the target repository.
+    user_project = user.get("project")
+    project_project = project.get("project")
+    trusted_project = user_project if isinstance(user_project, dict) else {}
+    merged_project = _merge(
+        trusted_project,
+        project_project if isinstance(project_project, dict) else {},
+    )
+    for key in ("state_dir", "workspace_dir", "namespace_state"):
+        if key in trusted_project:
+            merged_project[key] = trusted_project[key]
+        else:
+            merged_project.pop(key, None)
+    if merged_project:
+        result["project"] = merged_project
+    else:
+        result.pop("project", None)
 
     user_github = user.get("github")
     if isinstance(user_github, dict):
@@ -338,7 +385,8 @@ def load_config(
     _validate_config_version(raw, config_path)
 
     project = _section(raw, "project")
-    state_value = str(project.get("state_dir", ".reposteward"))
+    state_is_explicit = "state_dir" in project
+    state_value = str(project.get("state_dir", default_state_dir()))
     state_dir = Path(state_value).expanduser()
     if not state_dir.is_absolute():
         project_section = project_raw.get("project", {})
@@ -348,8 +396,30 @@ def load_config(
         elif isinstance(user_section, dict) and "state_dir" in user_section:
             state_base = resolved_user_path.parent if resolved_user_path else Path.cwd()
         else:
-            state_base = project_path.parent if project_path else Path.cwd()
+            state_base = default_state_dir().parent
         state_dir = (state_base / state_dir).resolve()
+
+    workspace_is_explicit = "workspace_dir" in project
+    workspace_dir: Path | None
+    if workspace_is_explicit:
+        workspace_dir = Path(str(project["workspace_dir"])).expanduser()
+        if not workspace_dir.is_absolute():
+            project_section = project_raw.get("project", {})
+            user_section = user_raw.get("project", {})
+            if isinstance(project_section, dict) and "workspace_dir" in project_section:
+                workspace_base = project_path.parent if project_path else Path.cwd()
+            elif isinstance(user_section, dict) and "workspace_dir" in user_section:
+                workspace_base = (
+                    resolved_user_path.parent if resolved_user_path else Path.cwd()
+                )
+            else:
+                workspace_base = default_workspace_dir().parent
+            workspace_dir = (workspace_base / workspace_dir).resolve()
+    elif state_is_explicit:
+        # Preserve the layout of existing configs that only define state_dir.
+        workspace_dir = None
+    else:
+        workspace_dir = default_workspace_dir()
 
     github_raw = _section(raw, "github")
     login = str(github_raw.get("login", "")).strip()
@@ -375,6 +445,12 @@ def load_config(
         safe_host = re.sub(r"[^a-z0-9.-]+", "-", host.casefold()).strip("-")
         safe_login = re.sub(r"[^a-z0-9._-]+", "-", github.login.casefold()).strip("-")
         state_dir = state_dir / (safe_host or "forge") / (safe_login or "user")
+        if workspace_dir is not None:
+            workspace_dir = (
+                workspace_dir / (safe_host or "forge") / (safe_login or "user")
+            )
+    if workspace_dir is None:
+        workspace_dir = state_dir / "workspaces"
 
     discovery_raw = _section(raw, "discovery")
     discovery_defaults = DiscoveryConfig()
@@ -395,13 +471,14 @@ def load_config(
 
     safety_raw = _section(raw, "safety")
     safety_defaults = SafetyConfig()
+    configured_forbidden = _tuple(safety_raw.get("forbidden_paths"))
     safety = SafetyConfig(
         max_files_changed=int(safety_raw.get("max_files_changed", 18)),
         max_diff_lines=int(safety_raw.get("max_diff_lines", 700)),
         require_verification=_boolean(safety_raw.get("require_verification"), True),
         draft_pull_requests=_boolean(safety_raw.get("draft_pull_requests"), True),
-        forbidden_paths=_tuple(
-            safety_raw.get("forbidden_paths"), safety_defaults.forbidden_paths
+        forbidden_paths=tuple(
+            dict.fromkeys(safety_defaults.forbidden_paths + configured_forbidden)
         ),
     )
 
@@ -560,6 +637,7 @@ def load_config(
         config_version=version_value or CONFIG_VERSION,
         path=config_path,
         state_dir=state_dir,
+        workspace_dir=workspace_dir,
         state_namespace=state_namespace,
         github=github,
         discovery=discovery,

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -8,7 +8,13 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from .config import CONFIG_VERSION, ConfigError, default_user_config_path
+from .config import (
+    CONFIG_VERSION,
+    ConfigError,
+    default_state_dir,
+    default_user_config_path,
+    default_workspace_dir,
+)
 
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -42,6 +48,11 @@ def _toml_string(value: str) -> str:
 
 def render_user_config(login: str, git_name: str, git_email: str) -> str:
     return f"""config_version = {CONFIG_VERSION}
+
+[project]
+state_dir = {_toml_string(str(default_state_dir()))}
+workspace_dir = {_toml_string(str(default_workspace_dir()))}
+namespace_state = true
 
 [github]
 login = {_toml_string(login)}
@@ -144,12 +155,7 @@ def add_repository(
         ):
             raise ConfigError(f"repository is already configured: {repository}")
     else:
-        existing = (
-            f"config_version = {CONFIG_VERSION}\n\n"
-            "[project]\n"
-            'state_dir = ".reposteward"\n'
-            "namespace_state = true\n"
-        )
+        existing = f"config_version = {CONFIG_VERSION}\n"
     separator = (
         ""
         if existing.endswith("\n\n")
@@ -169,9 +175,48 @@ branch_template = "{{login}}/{{scope}}/{{slug}}"
 default_scope = "repo"
 """
     _write_atomic(target, existing + separator + section, force=target.exists())
+    git_exclude_added = _exclude_local_config(target)
     return {
         "config": str(target),
         "repository": repository,
         "mode": mode,
+        "git_exclude_added": git_exclude_added,
         "next_action": "configure bootstrap_commands and verification_prefixes",
     }
+
+
+def _exclude_local_config(target: Path) -> bool:
+    """Keep an untracked local config out of target-repository changes."""
+    repository_root = _capture(
+        ["git", "-C", str(target.parent), "rev-parse", "--show-toplevel"]
+    )
+    if not repository_root:
+        return False
+    root = Path(repository_root).resolve()
+    try:
+        relative = target.resolve().relative_to(root)
+    except ValueError:
+        return False
+    tracked = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--error-unmatch", "--", str(relative)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if tracked.returncode == 0:
+        return False
+    exclude_value = _capture(
+        ["git", "-C", str(root), "rev-parse", "--git-path", "info/exclude"]
+    )
+    if not exclude_value:
+        return False
+    exclude_path = Path(exclude_value)
+    if not exclude_path.is_absolute():
+        exclude_path = root / exclude_path
+    pattern = f"/{relative.as_posix()}"
+    existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+    if pattern in existing.splitlines():
+        return False
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    _write_atomic(exclude_path, f"{existing}{separator}{pattern}\n", force=True)
+    return True

--- a/src/reposteward/workspace.py
+++ b/src/reposteward/workspace.py
@@ -66,7 +66,7 @@ def slugify(value: str, *, limit: int = 48) -> str:
 class WorkspaceManager:
     def __init__(self, config: AppConfig) -> None:
         self.config = config
-        self.root = config.state_dir / "workspaces"
+        self.root = config.workspace_dir
         self.root.mkdir(parents=True, exist_ok=True)
 
     def clone(self, candidate: Candidate) -> Path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,7 +77,14 @@ class CliSetupTests(unittest.TestCase):
                 "alice",
             ]
             output = io.StringIO()
-            with patch.dict("os.environ", {"XDG_CONFIG_HOME": str(config_home)}):
+            with patch.dict(
+                "os.environ",
+                {
+                    "XDG_CONFIG_HOME": str(config_home),
+                    "XDG_STATE_HOME": str(root / "state"),
+                    "XDG_DATA_HOME": str(root / "data"),
+                },
+            ):
                 with redirect_stdout(io.StringIO()):
                     self.assertEqual(main(initialize_args), 0)
                     self.assertEqual(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from reposteward.config import ConfigError, load_config
 
@@ -14,6 +15,7 @@ class ConfigTests(unittest.TestCase):
         config = load_config(ROOT / "examples" / "tiammomo.toml")
 
         self.assertEqual(config.github.login, "tiammomo")
+        self.assertEqual(config.workspace_dir, config.state_dir / "workspaces")
         self.assertEqual(config.runner.max_output_chars, 12_000)
         self.assertEqual(config.runner.passed_output_chars, 2_000)
         self.assertEqual(config.runner.max_log_chars, 2_000_000)
@@ -116,6 +118,7 @@ executable = "codex"
                 """config_version = 1
 [project]
 state_dir = ".state"
+workspace_dir = ".workspaces"
 [runner]
 memory = "4g"
 image = "untrusted-runner:latest"
@@ -134,7 +137,14 @@ max_diff_lines = 99
                 encoding="utf-8",
             )
 
-            config = load_config(project, user_path=user)
+            with patch.dict(
+                "os.environ",
+                {
+                    "XDG_STATE_HOME": str(root / "user-state"),
+                    "XDG_DATA_HOME": str(root / "user-data"),
+                },
+            ):
+                config = load_config(project, user_path=user)
 
         self.assertEqual(config.github.login, "alice")
         self.assertEqual(config.github.git_name, "Alice")
@@ -147,7 +157,17 @@ max_diff_lines = 99
         self.assertTrue(config.safety.require_verification)
         self.assertIn(".github/workflows/", config.safety.forbidden_paths)
         self.assertEqual(
-            config.state_dir, project.parent / ".state" / "api.github.com" / "alice"
+            config.state_dir,
+            root / "user-state" / "reposteward" / "api.github.com" / "alice",
+        )
+        self.assertEqual(
+            config.workspace_dir,
+            root
+            / "user-data"
+            / "reposteward"
+            / "workspaces"
+            / "api.github.com"
+            / "alice",
         )
         self.assertTrue(config.state_namespace)
         self.assertEqual(config.repositories["owner/repo"].max_diff_lines, 99)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import subprocess
 import tomllib
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from reposteward.config import ConfigError, load_config
 from reposteward.setup import add_repository, initialize_user_config
@@ -12,20 +14,35 @@ from reposteward.setup import add_repository, initialize_user_config
 class SetupTests(unittest.TestCase):
     def test_init_writes_versioned_user_configuration(self) -> None:
         with TemporaryDirectory() as directory:
-            path = Path(directory) / "config.toml"
+            root = Path(directory)
+            path = root / "config.toml"
 
-            result = initialize_user_config(
-                path=path,
-                login="alice",
-                git_name="Alice",
-                git_email="alice@example.com",
-            )
+            with patch.dict(
+                "os.environ",
+                {
+                    "XDG_STATE_HOME": str(root / "state"),
+                    "XDG_DATA_HOME": str(root / "data"),
+                },
+            ):
+                result = initialize_user_config(
+                    path=path,
+                    login="alice",
+                    git_name="Alice",
+                    git_email="alice@example.com",
+                )
             content = path.read_text(encoding="utf-8")
             parsed = tomllib.loads(content)
 
         self.assertEqual(result["github_login"], "alice")
         self.assertEqual(parsed["config_version"], 1)
         self.assertEqual(parsed["github"]["login"], "alice")
+        self.assertEqual(
+            parsed["project"]["state_dir"], str(root / "state" / "reposteward")
+        )
+        self.assertEqual(
+            parsed["project"]["workspace_dir"],
+            str(root / "data" / "reposteward" / "workspaces"),
+        )
         self.assertNotIn("github_token =", content.casefold())
 
     def test_init_does_not_overwrite_existing_configuration_by_default(self) -> None:
@@ -44,18 +61,31 @@ class SetupTests(unittest.TestCase):
             user = root / "user.toml"
             project = root / "project" / ".reposteward.toml"
             project.parent.mkdir()
-            initialize_user_config(path=user, login="alice")
+            with patch.dict(
+                "os.environ",
+                {
+                    "XDG_STATE_HOME": str(root / "state"),
+                    "XDG_DATA_HOME": str(root / "data"),
+                },
+            ):
+                initialize_user_config(path=user, login="alice")
 
             result = add_repository("Owner/Repo", path=project)
             config = load_config(project, user_path=user)
+            project_config = tomllib.loads(project.read_text(encoding="utf-8"))
 
         self.assertEqual(result["repository"], "Owner/Repo")
         self.assertEqual(config.github.login, "alice")
         self.assertIn("owner/repo", config.repositories)
         self.assertEqual(
             config.state_dir,
-            project.parent / ".reposteward" / "api.github.com" / "alice",
+            root / "state" / "reposteward" / "api.github.com" / "alice",
         )
+        self.assertEqual(
+            config.workspace_dir,
+            root / "data" / "reposteward" / "workspaces" / "api.github.com" / "alice",
+        )
+        self.assertNotIn("project", project_config)
 
     def test_repo_add_rejects_duplicate_case_insensitively(self) -> None:
         with TemporaryDirectory() as directory:
@@ -78,6 +108,52 @@ class SetupTests(unittest.TestCase):
         policy = config.repositories["owner/repo"]
         self.assertEqual(policy.mode, "maintainer")
         self.assertEqual(policy.submission_strategy, "same-repository")
+
+    def test_repo_add_excludes_local_config_without_changing_gitignore(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+
+            result = add_repository("owner/repo", path=root / ".reposteward.toml")
+
+            ignored = subprocess.run(
+                ["git", "-C", str(root), "check-ignore", "-q", ".reposteward.toml"],
+                check=False,
+            )
+            status = subprocess.run(
+                ["git", "-C", str(root), "status", "--short"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            gitignore_exists = (root / ".gitignore").exists()
+
+        self.assertTrue(result["git_exclude_added"])
+        self.assertEqual(ignored.returncode, 0)
+        self.assertEqual(status, "")
+        self.assertFalse(gitignore_exists)
+
+    def test_repo_add_does_not_hide_an_explicitly_tracked_config(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            config_path = root / ".reposteward.toml"
+            config_path.write_text("config_version = 1\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(root), "add", "-f", ".reposteward.toml"],
+                check=True,
+            )
+
+            result = add_repository("owner/repo", path=config_path)
+            status = subprocess.run(
+                ["git", "-C", str(root), "status", "--short"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+
+        self.assertFalse(result["git_exclude_added"])
+        self.assertIn("AM .reposteward.toml", status)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 关联 Issue

Closes #1

## 问题与改动

RepoSteward 的新配置默认把状态、日志和临时工作区放在目标仓库附近，`repo add` 创建的 `.reposteward.toml` 也会立即出现在目标仓库的 Git 状态中。

本 PR 将新用户的状态和工作区分别放入 XDG/`LOCALAPPDATA` 用户目录，并继续按 GitHub host 与 login 分区。项目配置不能重定向用户信任的运行目录；旧配置显式指定 `state_dir` 时保留旧布局。`repo add` 还会将未跟踪的本地配置写入 `.git/info/exclude`，不修改目标项目的 `.gitignore`，也不隐藏已跟踪配置。

## 验证

```text
uvx ruff format --check .                                      passed
uvx ruff check .                                               passed
uv run python -W error::ResourceWarning -m unittest discover -s tests -v
                                                               94 tests passed
uv run reposteward --help                                      passed
uv build                                                       passed
```

## 风险与兼容性

已显式配置 `state_dir` 的旧安装保持原有状态与 workspace 布局。新安装的默认目录改为用户级位置，这是预期的隔离行为。本 PR 不读取、迁移或提交现有目标仓库中的运行数据。

## 自动化辅助

使用 Codex 辅助检查实际配置合并和 Git 排除路径，并生成回归测试。提交者已人工复核完整 diff、兼容性分支、测试结果和敏感信息扫描。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建。
- [x] 新行为有回归测试。
- [x] 文档和配置示例已与行为同步；JSON Schema 和数据库迁移不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
