### PR TITLE
feat(storage): plan safe event payload retention

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,8 +79,14 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
   内容摘要，原始正文显式标记为 GitHub 不可信输入。
 - `content_blobs`：按 SHA-256 对较大的 GitHub 事件载荷做内容寻址和跨引用去重；事件索引通过摘要
   引用 Blob，事务会同时写入并校验内容，旧版内联正文原地无损迁移。
+- `content_blob_tombstones`：记录经显式保留策略删除的载荷摘要、原大小、原因和时间，防止后续完整
+  GitHub 轮询把已到期正文静默恢复；事件轻量索引和水位仍永久保留。
 - `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
-  Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
+Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
+
+事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
+的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
+写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -139,6 +139,7 @@ class RepositoryPolicy:
     max_files_changed: int | None = None
     max_diff_lines: int | None = None
     merge_risk_paths: tuple[str, ...] = ()
+    event_payload_retention_days: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -592,6 +593,11 @@ def load_config(
                 else None
             ),
             merge_risk_paths=_tuple(repo_value.get("merge_risk_paths")),
+            event_payload_retention_days=(
+                int(repo_value["event_payload_retention_days"])
+                if "event_payload_retention_days" in repo_value
+                else None
+            ),
         )
 
     if not github.login:
@@ -670,6 +676,13 @@ def load_config(
             raise ConfigError(
                 f"{repository.name} must configure both pull_request_template_path "
                 "and pull_request_template_sha256"
+            )
+        if (
+            repository.event_payload_retention_days is not None
+            and repository.event_payload_retention_days < 1
+        ):
+            raise ConfigError(
+                f"{repository.name} event_payload_retention_days must be positive"
             )
 
     return AppConfig(

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -286,6 +286,21 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         """
         CREATE INDEX IF NOT EXISTS github_pr_events_for_payload
         ON github_pr_events(payload_digest)
+        """,
+    ),
+    8: (
+        """
+        CREATE TABLE IF NOT EXISTS content_blob_tombstones (
+            digest TEXT PRIMARY KEY,
+            category TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            deleted_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS github_pr_watermarks_for_pull
+        ON github_pr_watermarks(repository, pull_number, sequence)
         """,
     ),
 }
@@ -1006,28 +1021,34 @@ class Store:
                 raise StoreError("GitHub watermark belongs to a different pull request")
             for event in event_values:
                 payload_bytes = event["payload"].encode()
-                connection.execute(
-                    """
-                    INSERT INTO content_blobs(digest, payload, size_bytes, created_at)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(digest) DO NOTHING
-                    """,
-                    (
-                        event["version_digest"],
-                        payload_bytes,
-                        len(payload_bytes),
-                        now,
-                    ),
-                )
-                stored_blob = connection.execute(
-                    "SELECT payload FROM content_blobs WHERE digest=?",
+                tombstone = connection.execute(
+                    "SELECT digest FROM content_blob_tombstones WHERE digest=?",
                     (event["version_digest"],),
                 ).fetchone()
-                if (
-                    stored_blob is None
-                    or bytes(stored_blob["payload"]) != payload_bytes
-                ):
-                    raise StoreError("content blob digest collision or corruption")
+                if tombstone is None:
+                    connection.execute(
+                        """
+                        INSERT INTO content_blobs(
+                            digest, payload, size_bytes, created_at
+                        ) VALUES (?, ?, ?, ?)
+                        ON CONFLICT(digest) DO NOTHING
+                        """,
+                        (
+                            event["version_digest"],
+                            payload_bytes,
+                            len(payload_bytes),
+                            now,
+                        ),
+                    )
+                    stored_blob = connection.execute(
+                        "SELECT payload FROM content_blobs WHERE digest=?",
+                        (event["version_digest"],),
+                    ).fetchone()
+                    if (
+                        stored_blob is None
+                        or bytes(stored_blob["payload"]) != payload_bytes
+                    ):
+                        raise StoreError("content blob digest collision or corruption")
                 connection.execute(
                     """
                     INSERT INTO github_pr_events(
@@ -1073,12 +1094,12 @@ class Store:
         for row in rows:
             event = dict(row)
             blob_payload = event.pop("blob_payload")
-            if blob_payload is None:
-                raise StoreError(
-                    f"GitHub event payload is unavailable: {event['payload_digest']}"
-                )
-            event["payload"] = json.loads(bytes(blob_payload))
-            event["payload_available"] = True
+            event["payload_available"] = blob_payload is not None
+            event["payload"] = (
+                json.loads(bytes(blob_payload))
+                if blob_payload is not None
+                else self._expired_event_payload(event)
+            )
             events.append(event)
         through_sequence = int(events[-1]["sequence"]) if events else previous_sequence
         batch_digest = _json_digest(
@@ -1194,10 +1215,24 @@ class Store:
             blob_payload = event.pop("blob_payload")
             event["payload_available"] = blob_payload is not None
             event["payload"] = (
-                json.loads(bytes(blob_payload)) if blob_payload is not None else None
+                json.loads(bytes(blob_payload))
+                if blob_payload is not None
+                else self._expired_event_payload(event)
             )
             result.append(event)
         return result
+
+    @staticmethod
+    def _expired_event_payload(event: dict[str, Any]) -> dict[str, Any]:
+        external_id = str(event.get("external_id", ""))
+        return {
+            "id": int(external_id) if external_id.isdecimal() else external_id,
+            "author": str(event.get("source_actor", "")),
+            "state": str(event.get("source_state", "")),
+            "created_at": str(event.get("source_created_at", "")),
+            "updated_at": str(event.get("source_updated_at", "")),
+            "payload_unavailable": True,
+        }
 
     def content_blob(self, digest: str) -> bytes | None:
         with self._connection() as connection:
@@ -1318,6 +1353,124 @@ class Store:
         with self._connection() as connection:
             rows = connection.execute("SELECT id, repository FROM runs").fetchall()
         return {str(row["id"]): str(row["repository"]) for row in rows}
+
+    @staticmethod
+    def _event_payload_gc_inventory(
+        connection: sqlite3.Connection, retention_cutoffs: dict[str, str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        rows = connection.execute(
+            """
+            SELECT b.digest, b.size_bytes, b.created_at,
+                   e.repository, e.pull_number, e.sequence, e.ingested_at,
+                   COALESCE(w.watermark_count, 0) AS watermark_count,
+                   COALESCE(w.minimum_watermark, 0) AS minimum_watermark
+            FROM content_blobs b
+            LEFT JOIN github_pr_events e ON e.payload_digest=b.digest
+            LEFT JOIN (
+                SELECT repository, pull_number,
+                       COUNT(*) AS watermark_count,
+                       MIN(sequence) AS minimum_watermark
+                FROM github_pr_watermarks
+                GROUP BY repository, pull_number
+            ) w ON w.repository=e.repository AND w.pull_number=e.pull_number
+            ORDER BY b.created_at, b.digest, e.sequence
+            """
+        ).fetchall()
+        grouped: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            digest = str(row["digest"])
+            value = grouped.setdefault(
+                digest,
+                {
+                    "kind": "github_event_payload",
+                    "digest": digest,
+                    "bytes": int(row["size_bytes"]),
+                    "created_at": str(row["created_at"]),
+                    "repositories": set(),
+                    "reference_count": 0,
+                    "reasons": set(),
+                },
+            )
+            if row["repository"] is None:
+                value["reasons"].add("unreferenced_content_blob")
+                continue
+            repository = str(row["repository"])
+            value["repositories"].add(repository)
+            value["reference_count"] += 1
+            cutoff = retention_cutoffs.get(repository)
+            if not cutoff:
+                value["reasons"].add("no_explicit_event_retention")
+            elif str(row["ingested_at"]) >= cutoff:
+                value["reasons"].add("within_event_retention")
+            if int(row["watermark_count"] or 0) < 1 or int(
+                row["minimum_watermark"] or 0
+            ) < int(row["sequence"]):
+                value["reasons"].add("not_checkpointed_by_every_run")
+        candidates = []
+        retained = []
+        for value in grouped.values():
+            reasons = set(value.pop("reasons"))
+            value["repositories"] = sorted(value["repositories"])
+            if reasons == {"unreferenced_content_blob"}:
+                value["reason"] = "unreferenced_content_blob"
+                candidates.append(value)
+            elif not reasons:
+                value["reason"] = "explicit_retention_elapsed_and_checkpointed"
+                candidates.append(value)
+            else:
+                value["reasons"] = sorted(reasons)
+                retained.append(value)
+        key = lambda item: (item["created_at"], item["digest"])
+        return {
+            "candidates": sorted(candidates, key=key),
+            "retained": sorted(retained, key=key),
+        }
+
+    def event_payload_gc_inventory(
+        self, retention_cutoffs: dict[str, str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        normalized = {
+            repository.casefold(): cutoff
+            for repository, cutoff in retention_cutoffs.items()
+        }
+        with self._connection() as connection:
+            return self._event_payload_gc_inventory(connection, normalized)
+
+    def delete_event_payloads(
+        self, digests: tuple[str, ...], *, retention_cutoffs: dict[str, str]
+    ) -> dict[str, Any]:
+        requested = set(digests)
+        if not requested:
+            return {"deleted": [], "skipped": []}
+        normalized = {
+            repository.casefold(): cutoff
+            for repository, cutoff in retention_cutoffs.items()
+        }
+        deleted = []
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            inventory = self._event_payload_gc_inventory(connection, normalized)
+            eligible = {value["digest"]: value for value in inventory["candidates"]}
+            for digest in sorted(requested & eligible.keys()):
+                value = eligible[digest]
+                connection.execute(
+                    """
+                    INSERT INTO content_blob_tombstones(
+                        digest, category, size_bytes, reason, deleted_at
+                    ) VALUES (?, 'github_event_payload', ?, ?, ?)
+                    ON CONFLICT(digest) DO NOTHING
+                    """,
+                    (digest, value["bytes"], value["reason"], utc_now()),
+                )
+                cursor = connection.execute(
+                    "DELETE FROM content_blobs WHERE digest=?", (digest,)
+                )
+                if cursor.rowcount:
+                    deleted.append(value)
+        return {
+            "deleted": deleted,
+            "skipped": sorted(requested - {value["digest"] for value in deleted}),
+        }
 
     def github_pr_watermark(self, run_id: str) -> dict[str, Any] | None:
         with self._connection() as connection:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,6 +139,7 @@ forbidden_paths = []
 [repositories."owner/repo"]
 max_diff_lines = 99
 merge_risk_paths = ["docs/operator/**"]
+event_payload_retention_days = 45
 """,
                 encoding="utf-8",
             )
@@ -184,6 +185,25 @@ merge_risk_paths = ["docs/operator/**"]
             config.repositories["owner/repo"].merge_risk_paths,
             ("docs/operator/**",),
         )
+        self.assertEqual(
+            config.repositories["owner/repo"].event_payload_retention_days, 45
+        )
+
+    def test_event_payload_retention_must_be_explicit_and_positive(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+event_payload_retention_days = 0
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "must be positive"):
+                load_config(path)
 
     def test_configuration_is_not_pinned_to_one_github_login(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -250,6 +250,18 @@ class StoreTests(unittest.TestCase):
                 )
                 connection.execute(
                     """
+                    CREATE TABLE github_pr_watermarks (
+                        run_id TEXT PRIMARY KEY,
+                        repository TEXT NOT NULL,
+                        pull_number INTEGER NOT NULL,
+                        sequence INTEGER NOT NULL DEFAULT 0,
+                        batch_digest TEXT NOT NULL DEFAULT '',
+                        updated_at TEXT NOT NULL
+                    )
+                    """
+                )
+                connection.execute(
+                    """
                     INSERT INTO github_pr_events(
                         repository, pull_number, event_type, external_id,
                         version_digest, payload, ingested_at
@@ -276,6 +288,117 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(events[0]["payload"]["body"], "keep me")
             self.assertTrue(events[0]["payload_available"])
             self.assertEqual(stored, ("", digest, "reviewer", len(payload.encode())))
+
+    def test_version_seven_database_receives_gc_tombstones(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE content_blob_tombstones")
+                connection.execute("DROP INDEX github_pr_watermarks_for_pull")
+                connection.execute("PRAGMA user_version=7")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type='table' AND name='content_blob_tombstones'
+                    """
+                ).fetchone()
+                index = connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type='index' AND name='github_pr_watermarks_for_pull'
+                    """
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIsNotNone(index)
+
+    def test_event_payload_gc_requires_retention_and_every_run_watermark(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            activity = {
+                "pull_request": {
+                    "number": 12,
+                    "head_sha": "a" * 40,
+                    "state": "open",
+                },
+                "comments": [],
+                "reviews": [],
+                "review_comments": [],
+                "checks": [],
+            }
+
+            def new_run() -> tuple[str, dict]:
+                run_id = store.start_run("owner/repo", 7, "pull_request")
+                store.update_run(
+                    run_id,
+                    status="submitted",
+                    details={"pr_url": "https://github.com/owner/repo/pull/12"},
+                )
+                batch = store.ingest_github_pr_activity(
+                    run_id=run_id,
+                    repository="owner/repo",
+                    pull_number=12,
+                    activity=activity,
+                )
+                return run_id, batch
+
+            first_run, first = new_run()
+            store.commit_github_follow_up(
+                run_id=first_run,
+                repository="owner/repo",
+                pull_number=12,
+                previous_sequence=first["previous_sequence"],
+                through_sequence=first["through_sequence"],
+                batch_digest=first["batch_digest"],
+            )
+            no_policy = store.event_payload_gc_inventory({})
+            second_run, second = new_run()
+            blocked = store.event_payload_gc_inventory(
+                {"owner/repo": "2099-01-01T00:00:00Z"}
+            )
+            store.commit_github_follow_up(
+                run_id=second_run,
+                repository="owner/repo",
+                pull_number=12,
+                previous_sequence=second["previous_sequence"],
+                through_sequence=second["through_sequence"],
+                batch_digest=second["batch_digest"],
+            )
+            eligible = store.event_payload_gc_inventory(
+                {"owner/repo": "2099-01-01T00:00:00Z"}
+            )
+            digest = eligible["candidates"][0]["digest"]
+            deleted = store.delete_event_payloads(
+                (digest,),
+                retention_cutoffs={"owner/repo": "2099-01-01T00:00:00Z"},
+            )
+            repeated = store.delete_event_payloads(
+                (digest,),
+                retention_cutoffs={"owner/repo": "2099-01-01T00:00:00Z"},
+            )
+            _third_run, third = new_run()
+            events = store.github_pr_events("owner/repo", 12)
+            blob = store.content_blob(digest)
+
+        self.assertEqual(
+            no_policy["retained"][0]["reasons"],
+            ["no_explicit_event_retention"],
+        )
+        self.assertIn(
+            "not_checkpointed_by_every_run", blocked["retained"][0]["reasons"]
+        )
+        self.assertEqual(len(eligible["candidates"]), 1)
+        self.assertEqual(len(deleted["deleted"]), 1)
+        self.assertEqual(repeated["skipped"], [digest])
+        self.assertFalse(third["events"][0]["payload_available"])
+        self.assertTrue(third["events"][0]["payload"]["payload_unavailable"])
+        self.assertFalse(events[0]["payload_available"])
+        self.assertIsNone(blob)
 
     def test_merge_decision_audit_is_append_only(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 关联 Issue

Refs #10

## 问题与改动

本 PR 实现安全 GC 的数据库核心，但尚不开放 CLI 删除入口：

- 仓库可显式设置正整数 `event_payload_retention_days`；未设置时原始 GitHub 事件正文永久保留。
- 候选规划要求载荷所有引用都超过各自保留期，并且同一 PR 的每个 run 水位均已越过对应事件。
- schema v8 新增不可被普通 GC 清理的 payload tombstone；删除后保留轻量事件索引，并防止后续完整 GitHub 轮询静默恢复已到期正文。
- 删除在 `BEGIN IMMEDIATE` 事务内重新计算资格，先写 tombstone 再删 Blob；重复执行幂等，状态变化会跳过而不是沿用旧计划。
- 为 watermark 聚合新增 `(repository, pull_number, sequence)` 索引，规划复杂度保持为事件与水位的线性扫描，避免逐事件相关子查询。
- 无引用 Blob 可作为可重建垃圾清理；Merge Decision 审计表不进入任何候选查询。

CLI dry-run、日志缓存清理和 apply 审计将在 #10 最后一支 PR 中接入。

## 验证

隔离 Runner 中执行，134 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

## 风险与兼容性

包含 SQLite schema v7 → v8 前向迁移，只新增 tombstone 表和 watermark 查询索引。当前没有用户可调用的删除命令。核心删除仅接受规划出的精确 digest，并在事务内二次校验；正文不可用时 follow-up 使用轻量占位元数据，不执行或重建已删除正文。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了完整 diff、默认保留语义、跨 run 水位、事务竞态、重复执行、tombstone 防回流、Merge Decision 排除和查询复杂度。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
