### PR TITLE
feat(issues): add reviewed online proposal queue

### DIFF
--- a/.github/workflows/issue-proposal-promote.yml
+++ b/.github/workflows/issue-proposal-promote.yml
@@ -1,0 +1,106 @@
+name: Promote reviewed issue proposal
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_item_id:
+        description: Project draft node ID, numeric itemId, or browser URL
+        required: true
+        type: string
+      repository:
+        description: Target repository in owner/name form
+        required: true
+        type: string
+      review_digest:
+        description: Exact digest from the latest review workflow
+        required: true
+        type: string
+      duplicates_reviewed:
+        description: I reviewed every duplicate candidate in the latest report
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize every promotion into the same repository. The later job must
+  # refresh duplicate search results after the earlier Issue becomes visible.
+  group: issue-promote-${{ inputs.repository }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    environment: reposteward-issue-publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PROJECT_ITEM_ID: ${{ inputs.project_item_id }}
+      TARGET_REPOSITORY: ${{ inputs.repository }}
+      REVIEW_DIGEST: ${{ inputs.review_digest }}
+      DUPLICATES_REVIEWED: ${{ inputs.duplicates_reviewed }}
+      PUBLISHER_LOGIN: ${{ vars.REPOSTEWARD_PUBLISHER_LOGIN }}
+      ISSUE_PROJECT_OWNER: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_OWNER }}
+      ISSUE_PROJECT_NUMBER: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_NUMBER }}
+      ISSUE_PROJECT_OWNER_TYPE: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_OWNER_TYPE }}
+      REPOSTEWARD_ENABLE_ISSUE_PROMOTION: "1"
+    steps:
+      - name: Check out trusted RepoSteward code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          enable-cache: true
+
+      - name: Install Python and RepoSteward
+        run: |
+          uv python install 3.12
+          uv sync --locked --python 3.12
+
+      - name: Isolate RepoSteward runtime state
+        run: |
+          {
+            echo "XDG_CONFIG_HOME=$RUNNER_TEMP/reposteward/config"
+            echo "XDG_STATE_HOME=$RUNNER_TEMP/reposteward/state"
+            echo "XDG_DATA_HOME=$RUNNER_TEMP/reposteward/data"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate publication attestation
+        env:
+          GH_TOKEN: ${{ secrets.REPOSTEWARD_GITHUB_PUBLISH_TOKEN }}
+        run: |
+          test -n "$GH_TOKEN"
+          test -n "$PUBLISHER_LOGIN"
+          test "$GITHUB_ACTOR" = "$PUBLISHER_LOGIN"
+          test "$DUPLICATES_REVIEWED" = "true"
+          test -n "$ISSUE_PROJECT_OWNER"
+          test -n "$ISSUE_PROJECT_NUMBER"
+          test "$ISSUE_PROJECT_OWNER_TYPE" = "user" -o "$ISSUE_PROJECT_OWNER_TYPE" = "organization"
+
+      - name: Create ephemeral trusted configuration
+        run: |
+          mkdir -p "$RUNNER_TEMP/reposteward/project"
+          uv run reposteward init \
+            --login "$PUBLISHER_LOGIN" \
+            --issue-project-owner "$ISSUE_PROJECT_OWNER" \
+            --issue-project-number "$ISSUE_PROJECT_NUMBER" \
+            --issue-project-owner-type "$ISSUE_PROJECT_OWNER_TYPE"
+          uv run reposteward repo add "$TARGET_REPOSITORY" \
+            --path "$RUNNER_TEMP/reposteward/project/.reposteward.toml"
+
+      - name: Convert the exact reviewed proposal into an Issue
+        env:
+          GH_TOKEN: ${{ secrets.REPOSTEWARD_GITHUB_PUBLISH_TOKEN }}
+        run: |
+          uv run reposteward \
+            --config "$RUNNER_TEMP/reposteward/project/.reposteward.toml" \
+            issue promote "$PROJECT_ITEM_ID" \
+            --repository "$TARGET_REPOSITORY" \
+            --reviewed-by "$PUBLISHER_LOGIN" \
+            --review-digest "$REVIEW_DIGEST" \
+            --duplicates-reviewed

--- a/.github/workflows/issue-proposal-review.yml
+++ b/.github/workflows/issue-proposal-review.yml
@@ -1,0 +1,86 @@
+name: Review online issue proposal
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_item_id:
+        description: Project draft node ID, numeric itemId, or browser URL
+        required: true
+        type: string
+      repository:
+        description: Target repository in owner/name form
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-review-${{ inputs.project_item_id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    environment: reposteward-issue-review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PROJECT_ITEM_ID: ${{ inputs.project_item_id }}
+      TARGET_REPOSITORY: ${{ inputs.repository }}
+      ISSUE_PROJECT_OWNER: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_OWNER }}
+      ISSUE_PROJECT_NUMBER: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_NUMBER }}
+      ISSUE_PROJECT_OWNER_TYPE: ${{ vars.REPOSTEWARD_ISSUE_PROJECT_OWNER_TYPE }}
+    steps:
+      - name: Check out trusted RepoSteward code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          enable-cache: true
+
+      - name: Install Python and RepoSteward
+        run: |
+          uv python install 3.12
+          uv sync --locked --python 3.12
+
+      - name: Isolate RepoSteward runtime state
+        run: |
+          {
+            echo "XDG_CONFIG_HOME=$RUNNER_TEMP/reposteward/config"
+            echo "XDG_STATE_HOME=$RUNNER_TEMP/reposteward/state"
+            echo "XDG_DATA_HOME=$RUNNER_TEMP/reposteward/data"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate review configuration
+        env:
+          GH_TOKEN: ${{ secrets.REPOSTEWARD_GITHUB_REVIEW_TOKEN }}
+        run: |
+          test -n "$GH_TOKEN"
+          test -n "$ISSUE_PROJECT_OWNER"
+          test -n "$ISSUE_PROJECT_NUMBER"
+          test "$ISSUE_PROJECT_OWNER_TYPE" = "user" -o "$ISSUE_PROJECT_OWNER_TYPE" = "organization"
+
+      - name: Create ephemeral trusted configuration
+        run: |
+          mkdir -p "$RUNNER_TEMP/reposteward/project"
+          uv run reposteward init \
+            --login "$GITHUB_ACTOR" \
+            --issue-project-owner "$ISSUE_PROJECT_OWNER" \
+            --issue-project-number "$ISSUE_PROJECT_NUMBER" \
+            --issue-project-owner-type "$ISSUE_PROJECT_OWNER_TYPE"
+          uv run reposteward repo add "$TARGET_REPOSITORY" \
+            --path "$RUNNER_TEMP/reposteward/project/.reposteward.toml"
+
+      - name: Produce read-only review digest
+        env:
+          GH_TOKEN: ${{ secrets.REPOSTEWARD_GITHUB_REVIEW_TOKEN }}
+        run: |
+          uv run reposteward \
+            --config "$RUNNER_TEMP/reposteward/project/.reposteward.toml" \
+            issue review "$PROJECT_ITEM_ID" \
+            --repository "$TARGET_REPOSITORY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,7 @@ opens pull requests only after repository-specific gates and local human review.
   matching the configured GitHub login.
 - Respect repository contribution policies. Assignment/approval checks are hard
   gates, not ranking hints.
-- Never automate security reports, mass comments, or issue creation.
+- Never automate security reports or mass comments. Repository Issue creation must
+  pass through the configured online Project draft, a fresh duplicate/security
+  review digest, a distinct reviewer, and the separate promotion gate.
 - Keep public-repository tests inside the hardened verifier container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 RepoSteward 采用 Issue 驱动、聚焦 PR、自动检查和人工 Review 的维护方式。除明显的拼写修正外，
 请先创建或认领 Issue，再开始实现。
 
+多人共同准备 Issue 时，先使用团队配置的 GitHub Project Draft Issue 作为线上提案。提案在转换为
+正式 Issue 前必须重新检查最新正文、潜在重复项和安全风险，并由提案创建者之外的 reviewer 确认。
+
 ## 开始前
 
 1. 搜索已有 Issue 和 PR，确认问题尚未被处理或认领。

--- a/README.md
+++ b/README.md
@@ -138,7 +138,36 @@ uv run reposteward issue duplicate-check DRAFT_ID
 ```
 
 草稿保存在当前用户和项目隔离的本地数据库中。`duplicate-check` 只调用 GitHub 搜索接口，
-不会创建或修改 Issue；用户需要审阅 Markdown，并在 GitHub 上手动发布。
+不会创建或修改 Issue。多人协作时，可以把草稿暂存为团队 GitHub Project 中的 Draft Issue：
+
+```bash
+REPOSTEWARD_ENABLE_ISSUE_STAGE=1 \
+  uv run reposteward issue stage DRAFT_ID --submitted-by your-github-login
+```
+
+Project Draft Issue 是线上共享提案，不会出现在目标仓库的正式 Issue 列表。团队可以在线修改正文；
+review 命令始终重新读取线上最新版本，并同时生成重复项快照、安全扫描结果和内容摘要：
+
+```bash
+uv run reposteward issue review PROJECT_ITEM_ID_OR_URL \
+  --repository owner/repository
+```
+
+另一位 reviewer 检查 Project 正文和所有潜在重复项后，使用该次 review 返回的精确摘要进行转换：
+
+```bash
+REPOSTEWARD_ENABLE_ISSUE_PROMOTION=1 \
+  uv run reposteward issue promote PROJECT_ITEM_ID_OR_URL \
+  --repository owner/repository \
+  --reviewed-by reviewer-login \
+  --review-digest REVIEW_DIGEST \
+  --duplicates-reviewed
+```
+
+线上正文、Project、重复项结果或目标仓库发生变化时，旧摘要失效，必须重新 review。默认禁止提案
+创建者自行转换；检测到凭据或疑似安全漏洞时，暂存和转换都会失败，必须改用私有报告渠道。
+GitHub Actions 的人工审查与转换流程见 [`docs/github-actions.md`](docs/github-actions.md)。
+Project 页面 URL 里的数字 `itemId` 也可直接使用，因此不经本地 `stage` 而在线创建的提案同样可审核。
 
 ## 基本工作流
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,9 @@ RepoSteward 在 Harness 之外持续保存这些信息，并提供稳定的控�
 - 人工责任：准备和提交分离，公开写入必须经过显式开关和 review attestation；
 - 可移植交接：不依赖某个供应商的会话 ID，也不依赖某个 GPT 账号的历史记录。
 
+Issue 在进入实现流水线前也采用准备/发布分离：GitHub Project Draft Issue 是多人共享的线上
+提案，仓库正式 Issue 是经过第二人审核后的工作契约。二者不能由一次无审核写操作直接贯通。
+
 Harness 仍然可以保留自己的原生 session，作为命中缓存或继续推理的加速信息；它不是任务事实
 的唯一副本。
 
@@ -41,6 +44,18 @@ GitHub facts + repository policy
             GitHub PR
 ```
 
+Issue 入口使用独立状态机：
+
+```text
+local draft ── explicit stage ──► Project Draft Issue
+                                      │ online edits
+                                      ▼
+                         duplicate + security review digest
+                                      │ distinct reviewer
+                                      ▼
+                              repository Issue
+```
+
 - RepoSteward 拥有流水线、策略、持久状态、审计和 GitHub 读写。
 - Harness 只接收一个 Context Pack 和隔离工作区，返回规范化结果与使用量。
 - Runner 只安装依赖并执行已允许的验证命令，不接触宿主凭据。
@@ -57,6 +72,8 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
 - `harness_runs`：run 与 Harness、模型、可选原生 session 的绑定；
 - `checkpoints`：按 run 单调递增的状态快照，记录 HEAD、完成项、决定、证据、风险和下一步。
 - `context_imports`：按 bundle digest 去重保存的跨机器交接历史，不覆盖本机较新的 Issue 快照。
+- `issue_proposals`：缓存本机发起的 Project item 和转换结果；GitHub Project 中的最新内容仍是
+  多人审查阶段的唯一真相。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,79 @@
+# GitHub Actions 公开写入门禁
+
+RepoSteward 把 Issue 提案和正式 Issue 分开。多人协作的共享真相是 GitHub Projects Draft Issue；
+本地 SQLite 只保存个人草稿和操作缓存，不作为团队审批记录。
+
+## Issue 流程
+
+```text
+本地草稿或 Project 在线草稿
+              ↓
+GitHub Project Draft Issue
+              ↓
+只读 review workflow
+最新正文 + 重复项 + 安全扫描 + review digest
+              ↓
+另一位 reviewer + GitHub Environment 审批
+              ↓
+promotion workflow
+Project Draft Issue 转换为正式仓库 Issue
+```
+
+GitHub 官方支持 Project Draft Issue 在线保存标题和正文，并在审核后转换为仓库 Issue。RepoSteward
+不会直接调用普通的 Issue 创建接口，因此 Project item 也是转换操作的幂等锚点。
+
+### 仓库变量
+
+在运行 workflow 的仓库中配置：
+
+- `REPOSTEWARD_ISSUE_PROJECT_OWNER`：共享 Project 所属用户或组织；
+- `REPOSTEWARD_ISSUE_PROJECT_NUMBER`：Project 页面中的编号；
+- `REPOSTEWARD_ISSUE_PROJECT_OWNER_TYPE`：`user` 或 `organization`；
+- `REPOSTEWARD_PUBLISHER_LOGIN`：最终发布凭据所属的 GitHub login。
+
+### Secrets
+
+- `REPOSTEWARD_GITHUB_REVIEW_TOKEN`：只能读取共享 Project 和目标仓库 Issue；
+- `REPOSTEWARD_GITHUB_PUBLISH_TOKEN`：可以写共享 Project，并在目标仓库创建 Issue。
+
+使用 classic PAT 时，review 凭据至少需要 `read:project`，publish 凭据需要 `project` 以及目标仓库
+Issue 写权限；私有仓库还需要相应的 `repo` 访问。实际权限应按 Project 所属用户或组织以及目标仓库
+收紧。发布 token 的实际 GitHub login 必须等于 `REPOSTEWARD_PUBLISHER_LOGIN`；当前版本的 promotion
+因此使用用户 token，GitHub App 安装 token 需在后续引入可审计的 CI 身份协议后再支持。不要把 token
+交给 Harness、测试、目标仓库代码或容器。
+
+### Environments 与分支限制
+
+创建两个 GitHub Environments：
+
+- `reposteward-issue-review`：保护只读 Project token；
+- `reposteward-issue-publishing`：配置 required reviewers，并只允许受保护的默认分支部署。
+
+同时为默认分支配置 Ruleset，要求 PR、CI 和 Code Owner review。不要允许任意功能分支直接运行
+带上述 secrets 的 workflow。
+
+### 操作顺序
+
+1. 运行 `Review online issue proposal`，输入 Project 提案的 GraphQL node ID、网页 URL 或 URL 中的
+   `itemId` 数字，以及目标仓库。Project 网页直接建立的提案也可以进入同一审核流程。
+2. 在日志中检查标题、重复 Issue、风险信号和 `review_digest`；正文以 Project 中的在线版本为准，
+   workflow 不把完整正文复制到日志。
+3. 如需修改，在 Project 中编辑 Draft Issue，然后重新运行 review。
+4. 运行 `Promote reviewed issue proposal`，输入同一 item、目标仓库和最新 digest，并勾选已审查
+   所有重复项。
+5. Environment reviewer 确认后，workflow 再次读取线上内容。任何变化都会使 digest 失效。
+
+同一目标仓库的 promotion 会串行执行。因此多人同时提交相似提案时，后一个任务会在前一个
+Issue 已可见后重新查重；重复项快照发生变化将使旧 digest 失效，不会直接继续发布。
+为保证数字 `itemId` 查找有界，RepoSteward 最多扫描 1,000 个未归档 Project item；团队应将已处理的
+提案定期归档，也可以直接使用 `stage` 返回的 GraphQL node ID。
+
+安全报告不会进入该流程。检测到高风险安全语义或凭据时，CLI 会在任何线上暂存或转换前失败。
+
+## PR 流程边界
+
+现有 `prepare`/`adopt` 只生成经过验证的本地 commit，`submit` 是唯一能够 push 和创建 PR 的
+命令。GitHub-hosted Runner 不持久保存本地数据库和 worktree，因此不能仅靠另一个 workflow
+直接恢复本地准备结果。远端 PR 发布需要独立的、带摘要的 publication bundle；在该协议完成前，
+不要把 Harness、写 token 和目标仓库代码放进同一个 CI job，也不要使用 `pull_request_target`
+执行外部代码。

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -12,6 +12,12 @@ git_email = "your-github-login@users.noreply.github.com"
 sign_commits = false
 signoff_commits = true
 
+[issue_review]
+project_owner = "your-github-login-or-organization"
+project_number = 1
+project_owner_type = "user"
+require_distinct_reviewer = true
+
 [discovery]
 min_score = 30
 preferred_labels = ["good first issue", "help wanted", "bug", "documentation"]

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -32,6 +32,13 @@ def _parser() -> argparse.ArgumentParser:
     initialize.add_argument("--login", default="")
     initialize.add_argument("--git-name", default="")
     initialize.add_argument("--git-email", default="")
+    initialize.add_argument("--issue-project-owner", default="")
+    initialize.add_argument("--issue-project-number", type=int, default=0)
+    initialize.add_argument(
+        "--issue-project-owner-type",
+        choices=("user", "organization"),
+        default="user",
+    )
     initialize.add_argument("--force", action="store_true")
 
     repo = subparsers.add_parser("repo", help="manage project repositories")
@@ -68,6 +75,30 @@ def _parser() -> argparse.ArgumentParser:
         "duplicate-check", help="search GitHub for potentially similar issues"
     )
     issue_duplicates.add_argument("draft_id")
+    issue_stage = issue_commands.add_parser(
+        "stage", help="stage a local draft in the configured GitHub Project"
+    )
+    issue_stage.add_argument("draft_id")
+    issue_stage.add_argument("--submitted-by", required=True)
+    issue_review = issue_commands.add_parser(
+        "review", help="review the latest online proposal and duplicate snapshot"
+    )
+    issue_review.add_argument(
+        "project_item_id", help="GraphQL node ID, numeric itemId, or Project item URL"
+    )
+    issue_review.add_argument("--repository", required=True)
+    issue_promote = issue_commands.add_parser(
+        "promote", help="convert an approved Project draft into a repository Issue"
+    )
+    issue_promote.add_argument(
+        "project_item_id", help="GraphQL node ID, numeric itemId, or Project item URL"
+    )
+    issue_promote.add_argument("--repository", required=True)
+    issue_promote.add_argument("--reviewed-by", required=True)
+    issue_promote.add_argument("--review-digest", required=True)
+    issue_promote.add_argument(
+        "--duplicates-reviewed", action="store_true", required=True
+    )
 
     subparsers.add_parser("doctor", help="check local tools and authentication")
     image = subparsers.add_parser("image", help="manage the isolated verifier image")
@@ -190,6 +221,9 @@ def main(argv: list[str] | None = None) -> int:
                     login=args.login,
                     git_name=args.git_name,
                     git_email=args.git_email,
+                    issue_project_owner=args.issue_project_owner,
+                    issue_project_number=args.issue_project_number,
+                    issue_project_owner_type=args.issue_project_owner_type,
                     force=args.force,
                 )
             )
@@ -232,6 +266,32 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
             if args.issue_command == "duplicate-check":
                 _json(pipeline.issue_duplicate_check(args.draft_id))
+                return 0
+            if args.issue_command == "stage":
+                _json(
+                    pipeline.stage_issue_proposal(
+                        args.draft_id, submitted_by=args.submitted_by
+                    )
+                )
+                return 0
+            if args.issue_command == "review":
+                _json(
+                    pipeline.issue_proposal_review(
+                        args.project_item_id,
+                        repository=args.repository,
+                    )
+                )
+                return 0
+            if args.issue_command == "promote":
+                _json(
+                    pipeline.promote_issue_proposal(
+                        args.project_item_id,
+                        repository=args.repository,
+                        reviewed_by=args.reviewed_by,
+                        review_digest=args.review_digest,
+                        duplicates_reviewed=args.duplicates_reviewed,
+                    )
+                )
                 return 0
             raise AssertionError(f"unhandled issue command: {args.issue_command}")
         if args.command == "doctor":

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -35,6 +35,14 @@ class GitHubConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class IssueReviewConfig:
+    project_owner: str = ""
+    project_number: int = 0
+    project_owner_type: str = "user"
+    require_distinct_reviewer: bool = True
+
+
+@dataclass(frozen=True, slots=True)
 class DiscoveryConfig:
     issues_per_repo: int = 100
     max_pages: int = 2
@@ -140,6 +148,7 @@ class AppConfig:
     workspace_dir: Path
     state_namespace: bool
     github: GitHubConfig
+    issue_review: IssueReviewConfig
     discovery: DiscoveryConfig
     safety: SafetyConfig
     agent: AgentConfig
@@ -279,6 +288,12 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
     user_github = user.get("github")
     if isinstance(user_github, dict):
         result["github"] = dict(user_github)
+
+    user_issue_review = user.get("issue_review")
+    if isinstance(user_issue_review, dict):
+        result["issue_review"] = dict(user_issue_review)
+    else:
+        result.pop("issue_review", None)
 
     user_agent = user.get("agent")
     project_agent = project.get("agent")
@@ -438,6 +453,18 @@ def load_config(
             ("gh", "auth", "token", "--hostname", "github.com"),
         ),
     )
+
+    issue_review_raw = _section(raw, "issue_review")
+    issue_review = IssueReviewConfig(
+        project_owner=str(issue_review_raw.get("project_owner", "")).strip(),
+        project_number=int(issue_review_raw.get("project_number", 0)),
+        project_owner_type=str(
+            issue_review_raw.get("project_owner_type", "user")
+        ).strip(),
+        require_distinct_reviewer=_boolean(
+            issue_review_raw.get("require_distinct_reviewer"), True
+        ),
+    )
     legacy_project = bool(project_raw) and "config_version" not in project_raw
     state_namespace = _boolean(project.get("namespace_state"), not legacy_project)
     if state_namespace:
@@ -571,6 +598,16 @@ def load_config(
         raise ConfigError("[github].git_name must not be empty")
     if not github.git_email:
         raise ConfigError("[github].git_email must not be empty")
+    if issue_review.project_owner_type not in {"user", "organization"}:
+        raise ConfigError(
+            "issue_review.project_owner_type must be 'user' or 'organization'"
+        )
+    if issue_review.project_number < 0:
+        raise ConfigError("issue_review.project_number must not be negative")
+    if bool(issue_review.project_owner) != bool(issue_review.project_number):
+        raise ConfigError(
+            "issue_review.project_owner and project_number must be configured together"
+        )
     if discovery.issues_per_repo < 1 or discovery.issues_per_repo > 100:
         raise ConfigError("discovery.issues_per_repo must be between 1 and 100")
     if discovery.max_pages < 1 or discovery.max_pages > 10:
@@ -640,6 +677,7 @@ def load_config(
         workspace_dir=workspace_dir,
         state_namespace=state_namespace,
         github=github,
+        issue_review=issue_review,
         discovery=discovery,
         safety=safety,
         agent=agent,

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -35,6 +35,23 @@ class PullRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class ProjectIssueProposal:
+    item_id: str
+    database_id: int
+    project_id: str
+    project_number: int
+    project_url: str
+    updated_at: str
+    creator: str
+    content_type: str
+    title: str
+    body: str
+    issue_number: int = 0
+    issue_url: str = ""
+    repository: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class CompetingWork:
     kind: str
     actor: str
@@ -133,6 +150,262 @@ class GitHubClient:
             raise GitHubError("cannot check login without a GitHub token")
         payload, _ = self._request("GET", "/user")
         return str(payload["login"])
+
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        payload, _ = self._request(
+            "POST", "/graphql", data={"query": query, "variables": variables}
+        )
+        if not isinstance(payload, dict):
+            raise GitHubError("GitHub GraphQL response was not an object")
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            messages = "; ".join(str(value.get("message", value)) for value in errors)
+            raise GitHubError(f"GitHub GraphQL failed: {messages}")
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise GitHubError("GitHub GraphQL response did not contain data")
+        return data
+
+    def project_v2(self, owner: str, number: int, *, owner_type: str) -> dict[str, Any]:
+        field = "organization" if owner_type == "organization" else "user"
+        data = self._graphql(
+            f"""
+            query($owner: String!, $number: Int!) {{
+              {field}(login: $owner) {{
+                projectV2(number: $number) {{ id number url closed }}
+              }}
+            }}
+            """,
+            {"owner": owner, "number": number},
+        )
+        container = data.get(field)
+        project = container.get("projectV2") if isinstance(container, dict) else None
+        if not isinstance(project, dict):
+            raise GitHubError(
+                f"GitHub Project not found: {owner_type} {owner}#{number}"
+            )
+        if bool(project.get("closed")):
+            raise GitHubError(
+                f"GitHub Project is closed: {owner_type} {owner}#{number}"
+            )
+        return {
+            "id": str(project["id"]),
+            "number": int(project["number"]),
+            "url": str(project["url"]),
+        }
+
+    @staticmethod
+    def _project_item_fields() -> str:
+        return """
+          id
+          fullDatabaseId
+          updatedAt
+          creator { login }
+          project { id number url }
+          content {
+            __typename
+            ... on DraftIssue { title body }
+            ... on Issue {
+              number
+              url
+              title
+              body
+              repository { nameWithOwner }
+            }
+          }
+        """
+
+    @staticmethod
+    def _parse_project_issue_proposal(value: dict[str, Any]) -> ProjectIssueProposal:
+        project = value.get("project")
+        content = value.get("content")
+        creator = value.get("creator")
+        if not isinstance(project, dict) or not isinstance(content, dict):
+            raise GitHubError("GitHub Project item is missing project or content")
+        content_type = str(content.get("__typename") or "")
+        if content_type not in {"DraftIssue", "Issue"}:
+            raise GitHubError(
+                f"GitHub Project item must contain a draft or issue, got {content_type!r}"
+            )
+        repository = content.get("repository")
+        return ProjectIssueProposal(
+            item_id=str(value["id"]),
+            database_id=int(value.get("fullDatabaseId") or 0),
+            project_id=str(project["id"]),
+            project_number=int(project["number"]),
+            project_url=str(project["url"]),
+            updated_at=str(value["updatedAt"]),
+            creator=(
+                str(creator.get("login") or "") if isinstance(creator, dict) else ""
+            ),
+            content_type=content_type,
+            title=str(content.get("title") or ""),
+            body=str(content.get("body") or ""),
+            issue_number=int(content.get("number") or 0),
+            issue_url=str(content.get("url") or ""),
+            repository=(
+                str(repository.get("nameWithOwner") or "")
+                if isinstance(repository, dict)
+                else ""
+            ),
+        )
+
+    def add_project_issue_proposal(
+        self, *, project_id: str, title: str, body: str, client_mutation_id: str
+    ) -> ProjectIssueProposal:
+        fields = self._project_item_fields()
+        data = self._graphql(
+            f"""
+            mutation($projectId: ID!, $title: String!, $body: String!,
+                     $clientMutationId: String!) {{
+              addProjectV2DraftIssue(input: {{
+                projectId: $projectId,
+                title: $title,
+                body: $body,
+                clientMutationId: $clientMutationId
+              }}) {{
+                projectItem {{ {fields} }}
+              }}
+            }}
+            """,
+            {
+                "projectId": project_id,
+                "title": title,
+                "body": body,
+                "clientMutationId": client_mutation_id,
+            },
+        )
+        result = data.get("addProjectV2DraftIssue")
+        item = result.get("projectItem") if isinstance(result, dict) else None
+        if not isinstance(item, dict):
+            raise GitHubError("GitHub did not return the created Project draft item")
+        return self._parse_project_issue_proposal(item)
+
+    def project_issue_proposal(self, item_id: str) -> ProjectIssueProposal:
+        fields = self._project_item_fields()
+        data = self._graphql(
+            f"""
+            query($itemId: ID!) {{
+              node(id: $itemId) {{
+                ... on ProjectV2Item {{ {fields} }}
+              }}
+            }}
+            """,
+            {"itemId": item_id},
+        )
+        item = data.get("node")
+        if not isinstance(item, dict) or not item.get("id"):
+            raise GitHubError(f"GitHub Project item not found: {item_id}")
+        return self._parse_project_issue_proposal(item)
+
+    def project_issue_proposal_by_database_id(
+        self,
+        *,
+        project_id: str,
+        database_id: int,
+        max_items: int = 1000,
+    ) -> ProjectIssueProposal:
+        """Resolve the numeric itemId exposed by GitHub Project browser URLs."""
+        if database_id < 1:
+            raise GitHubError("GitHub Project item database ID must be positive")
+        max_items = min(max(max_items, 1), 1000)
+        fields = self._project_item_fields()
+        cursor: str | None = None
+        scanned = 0
+        max_pages = (max_items + 99) // 100
+        pages = 0
+        while scanned < max_items and pages < max_pages:
+            pages += 1
+            page_size = min(100, max_items - scanned)
+            data = self._graphql(
+                f"""
+                query($projectId: ID!, $cursor: String, $first: Int!) {{
+                  node(id: $projectId) {{
+                    ... on ProjectV2 {{
+                      items(
+                        first: $first,
+                        after: $cursor,
+                        archivedStates: [NOT_ARCHIVED]
+                      ) {{
+                        nodes {{ {fields} }}
+                        pageInfo {{ hasNextPage endCursor }}
+                      }}
+                    }}
+                  }}
+                }}
+                """,
+                {
+                    "projectId": project_id,
+                    "cursor": cursor,
+                    "first": page_size,
+                },
+            )
+            project = data.get("node")
+            connection = project.get("items") if isinstance(project, dict) else None
+            if not isinstance(connection, dict):
+                raise GitHubError(f"GitHub Project not found: {project_id}")
+            nodes = connection.get("nodes")
+            if not isinstance(nodes, list):
+                raise GitHubError("GitHub Project items response was not a list")
+            if not nodes:
+                break
+            scanned += len(nodes)
+            for value in nodes:
+                if (
+                    isinstance(value, dict)
+                    and int(value.get("fullDatabaseId") or 0) == database_id
+                ):
+                    return self._parse_project_issue_proposal(value)
+            page_info = connection.get("pageInfo")
+            has_next = (
+                bool(page_info.get("hasNextPage"))
+                if isinstance(page_info, dict)
+                else False
+            )
+            if not has_next:
+                break
+            cursor_value = page_info.get("endCursor")
+            if not isinstance(cursor_value, str) or not cursor_value:
+                raise GitHubError("GitHub Project pagination cursor is missing")
+            cursor = cursor_value
+        raise GitHubError(
+            f"active GitHub Project item {database_id} was not found in the first "
+            f"{max_items} items; use its GraphQL node ID or archive old proposals"
+        )
+
+    def convert_project_issue_proposal(
+        self, *, item_id: str, repository: str
+    ) -> ProjectIssueProposal:
+        owner, name = repository.split("/", 1)
+        repository_data = self._graphql(
+            """
+            query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) { id }
+            }
+            """,
+            {"owner": owner, "name": name},
+        ).get("repository")
+        if not isinstance(repository_data, dict):
+            raise GitHubError(f"repository not found: {repository}")
+        fields = self._project_item_fields()
+        data = self._graphql(
+            f"""
+            mutation($itemId: ID!, $repositoryId: ID!) {{
+              convertProjectV2DraftIssueItemToIssue(input: {{
+                itemId: $itemId,
+                repositoryId: $repositoryId
+              }}) {{
+                item {{ {fields} }}
+              }}
+            }}
+            """,
+            {"itemId": item_id, "repositoryId": str(repository_data["id"])},
+        )
+        result = data.get("convertProjectV2DraftIssueItemToIssue")
+        item = result.get("item") if isinstance(result, dict) else None
+        if not isinstance(item, dict):
+            raise GitHubError("GitHub did not return the converted Issue")
+        return self._parse_project_issue_proposal(item)
 
     def repository(self, full_name: str) -> RepositoryInfo:
         payload, _ = self._request("GET", f"/repos/{full_name}")

--- a/src/reposteward/issues.py
+++ b/src/reposteward/issues.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from pathlib import Path
+from typing import Any
 
 MAX_ISSUE_TITLE_CHARS = 200
 MAX_ISSUE_BODY_CHARS = 30_000
@@ -11,6 +14,20 @@ SENSITIVE_DETAIL = re.compile(
     r"aws_secret_access_key|npm_token|pypi_token)\s*[:=]\s*\S+|"
     r"\bgh[pousr]_[A-Za-z0-9]{20,}\b|"
     r"-----BEGIN [A-Z ]*PRIVATE KEY-----"
+)
+SECURITY_REPORT = re.compile(
+    r"(?i)(?:\bCVE-\d{4}-\d+\b|\b(?:security vulnerability|"
+    r"remote code execution|arbitrary code execution|privilege escalation|"
+    r"authentication bypass|authorization bypass|credential leak|secret leak|"
+    r"token leak|command injection|sql injection|cross-site scripting|xss|csrf|"
+    r"path traversal|sandbox escape|insecure deserialization)\b|"
+    r"安全漏洞|凭据泄露|密钥泄露|令牌泄露|身份验证绕过|鉴权绕过|权限绕过|"
+    r"命令注入|SQL\s*注入|跨站脚本|路径穿越|沙箱逃逸|任意代码执行|远程代码执行|提权)"
+)
+PROPOSAL_MARKER = re.compile(
+    r"^<!-- reposteward-proposal:v1 repository=(?P<repository>[A-Za-z0-9_.-]+/"
+    r"[A-Za-z0-9_.-]+) draft_id=(?P<draft_id>[a-f0-9]{32}) -->\n?",
+    re.MULTILINE,
 )
 
 
@@ -109,3 +126,79 @@ def validate_issue_title(title: str) -> str:
     if SENSITIVE_DETAIL.search(value):
         raise ValueError("issue title appears to contain a credential")
     return value
+
+
+def issue_security_signals(title: str, body: str) -> tuple[str, ...]:
+    """Return fail-closed signals that require a private reporting channel."""
+    combined = f"{title}\n{body}"
+    signals: list[str] = []
+    if SENSITIVE_DETAIL.search(combined):
+        signals.append("credential-like content")
+    if SECURITY_REPORT.search(combined):
+        signals.append("potential security vulnerability")
+    return tuple(signals)
+
+
+def attach_proposal_marker(body: str, *, repository: str, draft_id: str) -> str:
+    marker = (
+        f"<!-- reposteward-proposal:v1 repository={repository.lower()} "
+        f"draft_id={draft_id} -->"
+    )
+    return f"{marker}\n{body.lstrip()}"
+
+
+def proposal_body(body: str, *, repository: str) -> str:
+    """Strip and validate optional RepoSteward routing metadata."""
+    match = PROPOSAL_MARKER.search(body)
+    if match and match.group("repository").casefold() != repository.casefold():
+        raise ValueError(
+            "online proposal targets a different repository than the review command"
+        )
+    clean = PROPOSAL_MARKER.sub("", body, count=1).strip() + "\n"
+    if not clean.strip():
+        raise ValueError("online proposal body must not be empty")
+    if len(clean) > MAX_ISSUE_BODY_CHARS:
+        raise ValueError(f"issue body exceeds {MAX_ISSUE_BODY_CHARS} characters")
+    if SENSITIVE_DETAIL.search(clean):
+        raise ValueError("issue body appears to contain a credential")
+    return clean
+
+
+def issue_review_digest(
+    *,
+    project_item_id: str,
+    project_id: str,
+    updated_at: str,
+    repository: str,
+    title: str,
+    body: str,
+    creator: str,
+    similar_issues: list[dict[str, Any]],
+) -> str:
+    normalized_similar = sorted(
+        (
+            {
+                "number": int(value["number"]),
+                "title": str(value["title"]),
+                "state": str(value["state"]),
+                "url": str(value["url"]),
+            }
+            for value in similar_issues
+        ),
+        key=lambda value: (value["number"], value["url"]),
+    )
+    payload = {
+        "version": 1,
+        "project_item_id": project_item_id,
+        "project_id": project_id,
+        "updated_at": updated_at,
+        "repository": repository.casefold(),
+        "title": title,
+        "body": body,
+        "creator": creator.casefold(),
+        "similar_issues": normalized_similar,
+    }
+    encoded = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -23,7 +23,14 @@ from .context import (
 from .discovery import score_issue
 from .github import GitHubClient, GitHubError, resolve_token
 from .harness import Harness, HarnessRequest, create_harness
-from .issues import render_issue_body, validate_issue_title
+from .issues import (
+    attach_proposal_marker,
+    issue_review_digest,
+    issue_security_signals,
+    proposal_body,
+    render_issue_body,
+    validate_issue_title,
+)
 from .models import AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
 from .protocol import read_context_bundle, validate_context_bundle
@@ -106,7 +113,10 @@ class Pipeline:
             "next_actions": [
                 f"reposteward issue duplicate-check {draft['id']}",
                 f"reposteward issue inspect {draft['id']}",
-                "review the Markdown and publish it manually on GitHub",
+                (
+                    f"REPOSTEWARD_ENABLE_ISSUE_STAGE=1 reposteward issue stage "
+                    f"{draft['id']} --submitted-by {self.config.github.login}"
+                ),
             ],
             "public_write": False,
         }
@@ -141,6 +151,262 @@ class Pipeline:
             "similar_issues": similar,
             "requires_human_judgment": True,
             "public_write": False,
+        }
+
+    def _issue_review_project(self, client: GitHubClient) -> dict[str, Any]:
+        review = self.config.issue_review
+        if not review.project_owner or not review.project_number:
+            raise PolicyError(
+                "online issue review is not configured; set [issue_review] "
+                "project_owner and project_number in the user config"
+            )
+        return client.project_v2(
+            review.project_owner,
+            review.project_number,
+            owner_type=review.project_owner_type,
+        )
+
+    @staticmethod
+    def _proposal_summary(proposal: Any) -> dict[str, Any]:
+        return {
+            "item_id": proposal.item_id,
+            "database_id": proposal.database_id,
+            "project_id": proposal.project_id,
+            "project_number": proposal.project_number,
+            "project_url": proposal.project_url,
+            "updated_at": proposal.updated_at,
+            "creator": proposal.creator,
+            "content_type": proposal.content_type,
+            "title": proposal.title,
+            "issue_number": proposal.issue_number,
+            "issue_url": proposal.issue_url,
+            "repository": proposal.repository,
+        }
+
+    @staticmethod
+    def _project_item_database_id(reference: str) -> int:
+        value = reference.strip()
+        if value.isdecimal():
+            return int(value)
+        match = re.search(r"(?:[?&])itemId=(\d+)(?:&|$)", value)
+        return int(match.group(1)) if match else 0
+
+    def _online_issue_proposal(
+        self,
+        client: GitHubClient,
+        *,
+        project_id: str,
+        reference: str,
+    ) -> Any:
+        database_id = self._project_item_database_id(reference)
+        if database_id:
+            return client.project_issue_proposal_by_database_id(
+                project_id=project_id,
+                database_id=database_id,
+            )
+        return client.project_issue_proposal(reference)
+
+    def _authenticated_publication_client(self, attested_by: str) -> GitHubClient:
+        if attested_by.casefold() != self.config.github.login.casefold():
+            raise PolicyError(
+                f"review attestation must match the configured account "
+                f"{self.config.github.login!r}"
+            )
+        token = resolve_token(self.config.github, required=True)
+        client = GitHubClient(self.config.github, token)
+        authenticated = client.authenticated_login()
+        if authenticated.casefold() != self.config.github.login.casefold():
+            raise GitHubError(
+                f"token belongs to {authenticated!r}, "
+                f"expected {self.config.github.login!r}"
+            )
+        return client
+
+    def stage_issue_proposal(
+        self, draft_id: str, *, submitted_by: str
+    ) -> dict[str, Any]:
+        if os.environ.get("REPOSTEWARD_ENABLE_ISSUE_STAGE") != "1":
+            raise PolicyError(
+                "online proposal staging is disabled; set "
+                "REPOSTEWARD_ENABLE_ISSUE_STAGE=1 for this command"
+            )
+        draft = self.issue_draft(draft_id)
+        self.policy(str(draft["repository"]))
+        signals = issue_security_signals(str(draft["title"]), str(draft["body"]))
+        if signals:
+            raise PolicyError(
+                "potential security report must use a private reporting channel: "
+                + ", ".join(signals)
+            )
+        client = self._authenticated_publication_client(submitted_by)
+        project = self._issue_review_project(client)
+        existing = self.store.issue_proposal_for_draft(project["id"], draft_id)
+        if existing is not None:
+            proposal = client.project_issue_proposal(existing["project_item_id"])
+            return {
+                **self._proposal_summary(proposal),
+                "repository": draft["repository"],
+                "idempotent": True,
+                "public_write": False,
+            }
+        staged_body = attach_proposal_marker(
+            str(draft["body"]),
+            repository=str(draft["repository"]),
+            draft_id=draft_id,
+        )
+        proposal = client.add_project_issue_proposal(
+            project_id=project["id"],
+            title=str(draft["title"]),
+            body=staged_body,
+            client_mutation_id=f"reposteward-stage-{draft_id}",
+        )
+        content_digest = hashlib.sha256(
+            f"{proposal.title}\0{proposal.body}".encode()
+        ).hexdigest()
+        self.store.record_issue_proposal(
+            project_item_id=proposal.item_id,
+            project_id=proposal.project_id,
+            project_url=proposal.project_url,
+            draft_id=draft_id,
+            repository=str(draft["repository"]),
+            creator=proposal.creator,
+            content_digest=content_digest,
+        )
+        return {
+            **self._proposal_summary(proposal),
+            "repository": draft["repository"],
+            "next_action": (
+                f"reposteward issue review {proposal.item_id} "
+                f"--repository {draft['repository']}"
+            ),
+            "public_write": True,
+        }
+
+    def issue_proposal_review(
+        self,
+        project_item_id: str,
+        *,
+        repository: str,
+        client: GitHubClient | None = None,
+    ) -> dict[str, Any]:
+        policy = self.policy(repository)
+        active_client = client or self.github
+        expected_project = self._issue_review_project(active_client)
+        proposal = self._online_issue_proposal(
+            active_client,
+            project_id=str(expected_project["id"]),
+            reference=project_item_id,
+        )
+        if proposal.project_id != expected_project["id"]:
+            raise PolicyError("proposal is not in the configured issue review project")
+        if proposal.content_type == "Issue":
+            if proposal.repository.casefold() != policy.name.casefold():
+                raise PolicyError(
+                    "converted proposal belongs to a different repository"
+                )
+            return {
+                **self._proposal_summary(proposal),
+                "repository": policy.name,
+                "status": "published",
+                "eligible_for_promotion": False,
+                "public_write": False,
+            }
+        title = validate_issue_title(proposal.title)
+        body = proposal_body(proposal.body, repository=policy.name)
+        security_signals = issue_security_signals(title, body)
+        similar = active_client.similar_issues(policy.name, title, limit=10)
+        content_digest = hashlib.sha256(f"{title}\0{body}".encode()).hexdigest()
+        digest = issue_review_digest(
+            project_item_id=proposal.item_id,
+            project_id=proposal.project_id,
+            updated_at=proposal.updated_at,
+            repository=policy.name,
+            title=title,
+            body=body,
+            creator=proposal.creator,
+            similar_issues=similar,
+        )
+        return {
+            **self._proposal_summary(proposal),
+            "repository": policy.name,
+            "title": title if not security_signals else "[potential security report]",
+            "content_digest": content_digest,
+            "similar_issues": similar,
+            "security_signals": list(security_signals),
+            "review_digest": digest,
+            "distinct_reviewer_required": (
+                self.config.issue_review.require_distinct_reviewer
+            ),
+            "duplicates_require_human_judgment": True,
+            "eligible_for_promotion": not security_signals,
+            "public_write": False,
+        }
+
+    def promote_issue_proposal(
+        self,
+        project_item_id: str,
+        *,
+        repository: str,
+        reviewed_by: str,
+        review_digest: str,
+        duplicates_reviewed: bool,
+    ) -> dict[str, Any]:
+        if os.environ.get("REPOSTEWARD_ENABLE_ISSUE_PROMOTION") != "1":
+            raise PolicyError(
+                "issue promotion is disabled; set "
+                "REPOSTEWARD_ENABLE_ISSUE_PROMOTION=1 for this command"
+            )
+        if not duplicates_reviewed:
+            raise PolicyError("promotion requires an explicit duplicate review")
+        client = self._authenticated_publication_client(reviewed_by)
+        report = self.issue_proposal_review(
+            project_item_id, repository=repository, client=client
+        )
+        if report.get("status") == "published":
+            return {**report, "idempotent": True}
+        if report["security_signals"]:
+            raise PolicyError(
+                "potential security report must use a private reporting channel: "
+                + ", ".join(report["security_signals"])
+            )
+        if review_digest != report["review_digest"]:
+            raise PolicyError(
+                "review digest is stale; inspect the latest online proposal and "
+                "duplicate results again"
+            )
+        if (
+            self.config.issue_review.require_distinct_reviewer
+            and str(report["creator"]).casefold() == reviewed_by.casefold()
+        ):
+            raise PolicyError("proposal creator and final reviewer must be different")
+        converted = client.convert_project_issue_proposal(
+            item_id=str(report["item_id"]),
+            repository=str(report["repository"]),
+        )
+        if converted.content_type != "Issue":
+            raise GitHubError("GitHub did not convert the proposal into an Issue")
+        if converted.repository.casefold() != str(report["repository"]).casefold():
+            raise GitHubError("GitHub converted the proposal into the wrong repository")
+        self.store.record_issue_proposal(
+            project_item_id=converted.item_id,
+            project_id=converted.project_id,
+            project_url=converted.project_url,
+            draft_id="",
+            repository=str(report["repository"]),
+            creator=str(report["creator"]),
+            content_digest=str(report["content_digest"]),
+        )
+        self.store.mark_issue_proposal_published(
+            converted.item_id,
+            issue_number=converted.issue_number,
+            issue_url=converted.issue_url,
+        )
+        return {
+            **self._proposal_summary(converted),
+            "repository": converted.repository,
+            "reviewed_by": reviewed_by,
+            "review_digest": review_digest,
+            "public_write": True,
         }
 
     def gate_status(self, repository: str, issue_number: int) -> dict[str, Any]:

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -46,7 +46,15 @@ def _toml_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def render_user_config(login: str, git_name: str, git_email: str) -> str:
+def render_user_config(
+    login: str,
+    git_name: str,
+    git_email: str,
+    *,
+    issue_project_owner: str = "",
+    issue_project_number: int = 0,
+    issue_project_owner_type: str = "user",
+) -> str:
     return f"""config_version = {CONFIG_VERSION}
 
 [project]
@@ -63,6 +71,12 @@ signoff_commits = true
 api_url = "https://api.github.com"
 token_env = ["GITHUB_TOKEN", "GH_TOKEN"]
 gh_auth_command = ["gh", "auth", "token", "--hostname", "github.com"]
+
+[issue_review]
+project_owner = {_toml_string(issue_project_owner)}
+project_number = {issue_project_number}
+project_owner_type = {_toml_string(issue_project_owner_type)}
+require_distinct_reviewer = true
 
 [agent]
 harness = "codex-cli"
@@ -107,6 +121,9 @@ def initialize_user_config(
     login: str = "",
     git_name: str = "",
     git_email: str = "",
+    issue_project_owner: str = "",
+    issue_project_number: int = 0,
+    issue_project_owner_type: str = "user",
     force: bool = False,
 ) -> dict[str, Any]:
     if not login:
@@ -116,10 +133,25 @@ def initialize_user_config(
         git_email = git_email or detected_email
     git_name = git_name or login
     git_email = git_email or f"{login}@users.noreply.github.com"
+    if issue_project_owner_type not in {"user", "organization"}:
+        raise ConfigError("issue project owner type must be 'user' or 'organization'")
+    if issue_project_number < 0:
+        raise ConfigError("issue project number must not be negative")
+    if bool(issue_project_owner.strip()) != bool(issue_project_number):
+        raise ConfigError(
+            "issue project owner and project number must be configured together"
+        )
     target = (path or default_user_config_path()).expanduser().resolve()
     _write_atomic(
         target,
-        render_user_config(login, git_name, git_email),
+        render_user_config(
+            login,
+            git_name,
+            git_email,
+            issue_project_owner=issue_project_owner.strip(),
+            issue_project_number=issue_project_number,
+            issue_project_owner_type=issue_project_owner_type,
+        ),
         force=force,
     )
     return {

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -12,7 +12,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -168,6 +168,33 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON context_imports(work_item_id, imported_at DESC)
         """,
     ),
+    4: (
+        """
+        CREATE TABLE IF NOT EXISTS issue_proposals (
+            project_item_id TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            project_url TEXT NOT NULL,
+            draft_id TEXT NOT NULL DEFAULT '',
+            repository TEXT NOT NULL,
+            creator TEXT NOT NULL,
+            content_digest TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'staged',
+            issue_number INTEGER NOT NULL DEFAULT 0,
+            issue_url TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS issue_proposals_for_local_draft
+        ON issue_proposals(project_id, draft_id)
+        WHERE draft_id <> ''
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS issue_proposals_recent
+        ON issue_proposals(status, updated_at DESC)
+        """,
+    ),
 }
 
 
@@ -266,6 +293,78 @@ class Store:
                 (limit,),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def issue_proposal_for_draft(
+        self, project_id: str, draft_id: str
+    ) -> dict[str, Any] | None:
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM issue_proposals
+                WHERE project_id=? AND draft_id=?
+                """,
+                (project_id, draft_id),
+            ).fetchone()
+        return dict(row) if row is not None else None
+
+    def record_issue_proposal(
+        self,
+        *,
+        project_item_id: str,
+        project_id: str,
+        project_url: str,
+        draft_id: str,
+        repository: str,
+        creator: str,
+        content_digest: str,
+    ) -> dict[str, Any]:
+        now = utc_now()
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO issue_proposals(
+                    project_item_id, project_id, project_url, draft_id,
+                    repository, creator, content_digest, status,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'staged', ?, ?)
+                ON CONFLICT(project_item_id) DO UPDATE SET
+                    project_url=excluded.project_url,
+                    repository=excluded.repository,
+                    creator=excluded.creator,
+                    content_digest=excluded.content_digest,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    project_item_id,
+                    project_id,
+                    project_url,
+                    draft_id,
+                    repository.casefold(),
+                    creator,
+                    content_digest,
+                    now,
+                    now,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM issue_proposals WHERE project_item_id=?",
+                (project_item_id,),
+            ).fetchone()
+        assert row is not None
+        return dict(row)
+
+    def mark_issue_proposal_published(
+        self, project_item_id: str, *, issue_number: int, issue_url: str
+    ) -> None:
+        with self._connection() as connection:
+            connection.execute(
+                """
+                UPDATE issue_proposals
+                SET status='published', issue_number=?, issue_url=?, updated_at=?
+                WHERE project_item_id=?
+                """,
+                (issue_number, issue_url, utc_now(), project_item_id),
+            )
 
     def ensure_work_item(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,11 @@ harness = "unknown"
 executable = "untrusted-agent"
 [github]
 login = "mallory"
+[issue_review]
+project_owner = "mallory"
+project_number = 99
+project_owner_type = "organization"
+require_distinct_reviewer = false
 [safety]
 max_diff_lines = 500
 require_verification = false
@@ -153,6 +158,9 @@ max_diff_lines = 99
         self.assertEqual(config.runner.image, "trusted-runner:latest")
         self.assertEqual(config.agent.harness, "codex-cli")
         self.assertEqual(config.agent.executable, "codex")
+        self.assertEqual(config.issue_review.project_owner, "")
+        self.assertEqual(config.issue_review.project_number, 0)
+        self.assertTrue(config.issue_review.require_distinct_reviewer)
         self.assertEqual(config.safety.max_diff_lines, 120)
         self.assertTrue(config.safety.require_verification)
         self.assertIn(".github/workflows/", config.safety.forbidden_paths)
@@ -220,6 +228,41 @@ image = "untrusted-runner:latest"
         self.assertEqual(config.agent.harness, "codex-cli")
         self.assertEqual(config.agent.executable, "codex")
         self.assertEqual(config.runner.image, "reposteward-runner:latest")
+
+    def test_user_config_owns_the_shared_issue_review_project(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[issue_review]
+project_owner = "trusted-team"
+project_number = 7
+project_owner_type = "organization"
+require_distinct_reviewer = true
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[issue_review]
+project_owner = "attacker"
+project_number = 99
+project_owner_type = "user"
+require_distinct_reviewer = false
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project, user_path=user)
+
+        self.assertEqual(config.issue_review.project_owner, "trusted-team")
+        self.assertEqual(config.issue_review.project_number, 7)
+        self.assertEqual(config.issue_review.project_owner_type, "organization")
+        self.assertTrue(config.issue_review.require_distinct_reviewer)
 
     def test_unknown_configuration_version_is_rejected(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 from reposteward.config import GitHubConfig
-from reposteward.github import GitHubClient, resolve_authentication
+from reposteward.github import GitHubClient, GitHubError, resolve_authentication
 
 
 class StubGitHubClient(GitHubClient):
@@ -120,6 +120,88 @@ class GitHubIssueSearchTests(unittest.TestCase):
         args, kwargs = request.call_args
         self.assertEqual(args[:2], ("GET", "/search/issues"))
         self.assertIn("repo:owner/repo is:issue", kwargs["query"]["q"])
+
+
+class GitHubProjectIssueTests(unittest.TestCase):
+    def test_project_draft_item_is_parsed_from_graphql(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        payload = {
+            "data": {
+                "node": {
+                    "id": "PVTI_example",
+                    "fullDatabaseId": "123456",
+                    "updatedAt": "2026-08-21T00:00:00Z",
+                    "creator": {"login": "author"},
+                    "project": {
+                        "id": "PVT_example",
+                        "number": 1,
+                        "url": "https://example.test/project/1",
+                    },
+                    "content": {
+                        "__typename": "DraftIssue",
+                        "title": "Proposal title",
+                        "body": "Proposal body",
+                    },
+                }
+            }
+        }
+
+        with patch.object(client, "_request", return_value=(payload, None)):
+            result = client.project_issue_proposal("PVTI_example")
+
+        self.assertEqual(result.creator, "author")
+        self.assertEqual(result.database_id, 123456)
+        self.assertEqual(result.content_type, "DraftIssue")
+        self.assertEqual(result.project_id, "PVT_example")
+
+    def test_numeric_project_item_id_is_resolved_from_active_project_items(
+        self,
+    ) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        payload = {
+            "data": {
+                "node": {
+                    "items": {
+                        "nodes": [
+                            {
+                                "id": "PVTI_example",
+                                "fullDatabaseId": "123456",
+                                "updatedAt": "2026-08-21T00:00:00Z",
+                                "creator": {"login": "author"},
+                                "project": {
+                                    "id": "PVT_example",
+                                    "number": 1,
+                                    "url": "https://example.test/project/1",
+                                },
+                                "content": {
+                                    "__typename": "DraftIssue",
+                                    "title": "Proposal title",
+                                    "body": "Proposal body",
+                                },
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        }
+
+        with patch.object(client, "_request", return_value=(payload, None)):
+            result = client.project_issue_proposal_by_database_id(
+                project_id="PVT_example", database_id=123456
+            )
+
+        self.assertEqual(result.item_id, "PVTI_example")
+
+    def test_graphql_errors_fail_closed(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        payload = {"errors": [{"message": "Projects permission is required"}]}
+
+        with (
+            patch.object(client, "_request", return_value=(payload, None)),
+            self.assertRaisesRegex(GitHubError, "Projects permission is required"),
+        ):
+            client.project_v2("owner", 1, owner_type="user")
 
 
 class GitHubPullRequestTests(unittest.TestCase):

--- a/tests/test_issue_proposals.py
+++ b/tests/test_issue_proposals.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from reposteward.config import load_config
+from reposteward.github import ProjectIssueProposal
+from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
+from reposteward.store import Store
+
+
+class FakeProposalClient:
+    def __init__(
+        self, proposal: ProjectIssueProposal, *, login: str = "reviewer"
+    ) -> None:
+        self.proposal = proposal
+        self.login = login
+        self.created = 0
+        self.converted = 0
+        self.converted_item_id = ""
+        self.similar = [
+            {
+                "number": 7,
+                "title": "Related watcher behavior",
+                "state": "open",
+                "url": "https://example.test/owner/repo/issues/7",
+            }
+        ]
+
+    def authenticated_login(self) -> str:
+        return self.login
+
+    def project_v2(
+        self, owner: str, number: int, *, owner_type: str
+    ) -> dict[str, object]:
+        return {
+            "id": self.proposal.project_id,
+            "number": number,
+            "url": self.proposal.project_url,
+        }
+
+    def add_project_issue_proposal(self, **_kwargs: object) -> ProjectIssueProposal:
+        self.created += 1
+        return self.proposal
+
+    def project_issue_proposal(self, _item_id: str) -> ProjectIssueProposal:
+        return self.proposal
+
+    def project_issue_proposal_by_database_id(
+        self, *, project_id: str, database_id: int
+    ) -> ProjectIssueProposal:
+        if project_id != self.proposal.project_id:
+            raise AssertionError("unexpected project")
+        if database_id != self.proposal.database_id:
+            raise AssertionError("unexpected database ID")
+        return self.proposal
+
+    def similar_issues(
+        self, _repository: str, _title: str, *, limit: int
+    ) -> list[dict[str, object]]:
+        return self.similar[:limit]
+
+    def convert_project_issue_proposal(
+        self, *, item_id: str, repository: str
+    ) -> ProjectIssueProposal:
+        self.converted += 1
+        self.converted_item_id = item_id
+        return ProjectIssueProposal(
+            item_id=item_id,
+            database_id=self.proposal.database_id,
+            project_id=self.proposal.project_id,
+            project_number=self.proposal.project_number,
+            project_url=self.proposal.project_url,
+            updated_at="2026-08-21T02:00:00Z",
+            creator=self.proposal.creator,
+            content_type="Issue",
+            title=self.proposal.title,
+            body=self.proposal.body,
+            issue_number=42,
+            issue_url="https://example.test/owner/repo/issues/42",
+            repository=repository,
+        )
+
+
+def proposal(
+    *, creator: str = "author", body: str = "## Summary\n\nDetails\n"
+) -> ProjectIssueProposal:
+    return ProjectIssueProposal(
+        item_id="PVTI_example",
+        database_id=123456,
+        project_id="PVT_example",
+        project_number=1,
+        project_url="https://github.com/users/example/projects/1",
+        updated_at="2026-08-21T01:00:00Z",
+        creator=creator,
+        content_type="DraftIssue",
+        title="Watcher repeats one read",
+        body=body,
+    )
+
+
+class IssueProposalTests(unittest.TestCase):
+    def _pipeline(self, root: Path, *, login: str = "reviewer") -> Pipeline:
+        path = root / "config.toml"
+        path.write_text(
+            f"""config_version = 1
+[project]
+state_dir = {str(root / "state")!r}
+namespace_state = false
+[github]
+login = {login!r}
+git_name = {login!r}
+git_email = {f"{login}@example.com"!r}
+[issue_review]
+project_owner = "example"
+project_number = 1
+project_owner_type = "user"
+require_distinct_reviewer = true
+[repositories."owner/repo"]
+""",
+            encoding="utf-8",
+        )
+        pipeline = Pipeline.__new__(Pipeline)
+        pipeline.config = load_config(path)
+        pipeline.store = Store(root / "state.sqlite3")
+        return pipeline
+
+    def test_stage_is_explicit_online_write_and_idempotent_locally(self) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory))
+            draft = pipeline.store.create_issue_draft(
+                "owner/repo", "Watcher repeats one read", "## Summary\n\nDetails\n"
+            )
+            client = FakeProposalClient(proposal(), login="reviewer")
+            with (
+                patch.dict("os.environ", {"REPOSTEWARD_ENABLE_ISSUE_STAGE": "1"}),
+                patch.object(
+                    pipeline,
+                    "_authenticated_publication_client",
+                    return_value=client,
+                ),
+            ):
+                first = pipeline.stage_issue_proposal(
+                    draft["id"], submitted_by="reviewer"
+                )
+                second = pipeline.stage_issue_proposal(
+                    draft["id"], submitted_by="reviewer"
+                )
+
+        self.assertTrue(first["public_write"])
+        self.assertFalse(second["public_write"])
+        self.assertTrue(second["idempotent"])
+        self.assertEqual(client.created, 1)
+
+    def test_security_like_content_never_reaches_online_staging(self) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory))
+            draft = pipeline.store.create_issue_draft(
+                "owner/repo",
+                "Authentication bypass",
+                "## Summary\n\nA security vulnerability.\n",
+            )
+            with (
+                patch.dict("os.environ", {"REPOSTEWARD_ENABLE_ISSUE_STAGE": "1"}),
+                self.assertRaisesRegex(PolicyError, "private reporting channel"),
+            ):
+                pipeline.stage_issue_proposal(draft["id"], submitted_by="reviewer")
+
+    def test_review_digest_covers_latest_online_content_and_duplicates(self) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory))
+            client = FakeProposalClient(proposal())
+            pipeline.github = client
+
+            first = pipeline.issue_proposal_review(
+                "PVTI_example", repository="owner/repo"
+            )
+            client.proposal = replace(
+                client.proposal,
+                updated_at="2026-08-21T03:00:00Z",
+                body="## Summary\n\nEdited online.\n",
+            )
+            second = pipeline.issue_proposal_review(
+                "PVTI_example", repository="owner/repo"
+            )
+
+        self.assertNotEqual(first["review_digest"], second["review_digest"])
+        self.assertTrue(first["duplicates_require_human_judgment"])
+        self.assertTrue(first["eligible_for_promotion"])
+
+    def test_review_accepts_the_numeric_item_id_from_a_project_browser_url(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory))
+            client = FakeProposalClient(proposal())
+            pipeline.github = client
+
+            report = pipeline.issue_proposal_review(
+                "https://github.com/users/example/projects/1?pane=issue&itemId=123456",
+                repository="owner/repo",
+            )
+
+        self.assertEqual(report["item_id"], "PVTI_example")
+        self.assertEqual(report["database_id"], 123456)
+
+    def test_promotion_requires_a_second_reviewer_and_current_digest(self) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory))
+            client = FakeProposalClient(proposal(creator="author"), login="reviewer")
+            pipeline.github = client
+            report = pipeline.issue_proposal_review(
+                "PVTI_example", repository="owner/repo"
+            )
+            with (
+                patch.dict("os.environ", {"REPOSTEWARD_ENABLE_ISSUE_PROMOTION": "1"}),
+                patch.object(
+                    pipeline,
+                    "_authenticated_publication_client",
+                    return_value=client,
+                ),
+            ):
+                with self.assertRaisesRegex(PolicyError, "digest is stale"):
+                    pipeline.promote_issue_proposal(
+                        "PVTI_example",
+                        repository="owner/repo",
+                        reviewed_by="reviewer",
+                        review_digest="0" * 64,
+                        duplicates_reviewed=True,
+                    )
+                published = pipeline.promote_issue_proposal(
+                    "https://github.com/users/example/projects/1?pane=issue&itemId=123456",
+                    repository="owner/repo",
+                    reviewed_by="reviewer",
+                    review_digest=report["review_digest"],
+                    duplicates_reviewed=True,
+                )
+
+        self.assertTrue(published["public_write"])
+        self.assertEqual(published["issue_number"], 42)
+        self.assertEqual(client.converted, 1)
+        self.assertEqual(client.converted_item_id, "PVTI_example")
+
+    def test_proposal_creator_cannot_self_approve_by_default(self) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(Path(directory), login="author")
+            client = FakeProposalClient(proposal(creator="author"), login="author")
+            pipeline.github = client
+            report = pipeline.issue_proposal_review(
+                "PVTI_example", repository="owner/repo"
+            )
+            with (
+                patch.dict("os.environ", {"REPOSTEWARD_ENABLE_ISSUE_PROMOTION": "1"}),
+                patch.object(
+                    pipeline,
+                    "_authenticated_publication_client",
+                    return_value=client,
+                ),
+                self.assertRaisesRegex(PolicyError, "must be different"),
+            ):
+                pipeline.promote_issue_proposal(
+                    "PVTI_example",
+                    repository="owner/repo",
+                    reviewed_by="author",
+                    review_digest=report["review_digest"],
+                    duplicates_reviewed=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -4,7 +4,14 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from reposteward.issues import read_details, render_issue_body, validate_issue_title
+from reposteward.issues import (
+    attach_proposal_marker,
+    issue_security_signals,
+    proposal_body,
+    read_details,
+    render_issue_body,
+    validate_issue_title,
+)
 
 
 class IssueDraftTests(unittest.TestCase):
@@ -48,6 +55,28 @@ class IssueDraftTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "credential"):
                 read_details(path)
+
+    def test_security_reports_are_blocked_before_online_staging(self) -> None:
+        signals = issue_security_signals(
+            "Authentication bypass",
+            "The report demonstrates a command injection vulnerability.",
+        )
+
+        self.assertIn("potential security vulnerability", signals)
+
+    def test_online_marker_cannot_silently_redirect_the_repository(self) -> None:
+        body = attach_proposal_marker(
+            "## Summary\n\nDetails\n",
+            repository="owner/repo",
+            draft_id="a" * 32,
+        )
+
+        self.assertEqual(
+            proposal_body(body, repository="owner/repo"),
+            "## Summary\n\nDetails\n",
+        )
+        with self.assertRaisesRegex(ValueError, "different repository"):
+            proposal_body(body, repository="other/repo")
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -36,6 +36,9 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(result["github_login"], "alice")
         self.assertEqual(parsed["config_version"], 1)
         self.assertEqual(parsed["github"]["login"], "alice")
+        self.assertEqual(parsed["issue_review"]["project_owner"], "")
+        self.assertEqual(parsed["issue_review"]["project_number"], 0)
+        self.assertTrue(parsed["issue_review"]["require_distinct_reviewer"])
         self.assertEqual(
             parsed["project"]["state_dir"], str(root / "state" / "reposteward")
         )
@@ -54,6 +57,23 @@ class SetupTests(unittest.TestCase):
                 initialize_user_config(path=path, login="alice")
 
             self.assertEqual(path.read_text(encoding="utf-8"), "existing")
+
+    def test_init_can_configure_a_shared_issue_review_project(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+
+            initialize_user_config(
+                path=path,
+                login="alice",
+                issue_project_owner="team",
+                issue_project_number=7,
+                issue_project_owner_type="organization",
+            )
+            parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(parsed["issue_review"]["project_owner"], "team")
+        self.assertEqual(parsed["issue_review"]["project_number"], 7)
+        self.assertEqual(parsed["issue_review"]["project_owner_type"], "organization")
 
     def test_repo_add_creates_project_config_that_layers_over_user_config(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -236,6 +236,32 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(restored["title"], "Example issue")
         self.assertEqual(listing[0]["id"], created["id"])
 
+    def test_issue_proposal_round_trip_and_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            created = store.record_issue_proposal(
+                project_item_id="PVTI_example",
+                project_id="PVT_example",
+                project_url="https://example.test/project/1",
+                draft_id="a" * 32,
+                repository="Owner/Repo",
+                creator="alice",
+                content_digest="b" * 64,
+            )
+            restored = store.issue_proposal_for_draft("PVT_example", "a" * 32)
+            store.mark_issue_proposal_published(
+                "PVTI_example",
+                issue_number=42,
+                issue_url="https://example.test/owner/repo/issues/42",
+            )
+            published = store.issue_proposal_for_draft("PVT_example", "a" * 32)
+
+        self.assertEqual(created["repository"], "owner/repo")
+        self.assertIsNotNone(restored)
+        assert published is not None
+        self.assertEqual(published["status"], "published")
+        self.assertEqual(published["issue_number"], 42)
+
     def test_context_bundle_round_trip_uses_latest_checkpoint(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PublicationWorkflowTests(unittest.TestCase):
+    def test_issue_workflows_are_manual_and_do_not_use_ambient_write_token(
+        self,
+    ) -> None:
+        for name in ("issue-proposal-review.yml", "issue-proposal-promote.yml"):
+            content = (ROOT / ".github" / "workflows" / name).read_text(
+                encoding="utf-8"
+            )
+
+            self.assertIn("workflow_dispatch:", content)
+            self.assertNotIn("pull_request_target", content)
+            self.assertNotIn("issue_comment:", content)
+            self.assertNotIn("github.token", content)
+            self.assertIn("permissions:\n  contents: read", content)
+            self.assertIn("github.event.repository.default_branch", content)
+            self.assertIn("persist-credentials: false", content)
+            self.assertIn("$RUNNER_TEMP/reposteward/state", content)
+            self.assertNotIn("${{ runner.temp }}", content)
+            self.assertNotIn(
+                "    env:\n      GH_TOKEN: ${{ secrets.REPOSTEWARD_GITHUB_", content
+            )
+
+    def test_issue_promotion_requires_environment_digest_and_duplicate_review(
+        self,
+    ) -> None:
+        content = (
+            ROOT / ".github" / "workflows" / "issue-proposal-promote.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("environment: reposteward-issue-publishing", content)
+        self.assertIn("group: issue-promote-${{ inputs.repository }}", content)
+        self.assertIn("review_digest:", content)
+        self.assertIn("duplicates_reviewed:", content)
+        self.assertIn('test "$GITHUB_ACTOR" = "$PUBLISHER_LOGIN"', content)
+        self.assertIn('REPOSTEWARD_ENABLE_ISSUE_PROMOTION: "1"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

Closes #2

## 问题与改动

RepoSteward 原有 Issue 草稿仅存在本地，不能支持多人共享待审提案；直接创建正式 Issue 又会绕过发布前的最新内容、重复项和安全检查。

本 PR 引入 GitHub Project Draft Issue 提案队列：`stage` 只把本地草稿暂存为线上 Draft Issue，`review` 重新读取线上最新内容并生成包含查重快照的 digest，`promote` 在另一位 reviewer、精确 digest、重复项确认和独立环境开关都通过后，才将提案转换成正式 Issue。

同时增加 GitHub Project GraphQL 集成、SQLite v4 无损迁移、Project URL/数字 `itemId` 解析、只读 review 与受保护 promotion Actions。同一目标仓库的 promotion 串行执行，写 token 仅暴露给最终转换步骤，不会交给第三方 Action、Harness、测试或目标仓库代码。

## 验证

```text
uvx ruff format --check .                                      passed
uvx ruff check .                                               passed
uv run python -W error::ResourceWarning -m unittest discover -s tests -v
                                                               110 tests passed
uv run reposteward --help                                      passed
uv build                                                       passed
PyYAML workflow parse                                          passed
actionlint 1.7.12                                               passed
zizmor (new issue workflows)                                   no findings
GitHub GraphQL schema introspection                             fields and mutations verified
```

## 风险与兼容性

数据库由 schema v3 无损迁移到 v4，新表只保存 Project 提案的本地幂等/审计缓存，GitHub Project 仍是多人协作的真相源。两个 workflow 均只能手动触发，且在配置 Project、Environment、仓库变量和独立 token 前不会产生任何公开写入。疑似安全报告或凭据内容会在线上暂存/转换前失败。

## 自动化辅助

使用 Codex 辅助实现和检查 GraphQL、数据库迁移、CLI 门禁与 Actions 安全边界。提交者已人工复核完整 diff、GitHub 实时 GraphQL schema、并发查重语义、凭据作用域和公开写入路径。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建。
- [x] 新行为有回归测试。
- [x] 文档、配置示例和数据库迁移已与行为同步；JSON Schema 不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
