### PR TITLE
feat(storage): report local usage by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,17 @@ uv run reposteward merge-decision RUN_ID
 Runner、数据库、依赖发布和安全风险规则不能被项目配置削弱；项目只能通过 `merge_risk_paths` 追加
 需要人工合并的路径。
 
+本地占用可以按仓库、数据类别和时间范围只读查看：
+
+```bash
+uv run reposteward storage stats
+uv run reposteward storage stats --repo owner/repository --since-days 30
+```
+
+输出分别给出逻辑载荷字节、验证日志缓存和 SQLite/WAL/SHM 的实际文件字节；跨仓库共享的内容
+寻址 Blob 会在各仓库行中显示引用字节，并在说明字段中明确其可能重复计算，避免把逻辑引用误当成
+全局物理占用。
+
 ## 安全约束
 
 - GitHub 凭据不会传给 Agent、测试、仓库 hooks、Git push 或 Docker 容器。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -172,6 +172,18 @@ def _parser() -> argparse.ArgumentParser:
     )
     logs.add_argument("--tail-chars", type=int, default=12000)
 
+    storage = subparsers.add_parser(
+        "storage", help="inspect and maintain local storage"
+    )
+    storage_commands = storage.add_subparsers(dest="storage_command", required=True)
+    storage_stats = storage_commands.add_parser(
+        "stats", help="report local records and bytes by repository and category"
+    )
+    storage_stats.add_argument("--repo", default="", help="limit to owner/name")
+    storage_stats.add_argument(
+        "--since-days", type=int, default=0, help="include only newer records"
+    )
+
     follow_up = subparsers.add_parser(
         "follow-up",
         help="fetch only pull request activity changed since the last check",
@@ -395,6 +407,15 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
             return 0
+        if args.command == "storage":
+            if args.storage_command == "stats":
+                _json(
+                    pipeline.storage_statistics(
+                        repository=args.repo, since_days=args.since_days
+                    )
+                )
+                return 0
+            raise AssertionError(f"unhandled storage command: {args.storage_command}")
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
             return 0

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -6,6 +6,7 @@ import re
 import sqlite3
 import subprocess
 from dataclasses import asdict
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -999,6 +1000,82 @@ class Pipeline:
             "tail": content[-tail_chars:],
             "tail_chars": min(len(content), tail_chars),
             "tail_truncated": len(content) > tail_chars,
+        }
+
+    def storage_statistics(
+        self, *, repository: str = "", since_days: int = 0
+    ) -> dict[str, Any]:
+        if since_days < 0 or since_days > 36_500:
+            raise ValueError("since_days must be between 0 and 36500")
+        normalized = repository.casefold()
+        if normalized:
+            self.policy(normalized)
+        cutoff = (
+            (datetime.now(UTC) - timedelta(days=since_days)).isoformat()
+            if since_days
+            else ""
+        )
+        categories = self.store.storage_statistics(repository=normalized, cutoff=cutoff)
+        repositories = self.store.run_repositories()
+        logs: dict[str, dict[str, Any]] = {}
+        runs_root = (self.config.state_dir / "runs").resolve()
+        if runs_root.is_dir():
+            for run_dir in runs_root.iterdir():
+                if run_dir.is_symlink() or not run_dir.is_dir():
+                    continue
+                run_repository = repositories.get(run_dir.name, "")
+                if not run_repository or (normalized and run_repository != normalized):
+                    continue
+                verification = run_dir / "verification"
+                if verification.is_symlink() or not verification.is_dir():
+                    continue
+                group = logs.setdefault(
+                    run_repository,
+                    {
+                        "repository": run_repository,
+                        "category": "verification_log_cache",
+                        "records": 0,
+                        "bytes": 0,
+                        "oldest_at": "",
+                        "newest_at": "",
+                    },
+                )
+                for path in verification.iterdir():
+                    if path.is_symlink() or not path.is_file() or path.suffix != ".log":
+                        continue
+                    try:
+                        stat = path.stat()
+                    except OSError:
+                        continue
+                    timestamp = datetime.fromtimestamp(stat.st_mtime, UTC).isoformat()
+                    if cutoff and timestamp < cutoff:
+                        continue
+                    group["records"] += 1
+                    group["bytes"] += stat.st_size
+                    group["oldest_at"] = min(
+                        value for value in (group["oldest_at"], timestamp) if value
+                    )
+                    group["newest_at"] = max(group["newest_at"], timestamp)
+        categories.extend(logs.values())
+        categories.sort(key=lambda value: (value["repository"], value["category"]))
+        database_files = []
+        for suffix in ("", "-wal", "-shm"):
+            path = Path(f"{self.store.path}{suffix}")
+            if path.is_file() and not path.is_symlink():
+                database_files.append({"name": path.name, "bytes": path.stat().st_size})
+        return {
+            "repository_filter": normalized,
+            "since_days": since_days,
+            "cutoff": cutoff,
+            "categories": categories,
+            "reported_logical_bytes": sum(value["bytes"] for value in categories),
+            "database_physical_bytes": sum(value["bytes"] for value in database_files),
+            "database_files": database_files,
+            "notes": (
+                "Per-repository event payload bytes are referenced bytes; one deduplicated "
+                "blob referenced by multiple repositories appears in each repository row."
+            ),
+            "public_write": False,
         }
 
     def follow_up(self, run_id: str) -> dict[str, Any]:

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -1206,6 +1206,119 @@ class Store:
             ).fetchone()
         return bytes(row["payload"]) if row is not None else None
 
+    def storage_statistics(
+        self, *, repository: str = "", cutoff: str = ""
+    ) -> list[dict[str, Any]]:
+        """Return logical payload usage grouped by repository and data category."""
+        repository = repository.casefold()
+        definitions = (
+            (
+                "github_event_index",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(
+                           length(CAST(repository AS BLOB)) +
+                           length(CAST(event_type AS BLOB)) +
+                           length(CAST(external_id AS BLOB)) +
+                           length(CAST(version_digest AS BLOB)) +
+                           length(CAST(head_sha AS BLOB)) +
+                           length(CAST(source_actor AS BLOB)) +
+                           length(CAST(source_state AS BLOB))
+                       ), 0) AS bytes,
+                       MIN(ingested_at) AS oldest_at, MAX(ingested_at) AS newest_at
+                FROM github_pr_events
+                WHERE (?='' OR repository=?) AND (?='' OR ingested_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
+                "github_event_payload",
+                """
+                SELECT refs.repository, COUNT(*) AS records,
+                       COALESCE(SUM(b.size_bytes), 0) AS bytes,
+                       MIN(refs.oldest_at) AS oldest_at,
+                       MAX(refs.newest_at) AS newest_at
+                FROM (
+                    SELECT repository, payload_digest,
+                           MIN(ingested_at) AS oldest_at,
+                           MAX(ingested_at) AS newest_at
+                    FROM github_pr_events
+                    WHERE payload_digest<>'' AND (?='' OR repository=?)
+                      AND (?='' OR ingested_at>=?)
+                    GROUP BY repository, payload_digest
+                ) refs JOIN content_blobs b ON b.digest=refs.payload_digest
+                GROUP BY refs.repository
+                """,
+            ),
+            (
+                "run_metadata",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(details AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(updated_at) AS newest_at
+                FROM runs
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
+                "context_pack",
+                """
+                SELECT r.repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(p.payload AS BLOB))), 0) AS bytes,
+                       MIN(p.created_at) AS oldest_at, MAX(p.created_at) AS newest_at
+                FROM context_packs p JOIN runs r ON r.id=p.run_id
+                WHERE (?='' OR r.repository=?) AND (?='' OR p.created_at>=?)
+                GROUP BY r.repository
+                """,
+            ),
+            (
+                "checkpoint",
+                """
+                SELECT r.repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(c.payload AS BLOB))), 0) AS bytes,
+                       MIN(c.created_at) AS oldest_at, MAX(c.created_at) AS newest_at
+                FROM checkpoints c JOIN runs r ON r.id=c.run_id
+                WHERE (?='' OR r.repository=?) AND (?='' OR c.created_at>=?)
+                GROUP BY r.repository
+                """,
+            ),
+            (
+                "merge_decision_audit",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM merge_decisions
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+        )
+        result: list[dict[str, Any]] = []
+        parameters = (repository, repository, cutoff, cutoff)
+        with self._connection() as connection:
+            for category, query in definitions:
+                for row in connection.execute(query, parameters).fetchall():
+                    result.append(
+                        {
+                            "repository": str(row["repository"]),
+                            "category": category,
+                            "records": int(row["records"]),
+                            "bytes": int(row["bytes"]),
+                            "oldest_at": str(row["oldest_at"] or ""),
+                            "newest_at": str(row["newest_at"] or ""),
+                        }
+                    )
+        return sorted(
+            result, key=lambda value: (value["repository"], value["category"])
+        )
+
+    def run_repositories(self) -> dict[str, str]:
+        with self._connection() as connection:
+            rows = connection.execute("SELECT id, repository FROM runs").fetchall()
+        return {str(row["id"]): str(row["repository"]) for row in rows}
+
     def github_pr_watermark(self, run_id: str) -> dict[str, Any] | None:
         with self._connection() as connection:
             row = connection.execute(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from reposteward.config import RepositoryPolicy
+from reposteward.pipeline import Pipeline
+
+
+class StubStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.write_bytes(b"database")
+
+    def storage_statistics(self, *, repository: str, cutoff: str) -> list[dict]:
+        return [
+            {
+                "repository": repository or "owner/repo",
+                "category": "checkpoint",
+                "records": 2,
+                "bytes": 120,
+                "oldest_at": "2026-08-20T00:00:00Z",
+                "newest_at": "2026-08-21T00:00:00Z",
+            }
+        ]
+
+    def run_repositories(self) -> dict[str, str]:
+        return {"run-1": "owner/repo"}
+
+
+class StorageStatisticsTests(unittest.TestCase):
+    def test_statistics_include_safe_log_and_database_sizes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            verification = root / "runs" / "run-1" / "verification"
+            verification.mkdir(parents=True)
+            (verification / "command.log").write_bytes(b"12345")
+            outside = root / "outside.log"
+            outside.write_bytes(b"do not follow")
+            os.symlink(outside, verification / "linked.log")
+            policy = RepositoryPolicy(name="owner/repo")
+            pipeline = object.__new__(Pipeline)
+            pipeline.config = SimpleNamespace(
+                state_dir=root,
+                repositories={"owner/repo": policy},
+            )
+            pipeline.store = StubStore(root / "state.sqlite3")
+
+            result = pipeline.storage_statistics(repository="Owner/Repo")
+
+        categories = {value["category"]: value for value in result["categories"]}
+        self.assertEqual(categories["verification_log_cache"]["records"], 1)
+        self.assertEqual(categories["verification_log_cache"]["bytes"], 5)
+        self.assertEqual(result["database_physical_bytes"], 8)
+        self.assertFalse(result["public_write"])
+
+    def test_invalid_time_window_is_rejected(self) -> None:
+        pipeline = object.__new__(Pipeline)
+        with self.assertRaisesRegex(ValueError, "between 0 and 36500"):
+            pipeline.storage_statistics(since_days=-1)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -605,6 +605,7 @@ class StoreTests(unittest.TestCase):
                 activity=activity,
             )
             events = store.github_pr_events("owner/repo", 12)
+            statistics = store.storage_statistics(repository="owner/repo")
             watermark = store.github_pr_watermark(run_id)
             bundle = store.context_bundle(run_id)
             with closing(sqlite3.connect(store.path)) as connection, connection:
@@ -628,6 +629,10 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(blob_count, 3)
         self.assertEqual(inline_bytes, 0)
         self.assertTrue(all(event["payload_available"] for event in events))
+        by_category = {value["category"]: value for value in statistics}
+        self.assertEqual(by_category["github_event_index"]["records"], 3)
+        self.assertEqual(by_category["github_event_payload"]["records"], 3)
+        self.assertGreater(by_category["checkpoint"]["bytes"], 0)
         self.assertTrue(
             all(event["source_trust"] == "github_untrusted" for event in events)
         )


### PR DESCRIPTION
## 关联 Issue

Refs #10

## 问题与改动

在 PR #19 的内容寻址层之上，本 PR 增加只读容量统计：

- 新增 `reposteward storage stats [--repo owner/name] [--since-days N]`。
- 按仓库和类别报告事件索引、去重事件载荷、run metadata、Context Pack、Checkpoint、Merge Decision 审计与验证日志缓存的记录数、UTF-8 字节数、最早/最新时间。
- 单独报告 SQLite、WAL、SHM 的实际文件字节，避免把逻辑载荷与数据库物理占用混淆。
- 对跨仓库共享 Blob 明确标记为“引用字节可能重复计算”，不伪装成可直接相加的全局物理占用。
- 日志统计只扫描受控 `state_dir/runs/<run>/verification/*.log`，忽略符号链接和未知 run。

安全 GC 将在 #10 的下一支 PR 中实现，因此本 PR 不关闭 Issue。

## 验证

隔离 Runner 中执行，131 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

## 风险与兼容性

所有数据库查询和文件操作均为只读。SQL 按现有索引和仓库/时间过滤聚合；日志扫描与日志文件数线性相关。命令不会读取日志正文、跟随符号链接、执行 GC 或调用 GitHub/Harness。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了统计口径、UTF-8 字节计算、共享 Blob 说明、路径边界、时间过滤、完整 diff 和测试结果。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
