### PR TITLE
feat(merge): add auditable decision core

### DIFF
--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -138,6 +138,7 @@ class RepositoryPolicy:
     default_scope: str = "repo"
     max_files_changed: int | None = None
     max_diff_lines: int | None = None
+    merge_risk_paths: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -590,6 +591,7 @@ def load_config(
                 if "max_diff_lines" in repo_value
                 else None
             ),
+            merge_risk_paths=_tuple(repo_value.get("merge_risk_paths")),
         )
 
     if not github.login:

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+
+SUCCESSFUL_CHECK_CONCLUSIONS = {"neutral", "skipped", "success"}
+
+# Repository configuration may add patterns, but it cannot remove these safeguards.
+BUILTIN_RISK_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("ci", (".github/workflows/**", ".circleci/**", "Jenkinsfile", ".gitlab-ci.yml")),
+    (
+        "identity_permissions_publication",
+        (
+            "**/auth/**",
+            "**/credentials/**",
+            "**/permissions/**",
+            "**/publish*",
+            "**/release*",
+        ),
+    ),
+    (
+        "runner_sandbox_network",
+        (
+            "Dockerfile*",
+            "docker/**",
+            "**/runner/**",
+            "**/sandbox/**",
+            "**/network/**",
+        ),
+    ),
+    (
+        "database_persistence",
+        ("**/migrations/**", "migrations/**", "**/*.sql", "**/schema.*"),
+    ),
+    (
+        "dependencies_release",
+        (
+            "pyproject.toml",
+            "uv.lock",
+            "requirements*.txt",
+            "package.json",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock",
+            "Cargo.toml",
+            "Cargo.lock",
+            "go.mod",
+            "go.sum",
+        ),
+    ),
+    ("security", ("SECURITY*", "security/**", "**/security/**")),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MergeCheck:
+    name: str
+    status: str
+    conclusion: str
+    required: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class MergeSnapshot:
+    repository: str
+    pull_number: int
+    head_sha: str
+    base_sha: str
+    policy_digest: str
+    state: str
+    draft: bool
+    mergeable: str
+    review_decision: str
+    unresolved_conversations: int
+    files: tuple[str, ...]
+    additions: int
+    deletions: int
+    checks: tuple[MergeCheck, ...]
+    files_complete: bool = True
+    conversations_complete: bool = True
+    checks_complete: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class MergeReason:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class MergeDecision:
+    eligible: bool
+    reasons: tuple[MergeReason, ...]
+    risk_categories: tuple[str, ...]
+    risk_files: tuple[str, ...]
+    snapshot_digest: str
+    decision_digest: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _matches(path: str, pattern: str) -> bool:
+    # fnmatch does not give ** special semantics, but matching both forms makes
+    # root-level and nested paths explicit and predictable.
+    return fnmatch.fnmatchcase(path, pattern) or (
+        pattern.startswith("**/") and fnmatch.fnmatchcase(path, pattern[3:])
+    )
+
+
+def classify_merge_risk(
+    files: tuple[str, ...], extra_patterns: tuple[str, ...] = ()
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    categories: set[str] = set()
+    risk_files: set[str] = set()
+    groups = BUILTIN_RISK_PATTERNS + (("repository_policy", extra_patterns),)
+    for path in files:
+        for category, patterns in groups:
+            if any(_matches(path, pattern) for pattern in patterns):
+                categories.add(category)
+                risk_files.add(path)
+    return tuple(sorted(categories)), tuple(sorted(risk_files))
+
+
+def evaluate_merge(
+    snapshot: MergeSnapshot,
+    *,
+    expected_head_sha: str,
+    expected_base_sha: str,
+    max_files_changed: int,
+    max_diff_lines: int,
+    extra_risk_patterns: tuple[str, ...] = (),
+) -> MergeDecision:
+    """Evaluate a snapshot without mutating GitHub, a workspace, or the harness."""
+    reasons: list[MergeReason] = []
+
+    def block(code: str, message: str) -> None:
+        reasons.append(MergeReason(code, message))
+
+    if snapshot.state.casefold() != "open":
+        block("pull_not_open", "Pull request is not open.")
+    if snapshot.draft:
+        block("pull_is_draft", "Pull request is still a draft.")
+    if snapshot.mergeable.casefold() != "mergeable":
+        block(
+            "pull_not_mergeable", "GitHub does not report the pull request mergeable."
+        )
+    if snapshot.head_sha != expected_head_sha:
+        block("head_changed", "Pull request head differs from the verified commit.")
+    if snapshot.base_sha != expected_base_sha:
+        block("base_changed", "Base branch changed after verification.")
+    if not snapshot.files_complete:
+        block("files_incomplete", "Changed-file data is incomplete.")
+    if not snapshot.conversations_complete:
+        block("conversations_incomplete", "Review-conversation data is incomplete.")
+    if not snapshot.checks_complete:
+        block("checks_incomplete", "Check data is incomplete.")
+    if snapshot.review_decision.casefold() != "approved":
+        block("review_not_approved", "The current review decision is not approved.")
+    if snapshot.unresolved_conversations:
+        block(
+            "unresolved_conversations",
+            f"{snapshot.unresolved_conversations} review conversation(s) remain unresolved.",
+        )
+    for check in sorted(snapshot.checks, key=lambda value: value.name.casefold()):
+        if not check.required:
+            continue
+        if check.status.casefold() != "completed":
+            block("required_check_pending", f"Required check is pending: {check.name}.")
+        elif check.conclusion.casefold() not in SUCCESSFUL_CHECK_CONCLUSIONS:
+            block(
+                "required_check_failed", f"Required check did not pass: {check.name}."
+            )
+    if len(snapshot.files) > max_files_changed:
+        block("file_limit_exceeded", "The change exceeds the configured file limit.")
+    if snapshot.additions + snapshot.deletions > max_diff_lines:
+        block("diff_limit_exceeded", "The change exceeds the configured diff limit.")
+
+    risk_categories, risk_files = classify_merge_risk(
+        snapshot.files, extra_risk_patterns
+    )
+    if risk_files:
+        block("high_risk_change", "High-risk paths require manual merge approval.")
+
+    snapshot_payload = asdict(snapshot)
+    snapshot_digest = _digest(snapshot_payload)
+    decision_payload = {
+        "eligible": not reasons,
+        "reasons": [asdict(value) for value in reasons],
+        "risk_categories": risk_categories,
+        "risk_files": risk_files,
+        "snapshot_digest": snapshot_digest,
+    }
+    return MergeDecision(
+        eligible=not reasons,
+        reasons=tuple(reasons),
+        risk_categories=risk_categories,
+        risk_files=risk_files,
+        snapshot_digest=snapshot_digest,
+        decision_digest=_digest(decision_payload),
+    )

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -230,6 +230,27 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
             updated_at TEXT NOT NULL,
             FOREIGN KEY(run_id) REFERENCES runs(id)
         )
+        """,
+    ),
+    6: (
+        """
+        CREATE TABLE IF NOT EXISTS merge_decisions (
+            id TEXT PRIMARY KEY,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            head_sha TEXT NOT NULL,
+            base_sha TEXT NOT NULL,
+            policy_digest TEXT NOT NULL,
+            snapshot_digest TEXT NOT NULL,
+            eligible INTEGER NOT NULL,
+            decision_digest TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS merge_decisions_for_pull
+        ON merge_decisions(repository, pull_number, created_at DESC)
         """,
     ),
 }
@@ -1496,6 +1517,78 @@ class Store:
             return None
         result = dict(row)
         result["details"] = json.loads(result["details"])
+        return result
+
+    def append_merge_decision(
+        self,
+        *,
+        repository: str,
+        pull_number: int,
+        head_sha: str,
+        base_sha: str,
+        policy_digest: str,
+        decision: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Append one immutable merge evaluation, including repeated evaluations."""
+        if pull_number < 1:
+            raise ValueError("pull_number must be positive")
+        decision_id = uuid.uuid4().hex
+        now = utc_now()
+        payload = _canonical_json(decision)
+        snapshot_digest = str(decision.get("snapshot_digest", ""))
+        decision_digest = str(decision.get("decision_digest", ""))
+        if not snapshot_digest or not decision_digest:
+            raise StoreError("merge decision is missing its audit digests")
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO merge_decisions(
+                    id, repository, pull_number, head_sha, base_sha,
+                    policy_digest, snapshot_digest, eligible,
+                    decision_digest, payload, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    decision_id,
+                    repository.casefold(),
+                    pull_number,
+                    head_sha,
+                    base_sha,
+                    policy_digest,
+                    snapshot_digest,
+                    int(bool(decision.get("eligible"))),
+                    decision_digest,
+                    payload,
+                    now,
+                ),
+            )
+        return {
+            "id": decision_id,
+            "repository": repository.casefold(),
+            "pull_number": pull_number,
+            "decision_digest": decision_digest,
+            "created_at": now,
+        }
+
+    def merge_decisions(
+        self, repository: str, pull_number: int, *, limit: int = 30
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 100)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM merge_decisions
+                WHERE repository=? AND pull_number=?
+                ORDER BY created_at DESC LIMIT ?
+                """,
+                (repository.casefold(), pull_number, limit),
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = dict(row)
+            value["eligible"] = bool(value["eligible"])
+            value["payload"] = json.loads(value["payload"])
+            result.append(value)
         return result
 
     def record_submission(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -138,6 +138,7 @@ require_verification = false
 forbidden_paths = []
 [repositories."owner/repo"]
 max_diff_lines = 99
+merge_risk_paths = ["docs/operator/**"]
 """,
                 encoding="utf-8",
             )
@@ -179,6 +180,10 @@ max_diff_lines = 99
         )
         self.assertTrue(config.state_namespace)
         self.assertEqual(config.repositories["owner/repo"].max_diff_lines, 99)
+        self.assertEqual(
+            config.repositories["owner/repo"].merge_risk_paths,
+            ("docs/operator/**",),
+        )
 
     def test_configuration_is_not_pinned_to_one_github_login(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from reposteward.merge import MergeCheck, MergeSnapshot, evaluate_merge
+
+
+class MergeDecisionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.snapshot = MergeSnapshot(
+            repository="owner/repo",
+            pull_number=12,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            policy_digest="c" * 64,
+            state="OPEN",
+            draft=False,
+            mergeable="MERGEABLE",
+            review_decision="APPROVED",
+            unresolved_conversations=0,
+            files=("src/example.py",),
+            additions=20,
+            deletions=5,
+            checks=(MergeCheck("quality", "COMPLETED", "SUCCESS"),),
+        )
+
+    def evaluate(self, snapshot: MergeSnapshot | None = None, **kwargs):
+        return evaluate_merge(
+            snapshot or self.snapshot,
+            expected_head_sha="a" * 40,
+            expected_base_sha="b" * 40,
+            max_files_changed=18,
+            max_diff_lines=700,
+            **kwargs,
+        )
+
+    def test_verified_approved_low_risk_snapshot_is_eligible_and_stable(self) -> None:
+        first = self.evaluate()
+        second = self.evaluate()
+
+        self.assertTrue(first.eligible)
+        self.assertEqual(first, second)
+        self.assertEqual(first.reasons, ())
+
+    def test_changed_revisions_and_incomplete_data_fail_closed(self) -> None:
+        result = self.evaluate(
+            replace(
+                self.snapshot,
+                head_sha="d" * 40,
+                base_sha="e" * 40,
+                files_complete=False,
+                conversations_complete=False,
+                checks_complete=False,
+            )
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertEqual(
+            {reason.code for reason in result.reasons},
+            {
+                "head_changed",
+                "base_changed",
+                "files_incomplete",
+                "conversations_incomplete",
+                "checks_incomplete",
+            },
+        )
+
+    def test_review_conversations_and_checks_block_merge(self) -> None:
+        result = self.evaluate(
+            replace(
+                self.snapshot,
+                review_decision="REVIEW_REQUIRED",
+                unresolved_conversations=2,
+                checks=(
+                    MergeCheck("build", "IN_PROGRESS", ""),
+                    MergeCheck("test", "COMPLETED", "FAILURE"),
+                    MergeCheck("optional", "COMPLETED", "FAILURE", required=False),
+                ),
+            )
+        )
+
+        self.assertEqual(
+            [reason.code for reason in result.reasons],
+            [
+                "review_not_approved",
+                "unresolved_conversations",
+                "required_check_pending",
+                "required_check_failed",
+            ],
+        )
+
+    def test_builtin_high_risk_paths_cannot_be_disabled(self) -> None:
+        result = self.evaluate(
+            replace(self.snapshot, files=(".github/workflows/quality.yml",))
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIn("ci", result.risk_categories)
+        self.assertEqual(result.risk_files, (".github/workflows/quality.yml",))
+
+    def test_repository_policy_can_only_add_high_risk_paths(self) -> None:
+        result = self.evaluate(
+            replace(self.snapshot, files=("docs/operator-guide.md",)),
+            extra_risk_patterns=("docs/**",),
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertEqual(result.risk_categories, ("repository_policy",))
+
+    def test_size_limits_and_pull_state_block_merge(self) -> None:
+        files = tuple(f"src/file-{index}.py" for index in range(19))
+        result = self.evaluate(
+            replace(
+                self.snapshot,
+                state="CLOSED",
+                draft=True,
+                mergeable="CONFLICTING",
+                files=files,
+                additions=701,
+            )
+        )
+
+        self.assertEqual(
+            {reason.code for reason in result.reasons},
+            {
+                "pull_not_open",
+                "pull_is_draft",
+                "pull_not_mergeable",
+                "file_limit_exceeded",
+                "diff_limit_exceeded",
+            },
+        )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -197,7 +197,56 @@ class StoreTests(unittest.TestCase):
 
             self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
             self.assertIn("github_pr_events", tables)
-            self.assertIn("github_pr_watermarks", tables)
+        self.assertIn("github_pr_watermarks", tables)
+
+    def test_version_five_database_receives_merge_decision_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE merge_decisions")
+                connection.execute("PRAGMA user_version=5")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE name='merge_decisions'"
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+
+    def test_merge_decision_audit_is_append_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            decision = {
+                "eligible": True,
+                "snapshot_digest": "a" * 64,
+                "decision_digest": "b" * 64,
+                "reasons": [],
+            }
+
+            first = store.append_merge_decision(
+                repository="Owner/Repo",
+                pull_number=12,
+                head_sha="c" * 40,
+                base_sha="d" * 40,
+                policy_digest="e" * 64,
+                decision=decision,
+            )
+            second = store.append_merge_decision(
+                repository="Owner/Repo",
+                pull_number=12,
+                head_sha="c" * 40,
+                base_sha="d" * 40,
+                policy_digest="e" * 64,
+                decision=decision,
+            )
+            audit = store.merge_decisions("owner/repo", 12)
+
+        self.assertNotEqual(first["id"], second["id"])
+        self.assertEqual(len(audit), 2)
+        self.assertTrue(all(value["eligible"] for value in audit))
 
     def test_candidate_round_trip_and_status_preservation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 关联 Issue

Refs #12

## 问题与改动

当前 Maintainer 流程缺少可独立审计的合并判断核心。本 PR 聚焦第一阶段：

- 新增纯函数式 Merge Decision Engine，依据已验证 head/base、PR 状态、审批、未解决会话、required checks、规模上限和风险路径给出稳定原因代码与摘要。
- 内置 CI、身份权限与发布、Runner/沙箱/网络、数据库与持久化、依赖发布、安全等不可被仓库配置削弱的高风险规则；仓库只能追加风险路径。
- 数据库升级到 schema v6，追加保存每一次评估，不覆盖相同快照的历史记录。

GitHub 快照读取、Pipeline 和 CLI 接入将在 #12 的下一支聚焦 PR 中完成，因此本 PR 使用 `Refs`，不会提前关闭 Issue。

## 验证

隔离 Runner 中执行，124 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

## 风险与兼容性

包含 SQLite schema v5 → v6 的向前迁移，只新增 `merge_decisions` 表和查询索引，不改写旧数据。决策核心是只读纯函数，不调用 GitHub 写接口、Harness 或 workspace；本 PR 尚未接入自动合并执行。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了 Issue 范围、完整 diff、不可削弱风险边界、迁移的无损性、稳定原因顺序、追加式审计语义和测试结果。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
