### PR TITLE
feat(storage): apply audited safe garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,27 @@ uv run reposteward storage stats --repo owner/repository --since-days 30
 寻址 Blob 会在各仓库行中显示引用字节，并在说明字段中明确其可能重复计算，避免把逻辑引用误当成
 全局物理占用。
 
+清理命令默认只生成精确计划，不写数据库或删除文件：
+
+```bash
+uv run reposteward storage gc --repo owner/repository
+```
+
+默认候选只有超过用户级 `cache_retention_days` 且已有终态 Checkpoint 的验证日志。原始 GitHub
+事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且每个 run 水位
+都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并始终保护事件
+索引、Checkpoint、Merge Decision 和 GC 审计。
+
+实际应用需要命令参数和独立环境开关同时存在：
+
+```bash
+REPOSTEWARD_ENABLE_GC=1 uv run reposteward storage gc \
+  --repo owner/repository --apply
+```
+
+apply 前会追加 `applying` 审计，删除后再追加 `completed` 审计；中断后可从未完成记录识别并安全
+重跑。SQLite Blob 删除释放的是可复用数据库页，不会自动执行 `VACUUM` 或承诺立即缩小数据库文件。
+
 ## 安全约束
 
 - GitHub 凭据不会传给 Agent、测试、仓库 hooks、Git push 或 Docker 容器。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,12 +81,17 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
   引用 Blob，事务会同时写入并校验内容，旧版内联正文原地无损迁移。
 - `content_blob_tombstones`：记录经显式保留策略删除的载荷摘要、原大小、原因和时间，防止后续完整
   GitHub 轮询把已到期正文静默恢复；事件轻量索引和水位仍永久保留。
+- `storage_gc_runs`：对实际 GC 追加 `applying` 与 `completed` 记录，保存精确计划摘要、操作者与结果；
+  进程中断会留下可识别的未完成意图，该审计不参与普通 GC。
 - `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
 Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
 
 事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
 的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
+验证日志是唯一默认可回收类别，期限和单次最大对象数由用户级 `[storage]` 配置拥有，项目层不能
+静默缩短。GC 默认 dry-run；apply 同时要求 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后
+追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Merge Decision 或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -39,6 +39,10 @@ timeout_seconds = 1800
 cpus = 4
 memory = "8g"
 
+[storage]
+cache_retention_days = 30
+max_gc_items = 1000
+
 [repositories."owner/repository"]
 enabled = true
 auto_prepare = false
@@ -54,3 +58,5 @@ required_verification_markers = ["pytest", "ruff check"]
 pull_request_body_style = "generic"
 branch_template = "{login}/{scope}/{slug}"
 default_scope = "repo"
+# Raw GitHub event bodies are retained indefinitely unless explicitly enabled:
+# event_payload_retention_days = 90

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -183,6 +183,11 @@ def _parser() -> argparse.ArgumentParser:
     storage_stats.add_argument(
         "--since-days", type=int, default=0, help="include only newer records"
     )
+    storage_gc = storage_commands.add_parser(
+        "gc", help="plan safe local cleanup; dry-run unless --apply is set"
+    )
+    storage_gc.add_argument("--repo", default="", help="limit to owner/name")
+    storage_gc.add_argument("--apply", action="store_true")
 
     follow_up = subparsers.add_parser(
         "follow-up",
@@ -414,6 +419,9 @@ def main(argv: list[str] | None = None) -> int:
                         repository=args.repo, since_days=args.since_days
                     )
                 )
+                return 0
+            if args.storage_command == "gc":
+                _json(pipeline.storage_gc(repository=args.repo, apply=args.apply))
                 return 0
             raise AssertionError(f"unhandled storage command: {args.storage_command}")
         if args.command == "follow-up":

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -110,6 +110,12 @@ class RunnerConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class StorageConfig:
+    cache_retention_days: int = 30
+    max_gc_items: int = 1_000
+
+
+@dataclass(frozen=True, slots=True)
 class RepositoryPolicy:
     name: str
     enabled: bool = True
@@ -155,6 +161,7 @@ class AppConfig:
     safety: SafetyConfig
     agent: AgentConfig
     runner: RunnerConfig
+    storage: StorageConfig
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
 
 
@@ -296,6 +303,12 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
         result["issue_review"] = dict(user_issue_review)
     else:
         result.pop("issue_review", None)
+
+    user_storage = user.get("storage")
+    if isinstance(user_storage, dict):
+        result["storage"] = dict(user_storage)
+    else:
+        result.pop("storage", None)
 
     user_agent = user.get("agent")
     project_agent = project.get("agent")
@@ -532,6 +545,12 @@ def load_config(
         max_log_chars=int(runner_raw.get("max_log_chars", 2_000_000)),
     )
 
+    storage_raw = _section(raw, "storage")
+    storage = StorageConfig(
+        cache_retention_days=int(storage_raw.get("cache_retention_days", 30)),
+        max_gc_items=int(storage_raw.get("max_gc_items", 1_000)),
+    )
+
     repositories_raw = _section(raw, "repositories")
     repositories: dict[str, RepositoryPolicy] = {}
     for name, repo_value in repositories_raw.items():
@@ -634,6 +653,10 @@ def load_config(
         raise ConfigError(
             "runner.max_log_chars must be at least runner.max_output_chars"
         )
+    if not 1 <= storage.cache_retention_days <= 36_500:
+        raise ConfigError("storage.cache_retention_days must be between 1 and 36500")
+    if not 1 <= storage.max_gc_items <= 10_000:
+        raise ConfigError("storage.max_gc_items must be between 1 and 10000")
     if not agent.harness:
         raise ConfigError("agent.harness must not be empty")
     for repository in repositories.values():
@@ -697,5 +720,6 @@ def load_config(
         safety=safety,
         agent=agent,
         runner=runner,
+        storage=storage,
         repositories=repositories,
     )

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import sqlite3
@@ -1077,6 +1078,221 @@ class Pipeline:
             ),
             "public_write": False,
         }
+
+    def _verification_log_gc_inventory(
+        self, *, repository: str, cutoff: str
+    ) -> dict[str, list[dict[str, Any]]]:
+        safety = self.store.run_gc_safety()
+        candidates = []
+        retained = []
+        state_root = self.config.state_dir.resolve()
+        runs_root = state_root / "runs"
+        if not runs_root.is_dir():
+            return {"candidates": candidates, "retained": retained}
+        for run_dir in sorted(runs_root.iterdir()):
+            if run_dir.is_symlink() or not run_dir.is_dir():
+                continue
+            run = safety.get(run_dir.name)
+            verification = run_dir / "verification"
+            if verification.is_symlink() or not verification.is_dir():
+                continue
+            for path in sorted(verification.iterdir()):
+                if path.is_symlink() or not path.is_file() or path.suffix != ".log":
+                    continue
+                try:
+                    stat = path.stat()
+                    relative = path.relative_to(state_root).as_posix()
+                except (OSError, ValueError):
+                    continue
+                run_repository = str(run.get("repository", "")) if run else ""
+                if repository and run_repository != repository:
+                    continue
+                timestamp = datetime.fromtimestamp(stat.st_mtime, UTC).isoformat()
+                item = {
+                    "kind": "verification_log_cache",
+                    "path": relative,
+                    "run_id": run_dir.name,
+                    "repository": run_repository,
+                    "bytes": stat.st_size,
+                    "created_at": timestamp,
+                    "mtime_ns": stat.st_mtime_ns,
+                }
+                if run is None:
+                    item["reasons"] = ["unknown_run"]
+                    retained.append(item)
+                elif not bool(run["terminal_checkpoint"]):
+                    item["reasons"] = ["no_terminal_checkpoint"]
+                    retained.append(item)
+                elif timestamp >= cutoff:
+                    item["reasons"] = ["within_cache_retention"]
+                    retained.append(item)
+                else:
+                    item["reason"] = "expired_rebuildable_cache"
+                    candidates.append(item)
+        key = lambda value: (value["created_at"], value["path"])
+        return {
+            "candidates": sorted(candidates, key=key),
+            "retained": sorted(retained, key=key),
+        }
+
+    @staticmethod
+    def _retained_gc_summary(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        grouped: dict[tuple[str, tuple[str, ...]], dict[str, Any]] = {}
+        for value in values:
+            reasons = tuple(str(item) for item in value.get("reasons", ()))
+            key = (str(value["kind"]), reasons)
+            group = grouped.setdefault(
+                key,
+                {
+                    "kind": key[0],
+                    "reasons": list(reasons),
+                    "records": 0,
+                    "bytes": 0,
+                },
+            )
+            group["records"] += 1
+            group["bytes"] += int(value["bytes"])
+        return sorted(
+            grouped.values(), key=lambda value: (value["kind"], value["reasons"])
+        )
+
+    def storage_gc(
+        self, *, repository: str = "", apply: bool = False
+    ) -> dict[str, Any]:
+        normalized = repository.casefold()
+        if normalized:
+            self.policy(normalized)
+        now = datetime.now(UTC)
+        cache_cutoff = (
+            now - timedelta(days=self.config.storage.cache_retention_days)
+        ).isoformat()
+        retention_cutoffs = {
+            policy.name.casefold(): (
+                now - timedelta(days=policy.event_payload_retention_days)
+            ).isoformat()
+            for policy in self.config.repositories.values()
+            if policy.event_payload_retention_days is not None
+        }
+        logs = self._verification_log_gc_inventory(
+            repository=normalized, cutoff=cache_cutoff
+        )
+        payloads = self.store.event_payload_gc_inventory(retention_cutoffs)
+
+        def in_scope(value: dict[str, Any]) -> bool:
+            repositories = value.get("repositories", ())
+            return not normalized or normalized in repositories
+
+        payload_candidates = [
+            value for value in payloads["candidates"] if in_scope(value)
+        ]
+        payload_retained = [value for value in payloads["retained"] if in_scope(value)]
+        candidates = [*logs["candidates"], *payload_candidates]
+        candidates.sort(
+            key=lambda value: (
+                value["created_at"],
+                value["kind"],
+                str(value.get("path") or value.get("digest")),
+            )
+        )
+        retained = [*logs["retained"], *payload_retained]
+        if len(candidates) > self.config.storage.max_gc_items:
+            for value in candidates[self.config.storage.max_gc_items :]:
+                retained.append({**value, "reasons": ["gc_item_limit"]})
+            candidates = candidates[: self.config.storage.max_gc_items]
+        generated_at = now.isoformat()
+        plan_material = {
+            "repository": normalized,
+            "generated_at": generated_at,
+            "cache_cutoff": cache_cutoff,
+            "retention_cutoffs": retention_cutoffs,
+            "candidates": candidates,
+        }
+        plan_digest = hashlib.sha256(
+            json.dumps(
+                plan_material,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+        result: dict[str, Any] = {
+            **plan_material,
+            "plan_digest": plan_digest,
+            "dry_run": not apply,
+            "candidate_count": len(candidates),
+            "estimated_reclaimable_bytes": sum(
+                int(value["bytes"]) for value in candidates
+            ),
+            "retained_summary": self._retained_gc_summary(retained),
+            "protected_categories": [
+                "checkpoint",
+                "github_event_index",
+                "merge_decision_audit",
+                "storage_gc_audit",
+            ],
+            "public_write": False,
+        }
+        if not apply:
+            return result
+        if os.environ.get("REPOSTEWARD_ENABLE_GC") != "1":
+            raise PolicyError(
+                "storage GC apply is disabled; set REPOSTEWARD_ENABLE_GC=1"
+            )
+        applying = self.store.record_storage_gc(
+            repository=normalized,
+            actor=self.config.github.login,
+            stage="applying",
+            plan_digest=plan_digest,
+            payload=result,
+        )
+        deleted_logs = []
+        skipped_logs = []
+        fresh_safety = self.store.run_gc_safety()
+        state_root = self.config.state_dir.resolve()
+        runs_root = state_root / "runs"
+        for value in candidates:
+            if value["kind"] != "verification_log_cache":
+                continue
+            path = state_root / str(value["path"])
+            run = fresh_safety.get(str(value["run_id"]))
+            try:
+                if (
+                    path.is_symlink()
+                    or path.suffix != ".log"
+                    or not path.resolve().is_relative_to(runs_root)
+                    or run is None
+                    or not bool(run["terminal_checkpoint"])
+                ):
+                    raise OSError("log no longer satisfies GC policy")
+                stat = path.stat()
+                if stat.st_mtime_ns != int(value["mtime_ns"]):
+                    raise OSError("log changed after planning")
+                path.unlink()
+                deleted_logs.append(value)
+            except OSError as exc:
+                skipped_logs.append({"path": value["path"], "reason": str(exc)})
+        payload_result = self.store.delete_event_payloads(
+            tuple(
+                str(value["digest"])
+                for value in candidates
+                if value["kind"] == "github_event_payload"
+            ),
+            retention_cutoffs=retention_cutoffs,
+        )
+        applied = {
+            "deleted_logs": deleted_logs,
+            "skipped_logs": skipped_logs,
+            "deleted_event_payloads": payload_result["deleted"],
+            "skipped_event_payloads": payload_result["skipped"],
+        }
+        completed = self.store.record_storage_gc(
+            repository=normalized,
+            actor=self.config.github.login,
+            stage="completed",
+            plan_digest=plan_digest,
+            payload=applied,
+        )
+        return {**result, "audit": [applying, completed], "applied": applied}
 
     def follow_up(self, run_id: str) -> dict[str, Any]:
         """Return only GitHub activity that changed since the previous check."""

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -94,6 +94,10 @@ pids_limit = 1024
 max_output_chars = 12000
 passed_output_chars = 2000
 max_log_chars = 2000000
+
+[storage]
+cache_retention_days = 30
+max_gc_items = 1000
 """
 
 

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -301,6 +301,23 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         """
         CREATE INDEX IF NOT EXISTS github_pr_watermarks_for_pull
         ON github_pr_watermarks(repository, pull_number, sequence)
+        """,
+    ),
+    9: (
+        """
+        CREATE TABLE IF NOT EXISTS storage_gc_runs (
+            id TEXT PRIMARY KEY,
+            repository TEXT NOT NULL DEFAULT '',
+            actor TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            plan_digest TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS storage_gc_runs_recent
+        ON storage_gc_runs(created_at DESC)
         """,
     ),
 }
@@ -1329,6 +1346,18 @@ class Store:
                 GROUP BY repository
                 """,
             ),
+            (
+                "storage_gc_audit",
+                """
+                SELECT CASE WHEN repository='' THEN '*' ELSE repository END AS repository,
+                       COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM storage_gc_runs
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
         )
         result: list[dict[str, Any]] = []
         parameters = (repository, repository, cutoff, cutoff)
@@ -1353,6 +1382,73 @@ class Store:
         with self._connection() as connection:
             rows = connection.execute("SELECT id, repository FROM runs").fetchall()
         return {str(row["id"]): str(row["repository"]) for row in rows}
+
+    def run_gc_safety(self) -> dict[str, dict[str, Any]]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT r.id, r.repository,
+                       EXISTS(
+                           SELECT 1 FROM checkpoints c
+                           WHERE c.run_id=r.id
+                             AND c.status IN ('ready', 'submitted', 'failed')
+                       ) AS terminal_checkpoint
+                FROM runs r
+                """
+            ).fetchall()
+        return {
+            str(row["id"]): {
+                "repository": str(row["repository"]),
+                "terminal_checkpoint": bool(row["terminal_checkpoint"]),
+            }
+            for row in rows
+        }
+
+    def record_storage_gc(
+        self,
+        *,
+        repository: str,
+        actor: str,
+        stage: str,
+        plan_digest: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        if stage not in {"applying", "completed"}:
+            raise ValueError("storage GC stage must be applying or completed")
+        record_id = uuid.uuid4().hex
+        created_at = utc_now()
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO storage_gc_runs(
+                    id, repository, actor, stage, plan_digest, payload, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record_id,
+                    repository.casefold(),
+                    actor,
+                    stage,
+                    plan_digest,
+                    _canonical_json(payload),
+                    created_at,
+                ),
+            )
+        return {"id": record_id, "stage": stage, "created_at": created_at}
+
+    def storage_gc_runs(self, *, limit: int = 30) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 100)
+        with self._connection() as connection:
+            rows = connection.execute(
+                "SELECT * FROM storage_gc_runs ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = dict(row)
+            value["payload"] = json.loads(value["payload"])
+            result.append(value)
+        return result
 
     @staticmethod
     def _event_payload_gc_inventory(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,6 +108,9 @@ require_verification = true
 [runner]
 cpus = 2
 image = "trusted-runner:latest"
+[storage]
+cache_retention_days = 45
+max_gc_items = 500
 [agent]
 harness = "codex-cli"
 executable = "codex"
@@ -132,6 +135,9 @@ project_owner = "mallory"
 project_number = 99
 project_owner_type = "organization"
 require_distinct_reviewer = false
+[storage]
+cache_retention_days = 1
+max_gc_items = 10000
 [safety]
 max_diff_lines = 500
 require_verification = false
@@ -160,6 +166,8 @@ event_payload_retention_days = 45
         self.assertEqual(config.runner.image, "trusted-runner:latest")
         self.assertEqual(config.agent.harness, "codex-cli")
         self.assertEqual(config.agent.executable, "codex")
+        self.assertEqual(config.storage.cache_retention_days, 45)
+        self.assertEqual(config.storage.max_gc_items, 500)
         self.assertEqual(config.issue_review.project_owner, "")
         self.assertEqual(config.issue_review.project_number, 0)
         self.assertTrue(config.issue_review.require_distinct_reviewer)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -39,6 +39,8 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(parsed["issue_review"]["project_owner"], "")
         self.assertEqual(parsed["issue_review"]["project_number"], 0)
         self.assertTrue(parsed["issue_review"]["require_distinct_reviewer"])
+        self.assertEqual(parsed["storage"]["cache_retention_days"], 30)
+        self.assertEqual(parsed["storage"]["max_gc_items"], 1000)
         self.assertEqual(
             parsed["project"]["state_dir"], str(root / "state" / "reposteward")
         )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,9 +5,11 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from reposteward.config import RepositoryPolicy
+from reposteward.config import RepositoryPolicy, StorageConfig
 from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
 
 
 class StubStore:
@@ -61,3 +63,91 @@ class StorageStatisticsTests(unittest.TestCase):
         pipeline = object.__new__(Pipeline)
         with self.assertRaisesRegex(ValueError, "between 0 and 36500"):
             pipeline.storage_statistics(since_days=-1)
+
+
+class GcStore:
+    def __init__(self) -> None:
+        self.audit: list[str] = []
+        self.payload_deleted = False
+
+    def run_gc_safety(self) -> dict[str, dict]:
+        return {"run-1": {"repository": "owner/repo", "terminal_checkpoint": True}}
+
+    def event_payload_gc_inventory(self, _cutoffs: dict[str, str]) -> dict:
+        if self.payload_deleted:
+            return {"candidates": [], "retained": []}
+        return {
+            "candidates": [
+                {
+                    "kind": "github_event_payload",
+                    "digest": "a" * 64,
+                    "bytes": 7,
+                    "created_at": "2020-01-01T00:00:00+00:00",
+                    "repositories": ["owner/repo"],
+                    "reference_count": 1,
+                    "reason": "explicit_retention_elapsed_and_checkpointed",
+                }
+            ],
+            "retained": [],
+        }
+
+    def delete_event_payloads(
+        self, digests: tuple[str, ...], *, retention_cutoffs: dict[str, str]
+    ) -> dict:
+        self.payload_deleted = True
+        return {
+            "deleted": [{"digest": digests[0], "bytes": 7}],
+            "skipped": [],
+        }
+
+    def record_storage_gc(self, *, stage: str, **_kwargs) -> dict:
+        self.audit.append(stage)
+        return {"id": f"audit-{len(self.audit)}", "stage": stage}
+
+
+class StorageGcTests(unittest.TestCase):
+    def pipeline(self, root: Path) -> tuple[Pipeline, GcStore, Path]:
+        verification = root / "runs" / "run-1" / "verification"
+        verification.mkdir(parents=True)
+        log = verification / "command.log"
+        log.write_bytes(b"12345")
+        os.utime(log, (1, 1))
+        policy = RepositoryPolicy(name="owner/repo", event_payload_retention_days=30)
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            state_dir=root,
+            storage=StorageConfig(cache_retention_days=30, max_gc_items=10),
+            repositories={"owner/repo": policy},
+            github=SimpleNamespace(login="operator"),
+        )
+        store = GcStore()
+        pipeline.store = store
+        return pipeline, store, log
+
+    def test_gc_defaults_to_exact_read_only_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pipeline, store, log = self.pipeline(Path(directory))
+
+            result = pipeline.storage_gc(repository="Owner/Repo")
+
+            self.assertTrue(log.exists())
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["candidate_count"], 2)
+        self.assertEqual(result["estimated_reclaimable_bytes"], 12)
+        self.assertEqual(store.audit, [])
+        self.assertIn("merge_decision_audit", result["protected_categories"])
+
+    def test_gc_apply_requires_switch_then_audits_and_deletes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pipeline, store, log = self.pipeline(Path(directory))
+            with self.assertRaisesRegex(PolicyError, "ENABLE_GC"):
+                pipeline.storage_gc(repository="owner/repo", apply=True)
+            self.assertTrue(log.exists())
+
+            with patch.dict("os.environ", {"REPOSTEWARD_ENABLE_GC": "1"}):
+                result = pipeline.storage_gc(repository="owner/repo", apply=True)
+
+            self.assertFalse(log.exists())
+        self.assertEqual(store.audit, ["applying", "completed"])
+        self.assertEqual(len(result["applied"]["deleted_logs"]), 1)
+        self.assertEqual(len(result["applied"]["deleted_event_payloads"]), 1)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -317,6 +317,38 @@ class StoreTests(unittest.TestCase):
             self.assertIsNotNone(table)
             self.assertIsNotNone(index)
 
+    def test_version_eight_database_receives_append_only_gc_audit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE storage_gc_runs")
+                connection.execute("PRAGMA user_version=8")
+
+            store = Store(path)
+            first = store.record_storage_gc(
+                repository="owner/repo",
+                actor="operator",
+                stage="applying",
+                plan_digest="a" * 64,
+                payload={"candidates": ["blob"]},
+            )
+            second = store.record_storage_gc(
+                repository="owner/repo",
+                actor="operator",
+                stage="completed",
+                plan_digest="a" * 64,
+                payload={"deleted": ["blob"]},
+            )
+            records = store.storage_gc_runs()
+            schema_version = store.schema_version()
+
+        self.assertEqual(schema_version, SCHEMA_VERSION)
+        self.assertNotEqual(first["id"], second["id"])
+        self.assertEqual(
+            [value["stage"] for value in records], ["completed", "applying"]
+        )
+
     def test_event_payload_gc_requires_retention_and_every_run_watermark(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")


### PR DESCRIPTION
## 关联 Issue

Closes #10

## 问题与改动

本 PR 完成安全 GC 的用户入口与审计闭环：

- 新增 `reposteward storage gc [--repo] [--apply]`，默认只输出精确、受上限约束的 dry-run 计划。
- 真正删除必须同时提供 `--apply` 与环境变量 `REPOSTEWARD_ENABLE_GC=1`，避免误操作和无人值守误删。
- 新增仅归用户配置所有的 `storage.cache_retention_days` 与 `storage.max_gc_items`；项目配置不能缩短本机缓存保留期。
- 验证日志只有在超过保留期且对应 run 已到终态时才成为候选；执行前重新校验路径位于状态目录内、不是符号链接且修改时间未变化。
- GitHub 事件正文复用前置 PR 的事务内资格复核与 tombstone 机制；状态变化时跳过，不使用过期计划删除。
- schema v9 新增 append-only `storage_gc_runs` 审计记录。apply 会先写入 `applying` 意图，再执行删除并追加 `completed` 结果；中断后仍可追查。
- 保留原因按类别汇总，候选列表受 `max_gc_items` 限制，避免大状态库输出和上下文无界增长；不会执行 `VACUUM`。
- checkpoint、轻量事件索引、Merge Decision 与 GC 审计均不属于清理对象。

## 验证

隔离 Runner 中执行，137 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

另使用当前真实本地状态执行了默认 dry-run：没有产生候选，也没有写数据库或删除文件；输出汇总显示 40 个验证日志（152,520 bytes）仍在保留期内。

## 风险与兼容性

包含 SQLite schema v8 → v9 前向迁移，只新增 GC 审计表。dry-run 无写入；apply 是本地破坏性操作，因此采用双重显式门槛、候选上限、执行时复核和 append-only 意图审计。日志文件删除与 SQLite 事务不能原子提交，但 `applying` 记录先落盘，重复执行幂等；事件 Blob 删除保持单事务。删除 Blob 后页面可由 SQLite 复用，但本 PR 不通过 `VACUUM` 立即缩小数据库文件。

性能上，日志规划对日志文件线性扫描；事件正文规划使用已有索引和聚合查询，不进行逐事件相关查询。默认候选上限为 1,000，配置最大允许 10,000。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了完整 diff、默认 dry-run、配置所有权、双重 apply 门槛、路径与 mtime 竞态、事务内资格复核、中断审计、幂等性、受限输出和查询复杂度。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
