### PR TITLE
feat(storage): deduplicate GitHub event payloads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,10 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
 - `issue_proposals`：缓存本机发起的 Project item 和转换结果；GitHub Project 中的最新内容仍是
   多人审查阶段的唯一真相。
 - `github_pr_events`：按 repository、PR、事件类型、稳定 ID 和内容摘要追加 GitHub 事件版本；
-  评论编辑、check 状态和 PR head 变化不会覆盖旧版本，原始正文显式标记为 GitHub 不可信输入。
+  评论编辑、check 状态和 PR head 变化不会覆盖旧版本。事件行只保留稳定 ID、作者、状态、时间与
+  内容摘要，原始正文显式标记为 GitHub 不可信输入。
+- `content_blobs`：按 SHA-256 对较大的 GitHub 事件载荷做内容寻址和跨引用去重；事件索引通过摘要
+  引用 Blob，事务会同时写入并校验内容，旧版内联正文原地无损迁移。
 - `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
   Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -253,6 +253,41 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON merge_decisions(repository, pull_number, created_at DESC)
         """,
     ),
+    7: (
+        """
+        CREATE TABLE IF NOT EXISTS content_blobs (
+            digest TEXT PRIMARY KEY,
+            payload BLOB NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        "ALTER TABLE github_pr_events ADD COLUMN payload_digest TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE github_pr_events ADD COLUMN source_actor TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE github_pr_events ADD COLUMN source_state TEXT NOT NULL DEFAULT ''",
+        """
+        INSERT OR IGNORE INTO content_blobs(digest, payload, size_bytes, created_at)
+        SELECT version_digest, CAST(payload AS BLOB),
+               length(CAST(payload AS BLOB)), ingested_at
+        FROM github_pr_events
+        """,
+        """
+        UPDATE github_pr_events
+        SET payload_digest=version_digest,
+            source_actor=COALESCE(json_extract(payload, '$.author'), ''),
+            source_state=COALESCE(
+                json_extract(payload, '$.state'),
+                json_extract(payload, '$.status'),
+                json_extract(payload, '$.conclusion'),
+                ''
+            ),
+            payload=''
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS github_pr_events_for_payload
+        ON github_pr_events(payload_digest)
+        """,
+    ),
 }
 
 
@@ -316,6 +351,18 @@ class Store:
                 connection.execute("BEGIN IMMEDIATE")
                 try:
                     for statement in statements:
+                        if version == 7 and statement.startswith(
+                            "ALTER TABLE github_pr_events ADD COLUMN"
+                        ):
+                            column = statement.split("ADD COLUMN", 1)[1].split()[0]
+                            existing = {
+                                str(row[1])
+                                for row in connection.execute(
+                                    "PRAGMA table_info(github_pr_events)"
+                                )
+                            }
+                            if column in existing:
+                                continue
                         connection.execute(statement)
                     connection.execute(f"PRAGMA user_version={version}")
                     connection.commit()
@@ -895,6 +942,13 @@ class Store:
                         "source_updated_at": str(
                             value.get("updated_at") or value.get("submitted_at") or ""
                         ),
+                        "source_actor": str(value.get("author") or ""),
+                        "source_state": str(
+                            value.get("state")
+                            or value.get("status")
+                            or value.get("conclusion")
+                            or ""
+                        ),
                         "payload": _canonical_json(value),
                     }
                 )
@@ -951,13 +1005,39 @@ class Store:
             ):
                 raise StoreError("GitHub watermark belongs to a different pull request")
             for event in event_values:
+                payload_bytes = event["payload"].encode()
+                connection.execute(
+                    """
+                    INSERT INTO content_blobs(digest, payload, size_bytes, created_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(digest) DO NOTHING
+                    """,
+                    (
+                        event["version_digest"],
+                        payload_bytes,
+                        len(payload_bytes),
+                        now,
+                    ),
+                )
+                stored_blob = connection.execute(
+                    "SELECT payload FROM content_blobs WHERE digest=?",
+                    (event["version_digest"],),
+                ).fetchone()
+                if (
+                    stored_blob is None
+                    or bytes(stored_blob["payload"]) != payload_bytes
+                ):
+                    raise StoreError("content blob digest collision or corruption")
                 connection.execute(
                     """
                     INSERT INTO github_pr_events(
                         repository, pull_number, event_type, external_id,
                         version_digest, head_sha, source_trust, source_created_at,
-                        source_updated_at, payload, ingested_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, 'github_untrusted', ?, ?, ?, ?)
+                        source_updated_at, payload, ingested_at, payload_digest,
+                        source_actor, source_state
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, 'github_untrusted', ?, ?, '', ?, ?, ?, ?
+                    )
                     ON CONFLICT(
                         repository, pull_number, event_type,
                         external_id, version_digest
@@ -972,15 +1052,19 @@ class Store:
                         event["head_sha"],
                         event["source_created_at"],
                         event["source_updated_at"],
-                        event["payload"],
                         now,
+                        event["version_digest"],
+                        event["source_actor"],
+                        event["source_state"],
                     ),
                 )
             previous_sequence = int(watermark["sequence"])
             rows = connection.execute(
                 """
-                SELECT * FROM github_pr_events
-                WHERE repository=? AND pull_number=? AND sequence>?
+                SELECT e.*, b.payload AS blob_payload
+                FROM github_pr_events e
+                LEFT JOIN content_blobs b ON b.digest=e.payload_digest
+                WHERE e.repository=? AND e.pull_number=? AND e.sequence>?
                 ORDER BY sequence
                 """,
                 (repository, pull_number, previous_sequence),
@@ -988,7 +1072,13 @@ class Store:
         events = []
         for row in rows:
             event = dict(row)
-            event["payload"] = json.loads(event["payload"])
+            blob_payload = event.pop("blob_payload")
+            if blob_payload is None:
+                raise StoreError(
+                    f"GitHub event payload is unavailable: {event['payload_digest']}"
+                )
+            event["payload"] = json.loads(bytes(blob_payload))
+            event["payload_available"] = True
             events.append(event)
         through_sequence = int(events[-1]["sequence"]) if events else previous_sequence
         batch_digest = _json_digest(
@@ -1091,17 +1181,30 @@ class Store:
         with self._connection() as connection:
             rows = connection.execute(
                 """
-                SELECT * FROM github_pr_events
-                WHERE repository=? AND pull_number=? ORDER BY sequence
+                SELECT e.*, b.payload AS blob_payload
+                FROM github_pr_events e
+                LEFT JOIN content_blobs b ON b.digest=e.payload_digest
+                WHERE e.repository=? AND e.pull_number=? ORDER BY e.sequence
                 """,
                 (repository.casefold(), pull_number),
             ).fetchall()
         result = []
         for row in rows:
             event = dict(row)
-            event["payload"] = json.loads(event["payload"])
+            blob_payload = event.pop("blob_payload")
+            event["payload_available"] = blob_payload is not None
+            event["payload"] = (
+                json.loads(bytes(blob_payload)) if blob_payload is not None else None
+            )
             result.append(event)
         return result
+
+    def content_blob(self, digest: str) -> bytes | None:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT payload FROM content_blobs WHERE digest=?", (digest,)
+            ).fetchone()
+        return bytes(row["payload"]) if row is not None else None
 
     def github_pr_watermark(self, run_id: str) -> dict[str, Any] | None:
         with self._connection() as connection:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -218,6 +218,65 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
             self.assertIsNotNone(table)
 
+    def test_version_six_database_moves_event_payloads_without_data_loss(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            payload = json.dumps(
+                {"id": 21, "author": "reviewer", "body": "keep me"},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            digest = hashlib.sha256(payload.encode()).hexdigest()
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute(
+                    """
+                    CREATE TABLE github_pr_events (
+                        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                        repository TEXT NOT NULL,
+                        pull_number INTEGER NOT NULL,
+                        event_type TEXT NOT NULL,
+                        external_id TEXT NOT NULL,
+                        version_digest TEXT NOT NULL,
+                        head_sha TEXT NOT NULL DEFAULT '',
+                        source_trust TEXT NOT NULL DEFAULT 'github_untrusted',
+                        source_created_at TEXT NOT NULL DEFAULT '',
+                        source_updated_at TEXT NOT NULL DEFAULT '',
+                        payload TEXT NOT NULL,
+                        ingested_at TEXT NOT NULL,
+                        UNIQUE(repository, pull_number, event_type, external_id,
+                               version_digest)
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO github_pr_events(
+                        repository, pull_number, event_type, external_id,
+                        version_digest, payload, ingested_at
+                    ) VALUES ('owner/repo', 12, 'issue_comment', '21', ?, ?,
+                              '2026-08-20T00:00:00Z')
+                    """,
+                    (digest, payload),
+                )
+                connection.execute("PRAGMA user_version=6")
+
+            migrated = Store(path)
+            events = migrated.github_pr_events("owner/repo", 12)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                stored = connection.execute(
+                    """
+                    SELECT e.payload, e.payload_digest, e.source_actor,
+                           b.size_bytes
+                    FROM github_pr_events e
+                    JOIN content_blobs b ON b.digest=e.payload_digest
+                    """
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertEqual(events[0]["payload"]["body"], "keep me")
+            self.assertTrue(events[0]["payload_available"])
+            self.assertEqual(stored, ("", digest, "reviewer", len(payload.encode())))
+
     def test_merge_decision_audit_is_append_only(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")
@@ -491,6 +550,7 @@ class StoreTests(unittest.TestCase):
                 "comments": [
                     {
                         "id": 21,
+                        "author": "reviewer",
                         "body": "first",
                         "created_at": "2026-08-20T00:00:00Z",
                         "updated_at": "2026-08-20T00:00:00Z",
@@ -507,6 +567,8 @@ class StoreTests(unittest.TestCase):
                 pull_number=12,
                 activity=activity,
             )
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                connection.execute("DELETE FROM content_blobs")
             repeated = store.ingest_github_pr_activity(
                 run_id=run_id,
                 repository="owner/repo",
@@ -545,19 +607,31 @@ class StoreTests(unittest.TestCase):
             events = store.github_pr_events("owner/repo", 12)
             watermark = store.github_pr_watermark(run_id)
             bundle = store.context_bundle(run_id)
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                blob_count = connection.execute(
+                    "SELECT COUNT(*) FROM content_blobs"
+                ).fetchone()[0]
+                inline_bytes = connection.execute(
+                    "SELECT SUM(length(payload)) FROM github_pr_events"
+                ).fetchone()[0]
 
         self.assertEqual(len(first["events"]), 2)
         self.assertEqual(repeated["batch_digest"], first["batch_digest"])
         self.assertEqual(len(repeated["events"]), 2)
+        self.assertTrue(all(event["payload_available"] for event in repeated["events"]))
         self.assertFalse(committed["idempotent"])
         self.assertEqual(committed["checkpoint"]["sequence"], 1)
         self.assertEqual(after_commit["events"], [])
         self.assertEqual(len(edited["events"]), 1)
         self.assertEqual(edited["events"][0]["event_type"], "issue_comment")
         self.assertEqual(len(events), 3)
+        self.assertEqual(blob_count, 3)
+        self.assertEqual(inline_bytes, 0)
+        self.assertTrue(all(event["payload_available"] for event in events))
         self.assertTrue(
             all(event["source_trust"] == "github_untrusted" for event in events)
         )
+        self.assertEqual(events[1]["source_actor"], "reviewer")
         self.assertEqual(
             [event["payload"]["body"] for event in events[1:]],
             ["first", "edited"],


### PR DESCRIPTION
## 关联 Issue

Refs #10

## 问题与改动

本 PR 建立 #10 的底层内容存储，不执行任何清理：

- schema v7 新增 SHA-256 内容寻址 `content_blobs`，GitHub 事件只保留轻量索引与 payload digest。
- 同一事务写入 Blob 和事件引用；重复内容复用 Blob，摘要碰撞或内容损坏时失败关闭。
- 事件索引新增作者与状态字段，原始正文继续标记为 GitHub 不可信数据。
- 旧版内联 payload 原地迁移到 Blob 后再清空冗余列，保留读取兼容；已存在列可安全重试部分升级。
- 缺失 Blob 在再次摄取相同 GitHub 事实时可以恢复，历史读取会显式报告 payload 是否可用。

容量统计和安全 GC 将在 #10 的后续聚焦 PR 中接入，所以本 PR 不提前关闭 Issue。

## 验证

隔离 Runner 中执行，129 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

## 风险与兼容性

包含 SQLite schema v6 → v7 无损迁移。迁移和新写入都在 `BEGIN IMMEDIATE` 事务中完成；旧事件正文仅在 Blob 成功保存后清空。读取多一次按摘要索引的 JOIN，复杂度仍为事件数线性，且 payload 只保留一份。本 PR 不删除任何内容，也不影响 Merge Decision 审计表。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了完整 diff、迁移顺序、部分升级重试、摘要一致性、重复摄取、缺失引用恢复和查询索引。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
