### PR TITLE
feat(follow-up): persist GitHub PR event versions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,10 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
 - `context_imports`：按 bundle digest 去重保存的跨机器交接历史，不覆盖本机较新的 Issue 快照。
 - `issue_proposals`：缓存本机发起的 Project item 和转换结果；GitHub Project 中的最新内容仍是
   多人审查阶段的唯一真相。
+- `github_pr_events`：按 repository、PR、事件类型、稳定 ID 和内容摘要追加 GitHub 事件版本；
+  原始正文显式标记为 GitHub 不可信输入。
+- `github_pr_watermarks`：保存每个 run 已形成 Review Checkpoint 的事件序号；Checkpoint 和水位
+  可以在同一事务中提交。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -17,6 +17,8 @@ from typing import Any
 from .config import GitHubConfig
 from .models import Issue, RepositoryInfo
 
+MAX_REST_PAGES = 1_000
+
 
 class GitHubError(RuntimeError):
     """A GitHub API request failed."""
@@ -165,6 +167,42 @@ class GitHubClient:
         if not isinstance(data, dict):
             raise GitHubError("GitHub GraphQL response did not contain data")
         return data
+
+    @staticmethod
+    def _response_has_next_page(response: object) -> bool:
+        headers = getattr(response, "headers", None)
+        if headers is None or not hasattr(headers, "get"):
+            return False
+        link = str(headers.get("Link", ""))
+        return any('rel="next"' in value for value in link.split(",") if value.strip())
+
+    def _paginated_rest_values(
+        self, path: str, *, container: str = ""
+    ) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            payload, response = self._request(
+                "GET", path, query={"per_page": 100, "page": page}
+            )
+            values = (
+                payload.get(container)
+                if container and isinstance(payload, dict)
+                else payload
+            )
+            if not isinstance(values, list) or not all(
+                isinstance(value, dict) for value in values
+            ):
+                label = container or "response"
+                raise GitHubError(f"GitHub paginated {label} was not a list")
+            result.extend(values)
+            if not self._response_has_next_page(response):
+                return result
+            if page >= MAX_REST_PAGES:
+                raise GitHubError(
+                    f"GitHub pagination exceeded {MAX_REST_PAGES} pages for {path}"
+                )
+            page += 1
 
     def project_v2(self, owner: str, number: int, *, owner_type: str) -> dict[str, Any]:
         field = "organization" if owner_type == "organization" else "user"
@@ -677,34 +715,20 @@ class GitHubClient:
 
     def pull_request_activity(self, upstream: str, number: int) -> dict[str, Any]:
         pull, _ = self._request("GET", f"/repos/{upstream}/pulls/{number}")
-        comments, _ = self._request(
-            "GET",
-            f"/repos/{upstream}/issues/{number}/comments",
-            query={"per_page": 100},
+        comments = self._paginated_rest_values(
+            f"/repos/{upstream}/issues/{number}/comments"
         )
-        reviews, _ = self._request(
-            "GET",
-            f"/repos/{upstream}/pulls/{number}/reviews",
-            query={"per_page": 100},
+        reviews = self._paginated_rest_values(
+            f"/repos/{upstream}/pulls/{number}/reviews"
         )
-        review_comments, _ = self._request(
-            "GET",
-            f"/repos/{upstream}/pulls/{number}/comments",
-            query={"per_page": 100},
+        review_comments = self._paginated_rest_values(
+            f"/repos/{upstream}/pulls/{number}/comments"
         )
         head_sha = str((pull.get("head") or {}).get("sha") or "")
-        checks, _ = self._request(
-            "GET",
+        check_runs = self._paginated_rest_values(
             f"/repos/{upstream}/commits/{head_sha}/check-runs",
-            query={"per_page": 100},
+            container="check_runs",
         )
-        if not all(
-            isinstance(value, list) for value in (comments, reviews, review_comments)
-        ):
-            raise GitHubError(
-                f"pull request activity for {upstream}#{number} is invalid"
-            )
-        check_runs = checks.get("check_runs", ()) if isinstance(checks, dict) else ()
         return {
             "pull_request": {
                 "number": int(pull["number"]),

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import uuid
@@ -12,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -195,6 +196,42 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON issue_proposals(status, updated_at DESC)
         """,
     ),
+    5: (
+        """
+        CREATE TABLE IF NOT EXISTS github_pr_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            external_id TEXT NOT NULL,
+            version_digest TEXT NOT NULL,
+            head_sha TEXT NOT NULL DEFAULT '',
+            source_trust TEXT NOT NULL DEFAULT 'github_untrusted',
+            source_created_at TEXT NOT NULL DEFAULT '',
+            source_updated_at TEXT NOT NULL DEFAULT '',
+            payload TEXT NOT NULL,
+            ingested_at TEXT NOT NULL,
+            UNIQUE(
+                repository, pull_number, event_type, external_id, version_digest
+            )
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS github_pr_events_for_pull
+        ON github_pr_events(repository, pull_number, sequence)
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS github_pr_watermarks (
+            run_id TEXT PRIMARY KEY,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            sequence INTEGER NOT NULL DEFAULT 0,
+            batch_digest TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        )
+        """,
+    ),
 }
 
 
@@ -204,6 +241,19 @@ class StoreError(RuntimeError):
 
 def utc_now() -> str:
     return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _json_digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
 
 
 class Store:
@@ -669,15 +719,15 @@ class Store:
             if cursor.rowcount != 1:
                 raise KeyError(f"harness run not found: {run_id}")
 
-    def save_checkpoint(
-        self,
+    @staticmethod
+    def _validate_checkpoint_record(
         *,
         work_item_id: str,
         run_id: str,
         context_pack_id: str,
         status: str,
         payload: dict[str, Any],
-    ) -> dict[str, Any]:
+    ) -> None:
         expected = {
             "work_item_id": work_item_id,
             "run_id": run_id,
@@ -692,59 +742,352 @@ class Store:
                 "checkpoint payload does not match its record: " + ", ".join(mismatched)
             )
         validate_checkpoint(payload)
+
+    @staticmethod
+    def _insert_checkpoint(
+        connection: sqlite3.Connection,
+        *,
+        work_item_id: str,
+        run_id: str,
+        context_pack_id: str,
+        status: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        context = connection.execute(
+            """
+            SELECT work_item_id, run_id FROM context_packs WHERE id=?
+            """,
+            (context_pack_id,),
+        ).fetchone()
+        if context is None:
+            raise KeyError(f"context pack not found: {context_pack_id}")
+        if (
+            str(context["work_item_id"]) != work_item_id
+            or str(context["run_id"]) != run_id
+        ):
+            raise StoreError(
+                "checkpoint context pack belongs to a different work item or run"
+            )
+        row = connection.execute(
+            """
+            SELECT COALESCE(MAX(sequence), 0) + 1 AS next_sequence
+            FROM checkpoints WHERE run_id=?
+            """,
+            (run_id,),
+        ).fetchone()
+        assert row is not None
+        sequence = int(row["next_sequence"])
         checkpoint_id = uuid.uuid4().hex
+        now = utc_now()
+        materialized = {
+            **payload,
+            "id": checkpoint_id,
+            "sequence": sequence,
+            "created_at": now,
+        }
+        connection.execute(
+            """
+            INSERT INTO checkpoints(
+                id, work_item_id, run_id, context_pack_id, sequence,
+                status, payload, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                checkpoint_id,
+                work_item_id,
+                run_id,
+                context_pack_id,
+                sequence,
+                status,
+                json.dumps(materialized, ensure_ascii=False),
+                now,
+            ),
+        )
+        return materialized
+
+    def save_checkpoint(
+        self,
+        *,
+        work_item_id: str,
+        run_id: str,
+        context_pack_id: str,
+        status: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._validate_checkpoint_record(
+            work_item_id=work_item_id,
+            run_id=run_id,
+            context_pack_id=context_pack_id,
+            status=status,
+            payload=payload,
+        )
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            return self._insert_checkpoint(
+                connection,
+                work_item_id=work_item_id,
+                run_id=run_id,
+                context_pack_id=context_pack_id,
+                status=status,
+                payload=payload,
+            )
+
+    @staticmethod
+    def _github_event_values(
+        activity: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        pull = activity.get("pull_request")
+        if not isinstance(pull, dict):
+            raise StoreError("GitHub activity is missing its pull request")
+        head_sha = str(pull.get("head_sha", ""))
+        collections: tuple[tuple[str, object], ...] = (
+            ("pull_request", (pull,)),
+            ("issue_comment", activity.get("comments")),
+            ("review", activity.get("reviews")),
+            ("review_comment", activity.get("review_comments")),
+            ("check", activity.get("checks")),
+        )
+        result: list[dict[str, str]] = []
+        for event_type, raw_values in collections:
+            if not isinstance(raw_values, (list, tuple)):
+                raise StoreError(f"GitHub {event_type} activity is not a list")
+            for value in raw_values:
+                if not isinstance(value, dict):
+                    raise StoreError(f"GitHub {event_type} event is not an object")
+                external_value = (
+                    value.get("number")
+                    if event_type == "pull_request"
+                    else value.get("id")
+                )
+                external_id = str(external_value or "").strip()
+                if not external_id:
+                    raise StoreError(f"GitHub {event_type} event has no stable ID")
+                result.append(
+                    {
+                        "event_type": event_type,
+                        "external_id": external_id,
+                        "version_digest": _json_digest(value),
+                        "head_sha": head_sha,
+                        "source_created_at": str(
+                            value.get("created_at") or value.get("submitted_at") or ""
+                        ),
+                        "source_updated_at": str(
+                            value.get("updated_at") or value.get("submitted_at") or ""
+                        ),
+                        "payload": _canonical_json(value),
+                    }
+                )
+        return result
+
+    def ingest_github_pr_activity(
+        self,
+        *,
+        run_id: str,
+        repository: str,
+        pull_number: int,
+        activity: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Persist immutable event versions and return those after the run watermark."""
+        repository = repository.casefold()
+        if pull_number < 1:
+            raise ValueError("pull_number must be positive")
+        event_values = self._github_event_values(activity)
         now = utc_now()
         with self._connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
-            context = connection.execute(
-                """
-                SELECT work_item_id, run_id FROM context_packs WHERE id=?
-                """,
-                (context_pack_id,),
+            run = connection.execute(
+                "SELECT repository, details FROM runs WHERE id=?", (run_id,)
             ).fetchone()
-            if context is None:
-                raise KeyError(f"context pack not found: {context_pack_id}")
-            if (
-                str(context["work_item_id"]) != work_item_id
-                or str(context["run_id"]) != run_id
-            ):
-                raise StoreError(
-                    "checkpoint context pack belongs to a different work item or run"
-                )
-            row = connection.execute(
+            if run is None:
+                raise KeyError(f"run not found: {run_id}")
+            if str(run["repository"]).casefold() != repository:
+                raise StoreError("GitHub activity belongs to a different repository")
+            details = json.loads(str(run["details"]))
+            pr_url = str(details.get("pr_url", "")).rstrip("/")
+            if pr_url and not pr_url.endswith(f"/pull/{pull_number}"):
+                raise StoreError("GitHub activity belongs to a different pull request")
+            connection.execute(
                 """
-                SELECT COALESCE(MAX(sequence), 0) + 1 AS next_sequence
-                FROM checkpoints WHERE run_id=?
+                INSERT INTO github_pr_watermarks(
+                    run_id, repository, pull_number, sequence,
+                    batch_digest, updated_at
+                ) VALUES (?, ?, ?, 0, '', ?)
+                ON CONFLICT(run_id) DO NOTHING
+                """,
+                (run_id, repository, pull_number, now),
+            )
+            watermark = connection.execute(
+                """
+                SELECT repository, pull_number, sequence
+                FROM github_pr_watermarks WHERE run_id=?
                 """,
                 (run_id,),
             ).fetchone()
-            assert row is not None
-            sequence = int(row["next_sequence"])
-            materialized = {
-                **payload,
-                "id": checkpoint_id,
-                "sequence": sequence,
-                "created_at": now,
+            assert watermark is not None
+            if (
+                str(watermark["repository"]).casefold() != repository
+                or int(watermark["pull_number"]) != pull_number
+            ):
+                raise StoreError("GitHub watermark belongs to a different pull request")
+            for event in event_values:
+                connection.execute(
+                    """
+                    INSERT INTO github_pr_events(
+                        repository, pull_number, event_type, external_id,
+                        version_digest, head_sha, source_trust, source_created_at,
+                        source_updated_at, payload, ingested_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'github_untrusted', ?, ?, ?, ?)
+                    ON CONFLICT(
+                        repository, pull_number, event_type,
+                        external_id, version_digest
+                    ) DO NOTHING
+                    """,
+                    (
+                        repository,
+                        pull_number,
+                        event["event_type"],
+                        event["external_id"],
+                        event["version_digest"],
+                        event["head_sha"],
+                        event["source_created_at"],
+                        event["source_updated_at"],
+                        event["payload"],
+                        now,
+                    ),
+                )
+            previous_sequence = int(watermark["sequence"])
+            rows = connection.execute(
+                """
+                SELECT * FROM github_pr_events
+                WHERE repository=? AND pull_number=? AND sequence>?
+                ORDER BY sequence
+                """,
+                (repository, pull_number, previous_sequence),
+            ).fetchall()
+        events = []
+        for row in rows:
+            event = dict(row)
+            event["payload"] = json.loads(event["payload"])
+            events.append(event)
+        through_sequence = int(events[-1]["sequence"]) if events else previous_sequence
+        batch_digest = _json_digest(
+            [
+                {
+                    "sequence": value["sequence"],
+                    "event_type": value["event_type"],
+                    "external_id": value["external_id"],
+                    "version_digest": value["version_digest"],
+                }
+                for value in events
+            ]
+        )
+        return {
+            "previous_sequence": previous_sequence,
+            "through_sequence": through_sequence,
+            "batch_digest": batch_digest,
+            "events": events,
+        }
+
+    def commit_github_follow_up(
+        self,
+        *,
+        run_id: str,
+        repository: str,
+        pull_number: int,
+        previous_sequence: int,
+        through_sequence: int,
+        batch_digest: str,
+        checkpoint: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Advance a PR watermark and append its Review Checkpoint atomically."""
+        repository = repository.casefold()
+        checkpoint_args: dict[str, str] | None = None
+        if checkpoint is not None:
+            checkpoint_args = {
+                "work_item_id": str(checkpoint.get("work_item_id", "")),
+                "run_id": str(checkpoint.get("run_id", "")),
+                "context_pack_id": str(checkpoint.get("context_pack_id", "")),
+                "status": str(checkpoint.get("status", "")),
             }
+            self._validate_checkpoint_record(payload=checkpoint, **checkpoint_args)
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            watermark = connection.execute(
+                "SELECT * FROM github_pr_watermarks WHERE run_id=?", (run_id,)
+            ).fetchone()
+            if watermark is None:
+                raise KeyError(f"GitHub watermark not found for run: {run_id}")
+            if (
+                str(watermark["repository"]).casefold() != repository
+                or int(watermark["pull_number"]) != pull_number
+            ):
+                raise StoreError("GitHub watermark belongs to a different pull request")
+            current_sequence = int(watermark["sequence"])
+            if current_sequence != previous_sequence:
+                if current_sequence >= through_sequence:
+                    return {
+                        "idempotent": True,
+                        "sequence": current_sequence,
+                        "checkpoint": None,
+                    }
+                raise StoreError("GitHub watermark changed during follow-up")
+            if through_sequence < previous_sequence:
+                raise StoreError("GitHub watermark cannot move backwards")
+            if through_sequence > previous_sequence:
+                event = connection.execute(
+                    """
+                    SELECT sequence FROM github_pr_events
+                    WHERE repository=? AND pull_number=? AND sequence=?
+                    """,
+                    (repository, pull_number, through_sequence),
+                ).fetchone()
+                if event is None:
+                    raise StoreError(
+                        "GitHub watermark does not reference a stored event"
+                    )
+            materialized = None
+            if checkpoint is not None:
+                assert checkpoint_args is not None
+                materialized = self._insert_checkpoint(
+                    connection, payload=checkpoint, **checkpoint_args
+                )
             connection.execute(
                 """
-                INSERT INTO checkpoints(
-                    id, work_item_id, run_id, context_pack_id, sequence,
-                    status, payload, created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                UPDATE github_pr_watermarks
+                SET sequence=?, batch_digest=?, updated_at=? WHERE run_id=?
                 """,
-                (
-                    checkpoint_id,
-                    work_item_id,
-                    run_id,
-                    context_pack_id,
-                    sequence,
-                    status,
-                    json.dumps(materialized, ensure_ascii=False),
-                    now,
-                ),
+                (through_sequence, batch_digest, utc_now(), run_id),
             )
-        return materialized
+        return {
+            "idempotent": False,
+            "sequence": through_sequence,
+            "checkpoint": materialized,
+        }
+
+    def github_pr_events(
+        self, repository: str, pull_number: int
+    ) -> list[dict[str, Any]]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM github_pr_events
+                WHERE repository=? AND pull_number=? ORDER BY sequence
+                """,
+                (repository.casefold(), pull_number),
+            ).fetchall()
+        result = []
+        for row in rows:
+            event = dict(row)
+            event["payload"] = json.loads(event["payload"])
+            result.append(event)
+        return result
+
+    def github_pr_watermark(self, run_id: str) -> dict[str, Any] | None:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM github_pr_watermarks WHERE run_id=?", (run_id,)
+            ).fetchone()
+        return dict(row) if row is not None else None
 
     def update_work_item_status(self, work_item_id: str, status: str) -> None:
         with self._connection() as connection:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -205,6 +206,67 @@ class GitHubProjectIssueTests(unittest.TestCase):
 
 
 class GitHubPullRequestTests(unittest.TestCase):
+    def test_pull_request_activity_follows_every_rest_page(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        pull = {
+            "number": 12,
+            "html_url": "https://example.test/pull/12",
+            "state": "open",
+            "draft": True,
+            "updated_at": "2026-08-20T00:00:00Z",
+            "head": {"sha": "a" * 40},
+            "base": {"ref": "main"},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "merged_at": None,
+        }
+        first_page = [
+            {
+                "id": value,
+                "user": {"login": "reviewer"},
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "html_url": f"https://example.test/comment/{value}",
+                "body": "review",
+            }
+            for value in range(1, 101)
+        ]
+        second_page = [
+            {
+                "id": 101,
+                "user": {"login": "reviewer"},
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "html_url": "https://example.test/comment/101",
+                "body": "last review",
+            }
+        ]
+        next_page = SimpleNamespace(
+            headers={
+                "Link": '<https://api.test/comments?page=2>; rel="next", '
+                '<https://api.test/comments?page=2>; rel="last"'
+            }
+        )
+        last_page = SimpleNamespace(headers={})
+
+        with patch.object(
+            client,
+            "_request",
+            side_effect=[
+                (pull, None),
+                (first_page, next_page),
+                (second_page, last_page),
+                ([], last_page),
+                ([], last_page),
+                ({"check_runs": []}, last_page),
+            ],
+        ) as request:
+            activity = client.pull_request_activity("owner/repo", 12)
+
+        self.assertEqual(len(activity["comments"]), 101)
+        self.assertEqual(request.call_args_list[1].kwargs["query"]["page"], 1)
+        self.assertEqual(request.call_args_list[2].kwargs["query"]["page"], 2)
+
     def test_pull_request_activity_returns_compact_structured_state(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")
         pull = {

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -177,6 +177,28 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
             self.assertIsNotNone(table)
 
+    def test_version_four_database_receives_github_event_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE github_pr_watermarks")
+                connection.execute("DROP TABLE github_pr_events")
+                connection.execute("PRAGMA user_version=4")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                tables = {
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table'"
+                    )
+                }
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIn("github_pr_events", tables)
+            self.assertIn("github_pr_watermarks", tables)
+
     def test_candidate_round_trip_and_status_preservation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")
@@ -331,6 +353,126 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(bundle["harness_run"]["harness"], "codex-cli")
         self.assertEqual(bundle["checkpoint"]["status"], "ready")
         self.assertEqual(json.dumps(bundle["context_pack"]), json.dumps(context))
+
+    def test_github_event_versions_and_checkpoint_watermark_are_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            work_item = store.ensure_work_item(
+                "owner/repo",
+                kind="github_issue",
+                external_id="7",
+                title="Example issue",
+            )
+            run_id = store.start_run("owner/repo", 7, "pull_request")
+            store.update_run(
+                run_id,
+                status="submitted",
+                details={
+                    "commit_sha": "a" * 40,
+                    "pr_url": "https://github.com/owner/repo/pull/12",
+                },
+            )
+            context = _context_payload(
+                pack_id="pack-1",
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                source_digest="a" * 64,
+                base_commit="b" * 40,
+            )
+            store.save_context_run(
+                pack_id="pack-1",
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                schema_version=1,
+                source_digest=_context_source_digest("a" * 64),
+                base_commit="b" * 40,
+                payload=context,
+                harness="codex-cli",
+            )
+            activity = {
+                "pull_request": {
+                    "number": 12,
+                    "url": "https://github.com/owner/repo/pull/12",
+                    "head_sha": "a" * 40,
+                },
+                "comments": [
+                    {
+                        "id": 21,
+                        "body": "first",
+                        "created_at": "2026-08-20T00:00:00Z",
+                        "updated_at": "2026-08-20T00:00:00Z",
+                    }
+                ],
+                "reviews": [],
+                "review_comments": [],
+                "checks": [],
+            }
+
+            first = store.ingest_github_pr_activity(
+                run_id=run_id,
+                repository="owner/repo",
+                pull_number=12,
+                activity=activity,
+            )
+            repeated = store.ingest_github_pr_activity(
+                run_id=run_id,
+                repository="owner/repo",
+                pull_number=12,
+                activity=activity,
+            )
+            checkpoint = _checkpoint_payload(
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                pack_id="pack-1",
+                status="submitted",
+            )
+            committed = store.commit_github_follow_up(
+                run_id=run_id,
+                repository="owner/repo",
+                pull_number=12,
+                previous_sequence=first["previous_sequence"],
+                through_sequence=first["through_sequence"],
+                batch_digest=first["batch_digest"],
+                checkpoint=checkpoint,
+            )
+            after_commit = store.ingest_github_pr_activity(
+                run_id=run_id,
+                repository="owner/repo",
+                pull_number=12,
+                activity=activity,
+            )
+            activity["comments"][0]["body"] = "edited"
+            activity["comments"][0]["updated_at"] = "2026-08-21T00:00:00Z"
+            edited = store.ingest_github_pr_activity(
+                run_id=run_id,
+                repository="owner/repo",
+                pull_number=12,
+                activity=activity,
+            )
+            events = store.github_pr_events("owner/repo", 12)
+            watermark = store.github_pr_watermark(run_id)
+            bundle = store.context_bundle(run_id)
+
+        self.assertEqual(len(first["events"]), 2)
+        self.assertEqual(repeated["batch_digest"], first["batch_digest"])
+        self.assertEqual(len(repeated["events"]), 2)
+        self.assertFalse(committed["idempotent"])
+        self.assertEqual(committed["checkpoint"]["sequence"], 1)
+        self.assertEqual(after_commit["events"], [])
+        self.assertEqual(len(edited["events"]), 1)
+        self.assertEqual(edited["events"][0]["event_type"], "issue_comment")
+        self.assertEqual(len(events), 3)
+        self.assertTrue(
+            all(event["source_trust"] == "github_untrusted" for event in events)
+        )
+        self.assertEqual(
+            [event["payload"]["body"] for event in events[1:]],
+            ["first", "edited"],
+        )
+        assert watermark is not None
+        self.assertEqual(watermark["sequence"], first["through_sequence"])
+        assert bundle is not None
+        self.assertEqual(bundle["checkpoint"]["status"], "submitted")
 
     def test_context_pack_and_harness_binding_are_atomic(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 关联 Issue

Refs #9

## 问题与改动

当前 `follow-up` 只能读取每类前 100 条 PR 活动，并把聚合快照写入 `runs.details`，无法保存同一评论的编辑版本，也没有可供后续 Review Checkpoint 使用的事件水位。

本 PR 提供 #9 的持久化基础：

- 完整遍历 GitHub comments、Reviews、Review comments 和 checks 的 REST 分页，超过 1000 页时明确失败而不是静默截断；
- 增加 schema v5，将 PR 活动按 repository、PR、事件类型、稳定 ID 和内容摘要保存为不可变版本；
- 显式记录 `github_untrusted` 来源，并保留事件正文、关联 head 和 GitHub 时间；
- 增加 run 水位以及“追加 Checkpoint + 推进水位”的原子事务 API；
- 覆盖旧数据库升级、重复摄取、评论编辑版本、分页和事务行为。

本 PR 不修改 `Pipeline.follow_up` 的公开行为，也不关闭 #9；后续小 PR 将接入这些 API 并生成 Review Checkpoint。

## 验证

以下命令已通过 RepoSteward Runner 在无凭据隔离容器内执行：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

本地还运行了文档要求的 `uv build` 和 CLI smoke test。共 115 项测试通过。

## 风险与兼容性

包含 SQLite schema v4 → v5 的追加式迁移，不修改或删除既有表和数据。事件正文会增加本地存储占用；分层保留和安全 GC 由 #10 单独处理。分页增加长 PR 的 API 请求次数，但不会重复保存内容相同的事件版本。

没有改变 GitHub 写入门禁、凭据隔离、Harness 契约或 Runner 网络边界。

## 自动化辅助

使用 Codex 协助实现和测试。`tiammomo` 已检查完整 diff、迁移、事件唯一键、事务边界、分页行为、测试结果和公开说明，并对提交负责。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
