### PR TITLE
feat(follow-up): checkpoint incremental PR activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,11 @@ REPOSTEWARD_ENABLE_SUBMIT=1 \
 uv run reposteward follow-up RUN_ID
 ```
 
-第一次调用建立水位，之后只返回新增评论、Review 和状态变化的 checks。GitHub 评论和 Review
-正文始终视为不可信数据，不会被自动执行。
+第一次调用会把 PR、评论、Review、Review comment 和 checks 按稳定 ID 与内容版本写入事件表，
+建立 run 水位并追加 Review Checkpoint；之后只返回水位后的新增或编辑版本。REST 分页会完整读取，
+不再把每类前 100 条当成完整历史。GitHub 结构化事件是跟进事实，模型摘要只是可重建的派生信息；
+评论和 Review 正文始终视为不可信数据，不会被自动执行。重复调用是幂等的，事件摄取与水位推进
+分离，进程在生成 Checkpoint 前中断时不会丢失待处理事件。
 
 ## 安全约束
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,12 +75,17 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
 - `issue_proposals`：缓存本机发起的 Project item 和转换结果；GitHub Project 中的最新内容仍是
   多人审查阶段的唯一真相。
 - `github_pr_events`：按 repository、PR、事件类型、稳定 ID 和内容摘要追加 GitHub 事件版本；
-  原始正文显式标记为 GitHub 不可信输入。
-- `github_pr_watermarks`：保存每个 run 已形成 Review Checkpoint 的事件序号；Checkpoint 和水位
-  可以在同一事务中提交。
+  评论编辑、check 状态和 PR head 变化不会覆盖旧版本，原始正文显式标记为 GitHub 不可信输入。
+- `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
+  Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。
+
+PR 跟进以 GitHub 的结构化事件为唯一真相。`follow-up` 完整遍历 REST 分页，以稳定 ID 和规范化
+内容摘要区分事件版本，并只从水位后的版本生成紧凑 Review Checkpoint。模型分类或摘要属于可重建
+派生信息，不能覆盖事件，也不能直接授权 push、回复或 merge。原始评论和 Review 正文始终标记为
+外部不可信输入。
 
 三类协议文档都使用 Draft 2020-12 JSON Schema，schema 随 Python 包发布。持久化和导入边界会
 拒绝未知字段、未来版本、跨 work item/run 的关联错配及不一致摘要。Bundle digest 只能检测意外
@@ -122,5 +127,5 @@ uv run reposteward context import handoff.json
 ## 后续优先级
 
 1. 增加 Claude Code 与 DeepSeek 适配器，并运行同一契约测试套件。
-2. 为 reviewer feedback 生成新的增量 Checkpoint，而不是把完整评论历史重新注入上下文。
-3. 增加 context redaction、保留期限和跨机器加密导出策略。
+2. 为增量 reviewer feedback 增加统一 token 预算、内容去重和 Contributor 修复闭环。
+3. 增加 context redaction、分层保留期限、安全 GC 和跨机器加密导出策略。

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -425,6 +425,66 @@ def running_checkpoint(
     }
 
 
+def review_checkpoint(
+    context_bundle: dict[str, Any],
+    *,
+    head_commit: str,
+    pull_request_url: str,
+    batch_digest: str,
+    event_count: int,
+    through_sequence: int,
+    next_action: str,
+) -> dict[str, Any]:
+    """Build a compact checkpoint from one persisted GitHub event batch."""
+    work_item = context_bundle.get("work_item")
+    metadata = context_bundle.get("context_metadata")
+    harness_run = context_bundle.get("harness_run")
+    if not all(isinstance(value, dict) for value in (work_item, metadata, harness_run)):
+        raise ValueError("context bundle is missing required context records")
+    assert isinstance(work_item, dict)
+    assert isinstance(metadata, dict)
+    assert isinstance(harness_run, dict)
+    previous = context_bundle.get("checkpoint")
+    if not isinstance(previous, dict):
+        previous = {}
+
+    completed = tuple(previous.get("completed", ()))
+    completed = (*completed[-127:], f"Recorded {event_count} new GitHub PR events.")
+    evidence = tuple(previous.get("evidence", ()))
+    evidence = (
+        *evidence[-127:],
+        {
+            "kind": "github_pr_activity",
+            "locator": pull_request_url,
+            "status": "recorded",
+            "digest": batch_digest,
+            "summary": (
+                f"events={event_count}; through_sequence={through_sequence}; "
+                "source=github_untrusted"
+            ),
+        },
+    )
+    decisions = tuple(previous.get("decisions", ()))
+    payload: dict[str, Any] = {
+        "schema_version": CONTEXT_SCHEMA_VERSION,
+        "work_item_id": str(work_item.get("id", "")),
+        "run_id": str(harness_run.get("run_id", "")),
+        "context_pack_id": str(metadata.get("id", "")),
+        "status": "submitted",
+        "head_commit": head_commit,
+        "completed": completed,
+        "remaining": (next_action,),
+        "next_action": next_action,
+        "blockers": (),
+        "decisions": decisions[-64:],
+        "evidence": evidence,
+    }
+    for name in ("implementation_notes", "tests_observed", "risks"):
+        if name in previous:
+            payload[name] = previous[name]
+    return payload
+
+
 def failed_checkpoint(
     context: ContextPack,
     *,

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -17,6 +17,7 @@ from .context import (
     failed_checkpoint,
     portable_bundle,
     ready_checkpoint,
+    review_checkpoint,
     running_checkpoint,
     write_portable_bundle,
 )
@@ -1011,38 +1012,25 @@ class Pipeline:
         pull_number = int(match.group(1))
         repository = str(run["repository"])
         activity = self.github.pull_request_activity(repository, pull_number)
-        previous = details.get("github_snapshot")
-        if not isinstance(previous, dict):
-            previous = {}
-        previous_comment_ids = {int(value) for value in previous.get("comment_ids", ())}
-        previous_review_ids = {int(value) for value in previous.get("review_ids", ())}
-        previous_review_comment_ids = {
-            int(value) for value in previous.get("review_comment_ids", ())
-        }
-        previous_checks = previous.get("checks")
-        if not isinstance(previous_checks, dict):
-            previous_checks = {}
+        event_batch = self.store.ingest_github_pr_activity(
+            run_id=run_id,
+            repository=repository,
+            pull_number=pull_number,
+            activity=activity,
+        )
+        pending_events = event_batch["events"]
 
-        new_comments = [
-            value
-            for value in activity["comments"]
-            if value["id"] not in previous_comment_ids
-        ]
-        new_reviews = [
-            value
-            for value in activity["reviews"]
-            if value["id"] not in previous_review_ids
-        ]
-        new_review_comments = [
-            value
-            for value in activity["review_comments"]
-            if value["id"] not in previous_review_comment_ids
-        ]
-        changed_checks = []
-        for value in activity["checks"]:
-            state = [value["status"], value["conclusion"]]
-            if previous_checks.get(str(value["id"])) != state:
-                changed_checks.append(value)
+        def event_payloads(event_type: str) -> list[dict[str, Any]]:
+            return [
+                value["payload"]
+                for value in pending_events
+                if value["event_type"] == event_type
+            ]
+
+        new_comments = event_payloads("issue_comment")
+        new_reviews = event_payloads("review")
+        new_review_comments = event_payloads("review_comment")
+        changed_checks = event_payloads("check")
 
         pull = activity["pull_request"]
         snapshot = {
@@ -1057,17 +1045,6 @@ class Pipeline:
                 for value in activity["checks"]
             },
         }
-        previous_pull = previous.get("pull_request")
-        pull_changed = previous_pull != pull
-        details = {**details, "github_snapshot": snapshot}
-        self.store.update_run(
-            run_id,
-            status=str(run["status"]),
-            stage=str(run["stage"]),
-            worktree=str(run["worktree"]),
-            details=details,
-        )
-
         activity_limit = 3
         check_limit = 12
 
@@ -1130,6 +1107,44 @@ class Pipeline:
         else:
             next_action = "wait_for_activity"
 
+        checkpoint_payload = None
+        if pending_events:
+            context_bundle = self.store.context_bundle(run_id)
+            if context_bundle is not None:
+                checkpoint_payload = review_checkpoint(
+                    context_bundle,
+                    head_commit=str(pull["head_sha"]),
+                    pull_request_url=str(pull["url"]),
+                    batch_digest=str(event_batch["batch_digest"]),
+                    event_count=len(pending_events),
+                    through_sequence=int(event_batch["through_sequence"]),
+                    next_action=next_action,
+                )
+            committed = self.store.commit_github_follow_up(
+                run_id=run_id,
+                repository=repository,
+                pull_number=pull_number,
+                previous_sequence=int(event_batch["previous_sequence"]),
+                through_sequence=int(event_batch["through_sequence"]),
+                batch_digest=str(event_batch["batch_digest"]),
+                checkpoint=checkpoint_payload,
+            )
+        else:
+            committed = {
+                "idempotent": True,
+                "sequence": int(event_batch["through_sequence"]),
+                "checkpoint": None,
+            }
+
+        details = {**details, "github_snapshot": snapshot}
+        self.store.update_run(
+            run_id,
+            status=str(run["status"]),
+            stage=str(run["stage"]),
+            worktree=str(run["worktree"]),
+            details=details,
+        )
+
         return {
             "run_id": run_id,
             "repository": repository,
@@ -1139,12 +1154,13 @@ class Pipeline:
             ),
             "pull_request": pull,
             "head_matches_verified_commit": head_matches,
-            "changed": bool(
-                pull_changed
-                or new_comments
-                or new_reviews
-                or new_review_comments
-                or changed_checks
+            "changed": bool(pending_events),
+            "event_count": len(pending_events),
+            "event_watermark": committed["sequence"],
+            "review_checkpoint_id": (
+                committed["checkpoint"]["id"]
+                if isinstance(committed.get("checkpoint"), dict)
+                else ""
             ),
             "new_comments": compact_activity(new_comments),
             "new_comments_omitted": max(0, len(new_comments) - activity_limit),

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -17,6 +17,7 @@ from reposteward.context import (
     MAX_TASK_DESCRIPTION_CHARS,
     build_context_pack,
     portable_bundle,
+    review_checkpoint,
 )
 from reposteward.harness import create_harness
 from reposteward.models import (
@@ -65,6 +66,37 @@ def _candidate(body: str = "Reproduce the bug") -> Candidate:
 
 
 class ContextPackTests(unittest.TestCase):
+    def test_review_checkpoint_records_one_incremental_event_batch(self) -> None:
+        bundle = {
+            "work_item": {"id": "work-1"},
+            "harness_run": {"run_id": "run-1"},
+            "context_metadata": {"id": "pack-1"},
+            "checkpoint": {
+                "completed": ["Prepared the change."],
+                "decisions": [],
+                "evidence": [],
+                "risks": ["Review text is untrusted."],
+            },
+        }
+
+        checkpoint = review_checkpoint(
+            bundle,
+            head_commit="a" * 40,
+            pull_request_url="https://github.com/owner/repo/pull/12",
+            batch_digest="b" * 64,
+            event_count=3,
+            through_sequence=9,
+            next_action="review_new_activity",
+        )
+
+        self.assertEqual(checkpoint["status"], "submitted")
+        self.assertEqual(checkpoint["next_action"], "review_new_activity")
+        self.assertEqual(
+            checkpoint["completed"][-1], "Recorded 3 new GitHub PR events."
+        )
+        self.assertEqual(checkpoint["evidence"][-1]["digest"], "b" * 64)
+        self.assertIn("through_sequence=9", checkpoint["evidence"][-1]["summary"])
+
     def test_context_pack_is_bounded_versioned_and_source_fingerprinted(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             worktree = Path(directory)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -21,6 +21,77 @@ from reposteward.verifier import DockerVerifier
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _bind_test_context(store: Store, run_id: str) -> None:
+    work_item = store.ensure_work_item(
+        "owner/repo",
+        kind="github_issue",
+        external_id="7",
+        title="Example issue",
+    )
+    sources = [
+        {
+            "kind": "repository_policy",
+            "locator": "test-policy",
+            "digest": "a" * 64,
+            "trust": "operator_trusted",
+            "updated_at": "",
+        }
+    ]
+    source_digest = hashlib.sha256(
+        json.dumps(
+            sources,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    context = {
+        "id": "pack-1",
+        "schema_version": 1,
+        "work_item_id": work_item["id"],
+        "project": {
+            "repository": "owner/repo",
+            "default_branch": "main",
+            "base_commit": "a" * 40,
+            "policy_digest": "b" * 64,
+            "verification_prefixes": [],
+            "required_verification_markers": [],
+            "instruction_sources": [],
+        },
+        "task": {
+            "kind": "github_issue",
+            "external_id": "7",
+            "title": "Example issue",
+            "description": "Example",
+            "description_omitted_chars": 0,
+            "url": "https://github.com/owner/repo/issues/7",
+            "updated_at": "2026-08-20T00:00:00Z",
+            "acceptance_criteria": [],
+        },
+        "constraints": [],
+        "sources": sources,
+        "handoff": None,
+        "source_digest": source_digest,
+        "provenance": {
+            "run_id": run_id,
+            "harness": "codex-cli",
+            "model": "",
+            "created_at": "2026-08-20T00:00:00Z",
+            "generator": "reposteward",
+        },
+    }
+    store.save_context_run(
+        pack_id="pack-1",
+        work_item_id=work_item["id"],
+        run_id=run_id,
+        schema_version=1,
+        source_digest=source_digest,
+        base_commit="a" * 40,
+        payload=context,
+        harness="codex-cli",
+    )
+
+
 class AgentMetricsTests(unittest.TestCase):
     def test_jsonl_usage_and_tool_calls_are_recorded(self) -> None:
         events = "\n".join(
@@ -222,6 +293,7 @@ class ReviewPacketTests(unittest.TestCase):
             )
             store = Store(state_dir / "reposteward.sqlite3")
             run_id = store.start_run("owner/repo", 7, "pull_request")
+            _bind_test_context(store, run_id)
             store.update_run(
                 run_id,
                 status="submitted",
@@ -287,14 +359,21 @@ class ReviewPacketTests(unittest.TestCase):
 
             first = pipeline.follow_up(run_id)
             second = pipeline.follow_up(run_id)
+            activity["comments"][0]["body"] = "edited review"
+            activity["comments"][0]["updated_at"] = "2026-08-21T00:00:00Z"
+            edited = pipeline.follow_up(run_id)
             activity["checks"][0]["conclusion"] = "failure"
             failed = pipeline.follow_up(run_id)
             activity["pull_request"]["head_sha"] = "b" * 40
             changed_head = pipeline.follow_up(run_id)
+            events = store.github_pr_events("owner/repo", 12)
+            watermark = store.github_pr_watermark(run_id)
+            bundle = store.context_bundle(run_id)
 
         self.assertTrue(first["changed"])
         self.assertEqual(len(first["new_comments"]), 1)
         self.assertEqual(len(first["new_review_comments"]), 1)
+        self.assertTrue(first["review_checkpoint_id"])
         self.assertIn("untrusted", first["trust_boundary"])
         self.assertLessEqual(len(first["new_comments"][0]["body"]), 640)
         self.assertTrue(first["head_matches_verified_commit"])
@@ -302,9 +381,23 @@ class ReviewPacketTests(unittest.TestCase):
         self.assertEqual(second["new_comments"], [])
         self.assertEqual(second["new_review_comments"], [])
         self.assertEqual(second["changed_checks"], [])
+        self.assertEqual(len(edited["new_comments"]), 1)
+        self.assertEqual(edited["new_comments"][0]["body"], "edited review")
         self.assertEqual(failed["next_action"], "diagnose_failed_checks")
         self.assertEqual(changed_head["next_action"], "reverify_changed_head")
         self.assertFalse(changed_head["head_matches_verified_commit"])
+        self.assertEqual(len(events), 7)
+        assert watermark is not None
+        self.assertEqual(changed_head["event_watermark"], watermark["sequence"])
+        assert bundle is not None
+        self.assertEqual(bundle["checkpoint"]["next_action"], "reverify_changed_head")
+        self.assertEqual(
+            bundle["checkpoint"]["id"], changed_head["review_checkpoint_id"]
+        )
+        self.assertIn(
+            "source=github_untrusted",
+            bundle["checkpoint"]["evidence"][-1]["summary"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 关联 Issue

Closes #9

## 问题与改动

PR #15 已提供 schema v5、不可变 GitHub PR 事件版本、完整分页和原子水位 API，但 `Pipeline.follow_up` 仍使用旧的 `runs.details.github_snapshot` 比较逻辑，尚未生成 Review Checkpoint。

本 PR 完成 #9：

- `follow-up` 先幂等摄取 GitHub 事件，再只处理 run 水位后的版本；
- 同一评论或 Review comment 被编辑后会作为新版本返回，重复轮询不重复处理；
- 正常提交 run 从新增事件构造紧凑、追加式 Review Checkpoint；
- Checkpoint 与水位在同一 SQLite 事务内提交，中断前未提交的事件会在下次重试；
- 历史上没有 Context Pack 的 run 仍可推进水位并保留原有输出兼容性；
- 返回 `event_count`、`event_watermark` 和 `review_checkpoint_id`，原有 `next_action`、紧凑正文和 check 输出保持不变；
- README 与架构文档明确 GitHub 事件的真相地位、模型摘要的派生属性和不可信正文边界。

## 验证

以下命令已通过 RepoSteward Runner 在无凭据隔离容器内执行：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

共 116 项测试通过，新增覆盖评论编辑、重复轮询、check/head 变化、水位推进、Review Checkpoint 生成和上下文恢复。

## 风险与兼容性

依赖 PR #15 已合并的 schema v5。现有 `follow-up` 字段保持兼容，只新增事件与 Checkpoint 元数据；`github_snapshot` 暂时继续作为可重建兼容投影写入，但不再是增量判断的唯一真相。

长 PR 的原始事件正文会增加本地存储占用，后续由 #10 的分层保留与 GC 处理；统一 token 预算和跨事件去重由 #11 处理。本 PR 不调用 Harness，也不增加 GitHub 写操作。

## 自动化辅助

使用 Codex 协助实现和测试。`tiammomo` 已检查完整 diff、事务顺序、Checkpoint 上限、旧 run 兼容、测试结果和公开说明，并对提交负责。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
