### PR TITLE
feat(merge): evaluate current pull request state

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ REPOSTEWARD_ENABLE_SUBMIT=1 \
 
 ```bash
 uv run reposteward follow-up RUN_ID
+uv run reposteward merge-decision RUN_ID
 ```
 
 第一次调用会把 PR、评论、Review、Review comment 和 checks 按稳定 ID 与内容版本写入事件表，
@@ -303,6 +304,12 @@ uv run reposteward follow-up RUN_ID
 不再把每类前 100 条当成完整历史。GitHub 结构化事件是跟进事实，模型摘要只是可重建的派生信息；
 评论和 Review 正文始终视为不可信数据，不会被自动执行。重复调用是幂等的，事件摄取与水位推进
 分离，进程在生成 Checkpoint 前中断时不会丢失待处理事件。
+
+`merge-decision` 只读获取完整的 changed files、required checks、Review decision 和未解决会话，
+再对照验证时冻结的 head、base、policy digest、规模上限及高风险路径生成确定性结果。每次调用都会
+追加一条本地审计记录，但不会调用 Harness、修改 workspace 或执行 GitHub 写操作。内置 CI、权限、
+Runner、数据库、依赖发布和安全风险规则不能被项目配置削弱；项目只能通过 `merge_risk_paths` 追加
+需要人工合并的路径。
 
 ## 安全约束
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,8 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
   评论编辑、check 状态和 PR head 变化不会覆盖旧版本，原始正文显式标记为 GitHub 不可信输入。
 - `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
   Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
+- `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
+  不覆盖旧结果，便于解释状态变化。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。
@@ -86,6 +88,11 @@ PR 跟进以 GitHub 的结构化事件为唯一真相。`follow-up` 完整遍历
 内容摘要区分事件版本，并只从水位后的版本生成紧凑 Review Checkpoint。模型分类或摘要属于可重建
 派生信息，不能覆盖事件，也不能直接授权 push、回复或 merge。原始评论和 Review 正文始终标记为
 外部不可信输入。
+
+Merge Decision Engine 位于执行器之前。它完整分页读取 GitHub 结构化状态，并以纯函数检查已验证
+head/base、策略摘要、审批、required checks、未解决会话、规模和不可削弱的高风险路径。结果只表示
+当前快照是否具备资格，不执行 merge，也不以 Harness 推理替代确定性事实。任何不完整快照都失败
+关闭；策略、head 或 base 在验证后变化时必须重新验证。
 
 三类协议文档都使用 Draft 2020-12 JSON Schema，schema 随 Python 包发布。持久化和导入边界会
 拒绝未知字段、未来版本、跨 work item/run 的关联错配及不一致摘要。Bundle digest 只能检测意外

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -178,6 +178,11 @@ def _parser() -> argparse.ArgumentParser:
     )
     follow_up.add_argument("run_id")
 
+    merge_decision = subparsers.add_parser(
+        "merge-decision", help="evaluate and audit read-only PR merge eligibility"
+    )
+    merge_decision.add_argument("run_id")
+
     submit = subparsers.add_parser(
         "submit", help="push a reviewed change and create or reopen a PR"
     )
@@ -392,6 +397,9 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
+            return 0
+        if args.command == "merge-decision":
+            _json(pipeline.merge_decision(args.run_id))
             return 0
         if args.command == "submit":
             _json(

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -41,6 +41,10 @@ def _digest(value: object) -> str:
     return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
 
 
+def repository_policy_digest(policy: RepositoryPolicy) -> str:
+    return _digest(asdict(policy))
+
+
 def _file_digest(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -253,8 +257,7 @@ def build_context_pack(
 ) -> ContextPack:
     issue = candidate.issue
     description = issue.body[:MAX_TASK_DESCRIPTION_CHARS]
-    policy_payload = asdict(policy)
-    policy_digest = _digest(policy_payload)
+    policy_digest = repository_policy_digest(policy)
     issue_digest = _digest(
         {
             "repository": issue.repository,

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -792,6 +792,179 @@ class GitHubClient:
             ],
         }
 
+    def pull_request_merge_snapshot(self, upstream: str, number: int) -> dict[str, Any]:
+        """Read a complete PR decision snapshot without making GitHub writes."""
+        owner, name = upstream.split("/", 1)
+        cursors: dict[str, str | None] = {
+            "files": None,
+            "threads": None,
+            "checks": None,
+        }
+        values: dict[str, list[dict[str, Any]]] = {
+            "files": [],
+            "threads": [],
+            "checks": [],
+        }
+        totals = {"files": 0, "threads": 0, "checks": 0}
+        pull: dict[str, Any] | None = None
+        for _page in range(MAX_REST_PAGES):
+            data = self._graphql(
+                """
+                query(
+                  $owner: String!, $name: String!, $number: Int!,
+                  $files: String, $threads: String, $checks: String
+                ) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      number state isDraft mergeable reviewDecision
+                      headRefOid baseRefOid additions deletions changedFiles
+                      files(first: 100, after: $files) {
+                        totalCount
+                        nodes { path }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                      reviewThreads(first: 100, after: $threads) {
+                        totalCount
+                        nodes { id isResolved }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            statusCheckRollup {
+                              contexts(first: 100, after: $checks) {
+                                totalCount
+                                nodes {
+                                  __typename
+                                  ... on CheckRun {
+                                    name status conclusion
+                                    isRequired(pullRequestNumber: $number)
+                                  }
+                                  ... on StatusContext {
+                                    context state
+                                    isRequired(pullRequestNumber: $number)
+                                  }
+                                }
+                                pageInfo { hasNextPage endCursor }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """,
+                {"owner": owner, "name": name, "number": number, **cursors},
+            )
+            repository = data.get("repository")
+            current = (
+                repository.get("pullRequest") if isinstance(repository, dict) else None
+            )
+            if not isinstance(current, dict):
+                raise GitHubError(f"pull request not found: {upstream}#{number}")
+            pull = current
+            commits = current.get("commits")
+            commit_nodes = commits.get("nodes") if isinstance(commits, dict) else []
+            latest = (
+                commit_nodes[0]
+                if isinstance(commit_nodes, list) and commit_nodes
+                else {}
+            )
+            commit = latest.get("commit") if isinstance(latest, dict) else {}
+            rollup = commit.get("statusCheckRollup") if isinstance(commit, dict) else {}
+            connections = {
+                "files": current.get("files"),
+                "threads": current.get("reviewThreads"),
+                "checks": (
+                    rollup.get("contexts") if isinstance(rollup, dict) else None
+                ),
+            }
+            pending = False
+            for key, connection in connections.items():
+                if connection is None and key == "checks":
+                    continue
+                if not isinstance(connection, dict):
+                    raise GitHubError(f"GitHub merge snapshot omitted {key}")
+                nodes = connection.get("nodes")
+                page_info = connection.get("pageInfo")
+                total_count = connection.get("totalCount")
+                if (
+                    not isinstance(nodes, list)
+                    or not isinstance(page_info, dict)
+                    or not isinstance(total_count, int)
+                ):
+                    raise GitHubError(f"GitHub merge snapshot returned invalid {key}")
+                totals[key] = total_count
+                values[key].extend(value for value in nodes if isinstance(value, dict))
+                if bool(page_info.get("hasNextPage")):
+                    cursor = str(page_info.get("endCursor") or "")
+                    if not cursor or cursor == cursors[key]:
+                        raise GitHubError(f"GitHub {key} pagination did not advance")
+                    cursors[key] = cursor
+                    pending = True
+                else:
+                    cursors[key] = str(page_info.get("endCursor") or "") or None
+            if not pending:
+                break
+        else:
+            raise GitHubError("GitHub merge snapshot pagination exceeded its limit")
+
+        assert pull is not None
+        incomplete = [key for key in values if len(values[key]) != totals[key]]
+        if incomplete:
+            raise GitHubError(
+                "GitHub merge snapshot is incomplete: " + ", ".join(incomplete)
+            )
+        checks = []
+        for value in values["checks"]:
+            kind = str(value.get("__typename") or "")
+            if kind == "CheckRun":
+                checks.append(
+                    {
+                        "name": str(value.get("name") or ""),
+                        "status": str(value.get("status") or ""),
+                        "conclusion": str(value.get("conclusion") or ""),
+                        "required": bool(value.get("isRequired")),
+                    }
+                )
+            elif kind == "StatusContext":
+                state = str(value.get("state") or "").casefold()
+                checks.append(
+                    {
+                        "name": str(value.get("context") or ""),
+                        "status": "completed" if state != "pending" else "pending",
+                        "conclusion": "success" if state == "success" else state,
+                        "required": bool(value.get("isRequired")),
+                    }
+                )
+        return {
+            "repository": upstream.casefold(),
+            "pull_number": int(pull["number"]),
+            "head_sha": str(pull.get("headRefOid") or ""),
+            "base_sha": str(pull.get("baseRefOid") or ""),
+            "state": str(pull.get("state") or ""),
+            "draft": bool(pull.get("isDraft")),
+            "mergeable": str(pull.get("mergeable") or ""),
+            "review_decision": str(pull.get("reviewDecision") or ""),
+            "unresolved_conversations": sum(
+                not bool(value.get("isResolved")) for value in values["threads"]
+            ),
+            "files": sorted(
+                {
+                    str(value.get("path") or "")
+                    for value in values["files"]
+                    if value.get("path")
+                }
+            ),
+            "additions": int(pull.get("additions") or 0),
+            "deletions": int(pull.get("deletions") or 0),
+            "checks": sorted(checks, key=lambda value: value["name"].casefold()),
+            "files_complete": True,
+            "conversations_complete": True,
+            "checks_complete": True,
+        }
+
     def reopen_pull_request(
         self,
         upstream: str,

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -136,6 +136,7 @@ def evaluate_merge(
     *,
     expected_head_sha: str,
     expected_base_sha: str,
+    expected_policy_digest: str,
     max_files_changed: int,
     max_diff_lines: int,
     extra_risk_patterns: tuple[str, ...] = (),
@@ -158,6 +159,8 @@ def evaluate_merge(
         block("head_changed", "Pull request head differs from the verified commit.")
     if snapshot.base_sha != expected_base_sha:
         block("base_changed", "Base branch changed after verification.")
+    if snapshot.policy_digest != expected_policy_digest:
+        block("policy_changed", "Repository policy changed after verification.")
     if not snapshot.files_complete:
         block("files_incomplete", "Changed-file data is incomplete.")
     if not snapshot.conversations_complete:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -17,6 +17,7 @@ from .context import (
     failed_checkpoint,
     portable_bundle,
     ready_checkpoint,
+    repository_policy_digest,
     review_checkpoint,
     running_checkpoint,
     write_portable_bundle,
@@ -32,6 +33,7 @@ from .issues import (
     render_issue_body,
     validate_issue_title,
 )
+from .merge import MergeCheck, MergeSnapshot, evaluate_merge
 from .models import AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
 from .protocol import read_context_bundle, validate_context_bundle
@@ -1173,6 +1175,81 @@ class Pipeline:
             "changed_checks": compact_checks(changed_checks),
             "changed_checks_omitted": max(0, len(changed_checks) - check_limit),
             "next_action": next_action,
+        }
+
+    def merge_decision(self, run_id: str) -> dict[str, Any]:
+        """Evaluate and audit current merge eligibility without writing to GitHub."""
+        run = self.store.run(run_id)
+        if run is None:
+            raise KeyError(f"run not found: {run_id}")
+        details = run.get("details", {})
+        match = re.search(r"/pull/(\d+)/?$", str(details.get("pr_url", "")))
+        if not match:
+            raise PolicyError("the selected run has no submitted pull request")
+        repository = str(run["repository"])
+        pull_number = int(match.group(1))
+        policy = self.policy(repository)
+        context = self.store.context_bundle(run_id)
+        if context is None:
+            raise PolicyError("the selected run has no verified context pack")
+        project = context["context_pack"].get("project")
+        if not isinstance(project, dict):
+            raise PolicyError("the verified context pack has no project policy")
+        expected_policy_digest = str(project.get("policy_digest") or "")
+        raw = self.github.pull_request_merge_snapshot(repository, pull_number)
+        snapshot = MergeSnapshot(
+            repository=repository,
+            pull_number=pull_number,
+            head_sha=str(raw["head_sha"]),
+            base_sha=str(raw["base_sha"]),
+            policy_digest=repository_policy_digest(policy),
+            state=str(raw["state"]),
+            draft=bool(raw["draft"]),
+            mergeable=str(raw["mergeable"]),
+            review_decision=str(raw["review_decision"]),
+            unresolved_conversations=int(raw["unresolved_conversations"]),
+            files=tuple(str(value) for value in raw["files"]),
+            additions=int(raw["additions"]),
+            deletions=int(raw["deletions"]),
+            checks=tuple(MergeCheck(**value) for value in raw["checks"]),
+            files_complete=bool(raw["files_complete"]),
+            conversations_complete=bool(raw["conversations_complete"]),
+            checks_complete=bool(raw["checks_complete"]),
+        )
+        decision = evaluate_merge(
+            snapshot,
+            expected_head_sha=str(details.get("commit_sha") or ""),
+            expected_base_sha=str(details.get("base_commit") or ""),
+            expected_policy_digest=expected_policy_digest,
+            max_files_changed=(
+                policy.max_files_changed
+                if policy.max_files_changed is not None
+                else self.config.safety.max_files_changed
+            ),
+            max_diff_lines=(
+                policy.max_diff_lines
+                if policy.max_diff_lines is not None
+                else self.config.safety.max_diff_lines
+            ),
+            extra_risk_patterns=policy.merge_risk_paths,
+        )
+        payload = decision.to_dict()
+        audit_payload = {**payload, "snapshot": asdict(snapshot)}
+        audit = self.store.append_merge_decision(
+            repository=repository,
+            pull_number=pull_number,
+            head_sha=snapshot.head_sha,
+            base_sha=snapshot.base_sha,
+            policy_digest=snapshot.policy_digest,
+            decision=audit_payload,
+        )
+        return {
+            "run_id": run_id,
+            "repository": repository,
+            "pull_number": pull_number,
+            **payload,
+            "audit": audit,
+            "public_write": False,
         }
 
     def submit(

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -1539,6 +1539,30 @@ class Store:
         decision_digest = str(decision.get("decision_digest", ""))
         if not snapshot_digest or not decision_digest:
             raise StoreError("merge decision is missing its audit digests")
+        snapshot = decision.get("snapshot")
+        if not isinstance(snapshot, dict) or _json_digest(snapshot) != snapshot_digest:
+            raise StoreError("merge decision snapshot does not match its digest")
+        expected_scope = {
+            "repository": repository.casefold(),
+            "pull_number": pull_number,
+            "head_sha": head_sha,
+            "base_sha": base_sha,
+            "policy_digest": policy_digest,
+        }
+        if any(snapshot.get(key) != value for key, value in expected_scope.items()):
+            raise StoreError("merge decision snapshot does not match its audit scope")
+        decision_material = {
+            key: decision.get(key)
+            for key in (
+                "eligible",
+                "reasons",
+                "risk_categories",
+                "risk_files",
+                "snapshot_digest",
+            )
+        }
+        if _json_digest(decision_material) != decision_digest:
+            raise StoreError("merge decision does not match its digest")
         with self._connection() as connection:
             connection.execute(
                 """

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -206,6 +206,135 @@ class GitHubProjectIssueTests(unittest.TestCase):
 
 
 class GitHubPullRequestTests(unittest.TestCase):
+    def test_merge_snapshot_paginates_and_normalizes_required_checks(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+
+        def page(
+            *,
+            files: list[dict[str, Any]],
+            files_next: bool,
+            file_cursor: str,
+            threads: list[dict[str, Any]],
+            checks: list[dict[str, Any]],
+        ) -> dict[str, Any]:
+            return {
+                "repository": {
+                    "pullRequest": {
+                        "number": 12,
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": "APPROVED",
+                        "headRefOid": "a" * 40,
+                        "baseRefOid": "b" * 40,
+                        "additions": 10,
+                        "deletions": 2,
+                        "changedFiles": 2,
+                        "files": {
+                            "totalCount": 2,
+                            "nodes": files,
+                            "pageInfo": {
+                                "hasNextPage": files_next,
+                                "endCursor": file_cursor,
+                            },
+                        },
+                        "reviewThreads": {
+                            "totalCount": 1,
+                            "nodes": threads,
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": "thread-end",
+                            },
+                        },
+                        "commits": {
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "contexts": {
+                                                "totalCount": 2,
+                                                "nodes": checks,
+                                                "pageInfo": {
+                                                    "hasNextPage": False,
+                                                    "endCursor": "check-end",
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+
+        first = page(
+            files=[{"path": "src/b.py"}],
+            files_next=True,
+            file_cursor="file-1",
+            threads=[{"id": "thread-1", "isResolved": False}],
+            checks=[
+                {
+                    "__typename": "CheckRun",
+                    "name": "quality",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "isRequired": True,
+                },
+                {
+                    "__typename": "StatusContext",
+                    "context": "legacy-ci",
+                    "state": "PENDING",
+                    "isRequired": False,
+                },
+            ],
+        )
+        second = page(
+            files=[{"path": "src/a.py"}],
+            files_next=False,
+            file_cursor="file-end",
+            threads=[],
+            checks=[],
+        )
+
+        with patch.object(client, "_graphql", side_effect=[first, second]) as graphql:
+            snapshot = client.pull_request_merge_snapshot("Owner/Repo", 12)
+
+        self.assertEqual(snapshot["files"], ["src/a.py", "src/b.py"])
+        self.assertEqual(snapshot["unresolved_conversations"], 1)
+        self.assertEqual(snapshot["checks"][0]["name"], "legacy-ci")
+        self.assertEqual(snapshot["checks"][0]["status"], "pending")
+        self.assertTrue(snapshot["checks"][1]["required"])
+        self.assertEqual(graphql.call_args_list[1].args[1]["files"], "file-1")
+        self.assertEqual(graphql.call_args_list[1].args[1]["threads"], "thread-end")
+
+    def test_merge_snapshot_rejects_incomplete_connection_data(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        malformed = {
+            "repository": {
+                "pullRequest": {
+                    "number": 12,
+                    "files": {
+                        "totalCount": 1,
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    },
+                    "reviewThreads": {
+                        "totalCount": 0,
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    },
+                    "commits": {"nodes": []},
+                }
+            }
+        }
+
+        with (
+            patch.object(client, "_graphql", return_value=malformed),
+            self.assertRaisesRegex(GitHubError, "incomplete: files"),
+        ):
+            client.pull_request_merge_snapshot("owner/repo", 12)
+
     def test_pull_request_activity_follows_every_rest_page(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")
         pull = {

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -30,6 +30,7 @@ class MergeDecisionTests(unittest.TestCase):
             snapshot or self.snapshot,
             expected_head_sha="a" * 40,
             expected_base_sha="b" * 40,
+            expected_policy_digest="c" * 64,
             max_files_changed=18,
             max_diff_lines=700,
             **kwargs,
@@ -49,6 +50,7 @@ class MergeDecisionTests(unittest.TestCase):
                 self.snapshot,
                 head_sha="d" * 40,
                 base_sha="e" * 40,
+                policy_digest="f" * 64,
                 files_complete=False,
                 conversations_complete=False,
                 checks_complete=False,
@@ -61,6 +63,7 @@ class MergeDecisionTests(unittest.TestCase):
             {
                 "head_changed",
                 "base_changed",
+                "policy_changed",
                 "files_incomplete",
                 "conversations_incomplete",
                 "checks_incomplete",

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from reposteward.config import RepositoryPolicy
+from reposteward.context import repository_policy_digest
+from reposteward.pipeline import Pipeline
+
+
+class StubStore:
+    def __init__(self, policy: RepositoryPolicy) -> None:
+        self.policy = policy
+        self.audits: list[dict] = []
+
+    def run(self, run_id: str) -> dict:
+        return {
+            "id": run_id,
+            "repository": "owner/repo",
+            "details": {
+                "pr_url": "https://github.com/owner/repo/pull/12",
+                "commit_sha": "a" * 40,
+                "base_commit": "b" * 40,
+            },
+        }
+
+    def context_bundle(self, _run_id: str) -> dict:
+        return {
+            "context_pack": {
+                "project": {"policy_digest": repository_policy_digest(self.policy)}
+            }
+        }
+
+    def append_merge_decision(self, **kwargs) -> dict:
+        self.audits.append(kwargs)
+        return {"id": f"audit-{len(self.audits)}"}
+
+
+class StubGitHub:
+    def pull_request_merge_snapshot(self, repository: str, number: int) -> dict:
+        return {
+            "repository": repository,
+            "pull_number": number,
+            "head_sha": "a" * 40,
+            "base_sha": "b" * 40,
+            "state": "OPEN",
+            "draft": False,
+            "mergeable": "MERGEABLE",
+            "review_decision": "APPROVED",
+            "unresolved_conversations": 0,
+            "files": ["src/example.py"],
+            "additions": 10,
+            "deletions": 2,
+            "checks": [
+                {
+                    "name": "quality",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "required": True,
+                }
+            ],
+            "files_complete": True,
+            "conversations_complete": True,
+            "checks_complete": True,
+        }
+
+
+class MergePipelineTests(unittest.TestCase):
+    def test_decision_reads_current_snapshot_and_appends_every_audit(self) -> None:
+        policy = RepositoryPolicy(name="owner/repo")
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": policy},
+            safety=SimpleNamespace(max_files_changed=18, max_diff_lines=700),
+        )
+        pipeline.store = StubStore(policy)
+        pipeline.github = StubGitHub()
+
+        first = pipeline.merge_decision("run-1")
+        second = pipeline.merge_decision("run-1")
+
+        self.assertTrue(first["eligible"])
+        self.assertFalse(first["public_write"])
+        self.assertEqual(first["decision_digest"], second["decision_digest"])
+        self.assertEqual(len(pipeline.store.audits), 2)
+        self.assertNotEqual(first["audit"]["id"], second["audit"]["id"])
+        self.assertEqual(
+            pipeline.store.audits[0]["decision"]["snapshot"]["head_sha"],
+            "a" * 40,
+        )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,8 +6,10 @@ import sqlite3
 import tempfile
 import unittest
 from contextlib import closing
+from dataclasses import asdict
 from pathlib import Path
 
+from reposteward.merge import MergeCheck, MergeSnapshot, evaluate_merge
 from reposteward.models import Candidate, Issue, RepositoryInfo
 from reposteward.store import SCHEMA_VERSION, Store, StoreError
 
@@ -219,12 +221,31 @@ class StoreTests(unittest.TestCase):
     def test_merge_decision_audit_is_append_only(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")
-            decision = {
-                "eligible": True,
-                "snapshot_digest": "a" * 64,
-                "decision_digest": "b" * 64,
-                "reasons": [],
-            }
+            snapshot = MergeSnapshot(
+                repository="owner/repo",
+                pull_number=12,
+                head_sha="c" * 40,
+                base_sha="d" * 40,
+                policy_digest="e" * 64,
+                state="OPEN",
+                draft=False,
+                mergeable="MERGEABLE",
+                review_decision="APPROVED",
+                unresolved_conversations=0,
+                files=("src/example.py",),
+                additions=1,
+                deletions=0,
+                checks=(MergeCheck("quality", "COMPLETED", "SUCCESS"),),
+            )
+            evaluated = evaluate_merge(
+                snapshot,
+                expected_head_sha="c" * 40,
+                expected_base_sha="d" * 40,
+                expected_policy_digest="e" * 64,
+                max_files_changed=18,
+                max_diff_lines=700,
+            )
+            decision = {**evaluated.to_dict(), "snapshot": asdict(snapshot)}
 
             first = store.append_merge_decision(
                 repository="Owner/Repo",
@@ -247,6 +268,29 @@ class StoreTests(unittest.TestCase):
         self.assertNotEqual(first["id"], second["id"])
         self.assertEqual(len(audit), 2)
         self.assertTrue(all(value["eligible"] for value in audit))
+
+    def test_merge_decision_audit_rejects_tampered_material(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            decision = {
+                "eligible": True,
+                "snapshot_digest": "a" * 64,
+                "decision_digest": "b" * 64,
+                "reasons": [],
+                "risk_categories": [],
+                "risk_files": [],
+                "snapshot": {},
+            }
+
+            with self.assertRaisesRegex(StoreError, "snapshot.*digest"):
+                store.append_merge_decision(
+                    repository="owner/repo",
+                    pull_number=12,
+                    head_sha="c" * 40,
+                    base_sha="d" * 40,
+                    policy_digest="e" * 64,
+                    decision=decision,
+                )
 
     def test_candidate_round_trip_and_status_preservation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 关联 Issue

Closes #12

## 问题与改动

PR #17 已建立确定性决策核心和追加式审计表，本 PR 完成剩余接入：

- 新增完整分页的 GitHub GraphQL 只读快照，覆盖 changed files、required checks、Review decision、未解决会话、head/base 和规模。
- 新增 `reposteward merge-decision RUN_ID`，对照验证时冻结的 head、base 和 policy digest 执行判断；任何变化或不完整数据都失败关闭。
- 审计记录同时保存规范化输入快照，并在入库前复算 snapshot/decision digest 与作用域，支持事后解释和重放。
- 补充真实 GitHub 只读 smoke test、分页/不完整数据/流水线/篡改审计回归测试和架构文档。

## 验证

隔离 Runner 中执行，128 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

另外对真实 `tiammomo/RepoSteward#17` 执行只读快照和端到端 `merge-decision` smoke test，正确读取 required check，并对已合并/策略已变化的旧 run 返回稳定阻断原因；未执行 GitHub 写操作。

## 风险与兼容性

GraphQL 会完整分页，复杂度与 PR files/threads/checks 总量线性相关，最多 1,000 页且游标不前进时立即失败。审计是本地 SQLite 追加写；不调用 Harness、不修改 workspace、不回复或合并 PR。本 PR 没有自动合并执行能力。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了完整 diff、真实 GitHub 返回结构、分页终止、required check 归一化、策略漂移门禁、摘要防篡改、只读边界和性能上限。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
