### PR TITLE
feat(contributor): publish guarded reviewer repairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ REPOSTEWARD_ENABLE_SUBMIT=1 \
 
 ```bash
 uv run reposteward follow-up RUN_ID
+uv run reposteward repair RUN_ID
 uv run reposteward merge-decision RUN_ID
 ```
 
@@ -304,6 +305,13 @@ uv run reposteward merge-decision RUN_ID
 不再把每类前 100 条当成完整历史。GitHub 结构化事件是跟进事实，模型摘要只是可重建的派生信息；
 评论和 Review 正文始终视为不可信数据，不会被自动执行。重复调用是幂等的，事件摄取与水位推进
 分离，进程在生成 Checkpoint 前中断时不会丢失待处理事件。
+
+Contributor fork 收到新的失败 check、Reviewer 正文或 diff 内行级评论后，可以对最近一次
+`submitted` run 执行 `repair`。命令先按水位读取增量并做确定性范围判断：没有新增可执行信息、
+只有成功 check，或只有指向当前 diff 之外路径的建议时不会调用 Harness。确需理解代码时，Harness
+只收到受限事件批次和最近 Checkpoint，在原 worktree 修改；Runner 重新验证后生成新的本地 `ready`
+commit。更新已有 PR 仍必须再次执行带 `--reviewed-by` 的 `submit`。准备后若 head、base、策略或
+事件水位变化，旧修复会被拒绝。该流程不会自动回复、催促 Reviewer 或合并 upstream PR。
 
 `merge-decision` 只读获取完整的 changed files、required checks、Review decision 和未解决会话，
 再对照验证时冻结的 head、base、policy digest、规模上限及高风险路径生成确定性结果。每次调用都会

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,12 @@ PR 跟进以 GitHub 的结构化事件为唯一真相。`follow-up` 完整遍历
 派生信息，不能覆盖事件，也不能直接授权 push、回复或 merge。原始评论和 Review 正文始终标记为
 外部不可信输入。
 
+Contributor 修复循环消费一个已提交 run 的下一批事件。确定性规划先排除重复轮询、非失败 check
+和指向原 PR diff 之外路径的建议；只有剩余反馈需要理解代码时才创建 successor run 并调用 Harness。
+successor 从已提交水位开始，避免重新注入完整 PR 历史。修复通过相同隔离 Runner 与 diff 策略后只
+进入本地 `ready` 状态；每个新 commit 都需要新的 submit 身份确认。准备时冻结 head、base、policy
+digest、事件水位和完整 GitHub 结构化快照，公开 push 前逐项复核，任一变化都使准备失效。
+
 Merge Decision Engine 位于执行器之前。它完整分页读取 GitHub 结构化状态，并以纯函数检查已验证
 head/base、策略摘要、审批、required checks、未解决会话、规模和不可削弱的高风险路径。结果只表示
 当前快照是否具备资格，不执行 merge，也不以 Harness 推理替代确定性事实。任何不完整快照都失败
@@ -148,5 +154,5 @@ uv run reposteward context import handoff.json
 ## 后续优先级
 
 1. 增加 Claude Code 与 DeepSeek 适配器，并运行同一契约测试套件。
-2. 为增量 reviewer feedback 增加统一 token 预算、内容去重和 Contributor 修复闭环。
-3. 增加 context redaction、分层保留期限、安全 GC 和跨机器加密导出策略。
+2. 为增量 reviewer feedback 增加统一 token 预算与内容去重。
+3. 增加 context redaction 和跨机器加密导出策略。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -195,6 +195,12 @@ def _parser() -> argparse.ArgumentParser:
     )
     follow_up.add_argument("run_id")
 
+    repair = subparsers.add_parser(
+        "repair",
+        help="prepare and verify one contributor repair from new PR activity",
+    )
+    repair.add_argument("run_id", help="submitted run whose pull request changed")
+
     merge_decision = subparsers.add_parser(
         "merge-decision", help="evaluate and audit read-only PR merge eligibility"
     )
@@ -426,6 +432,9 @@ def main(argv: list[str] | None = None) -> int:
             raise AssertionError(f"unhandled storage command: {args.storage_command}")
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
+            return 0
+        if args.command == "repair":
+            _json(pipeline.prepare_repair(args.run_id))
             return 0
         if args.command == "merge-decision":
             _json(pipeline.merge_decision(args.run_id))

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -1543,7 +1543,11 @@ class Pipeline:
         return result
 
     def _commit_repair_event_preview(
-        self, source_run: dict[str, Any], preview: dict[str, Any]
+        self,
+        source_run: dict[str, Any],
+        preview: dict[str, Any],
+        *,
+        suggestions: tuple[dict[str, Any], ...] = (),
     ) -> dict[str, Any]:
         committed = self.store.commit_github_follow_up(
             run_id=str(source_run["id"]),
@@ -1557,6 +1561,7 @@ class Pipeline:
         details = {
             **source_run.get("details", {}),
             "github_snapshot": preview["_github_snapshot"],
+            "repair_suggestions": list(suggestions),
         }
         self.store.update_run(
             str(source_run["id"]),
@@ -1615,7 +1620,9 @@ class Pipeline:
         changed_files = tuple(str(value) for value in details.get("changed_files", ()))
         repair_items, suggestions = _repair_feedback(follow, changed_files)
         if not repair_items:
-            self._commit_repair_event_preview(source_run, follow)
+            self._commit_repair_event_preview(
+                source_run, follow, suggestions=suggestions
+            )
             return {
                 "source_run_id": source_run_id,
                 "repair_prepared": False,
@@ -1805,7 +1812,9 @@ class Pipeline:
                 sequence=int(follow["event_watermark"]),
                 batch_digest=str(follow["event_batch_digest"]),
             )
-            self._commit_repair_event_preview(source_run, follow)
+            self._commit_repair_event_preview(
+                source_run, follow, suggestions=suggestions
+            )
             self._save_checkpoint(
                 context,
                 status="ready",
@@ -1857,6 +1866,57 @@ class Pipeline:
                 details={**failure_details, "error": str(exc)},
             )
             raise
+
+    def _validate_repair_submission(
+        self,
+        *,
+        client: GitHubClient,
+        policy: RepositoryPolicy,
+        details: dict[str, Any],
+    ) -> None:
+        """Reject a prepared repair when any frozen publication fact changed."""
+        guard = details.get("repair_guard")
+        if not isinstance(guard, dict):
+            return
+        if policy.mode != "contributor" or policy.submission_strategy != "fork":
+            raise PolicyError("prepared contributor repair has an invalid policy mode")
+        source_run_id = str(guard.get("source_run_id") or "")
+        source_run = self.store.run(source_run_id)
+        if source_run is None or str(source_run.get("status")) != "submitted":
+            raise PolicyError("prepared repair source run is unavailable")
+        pull_number = int(guard.get("pull_number") or 0)
+        activity = client.pull_request_activity(policy.name, pull_number)
+        event_batch = self.store.ingest_github_pr_activity(
+            run_id=source_run_id,
+            repository=policy.name,
+            pull_number=pull_number,
+            activity=activity,
+        )
+        snapshot = client.pull_request_merge_snapshot(policy.name, pull_number)
+        pull = activity["pull_request"]
+        expected_sequence = int(guard.get("event_watermark") or 0)
+        stale: list[str] = []
+        if (
+            int(event_batch["previous_sequence"]) != expected_sequence
+            or int(event_batch["through_sequence"]) != expected_sequence
+        ):
+            stale.append("event_watermark")
+        if str(pull.get("head_sha") or "") != str(guard.get("parent_commit") or ""):
+            stale.append("head")
+        if str(pull.get("base_branch") or "") != str(guard.get("base_branch") or ""):
+            stale.append("base_branch")
+        if str(snapshot.get("base_sha") or "") != str(guard.get("base_sha") or ""):
+            stale.append("base")
+        if repository_policy_digest(policy) != str(guard.get("policy_digest") or ""):
+            stale.append("policy")
+        if _canonical_digest(snapshot) != str(guard.get("snapshot_digest") or ""):
+            stale.append("github_snapshot")
+        if stale:
+            raise PolicyError(
+                "prepared repair is stale ("
+                + ", ".join(dict.fromkeys(stale))
+                + "); run follow-up and prepare a new repair"
+            )
 
     def merge_decision(self, run_id: str) -> dict[str, Any]:
         """Evaluate and audit current merge eligibility without writing to GitHub."""
@@ -2001,6 +2061,10 @@ class Pipeline:
         )
         closed_pull = None
         if reopen_pull_request:
+            if isinstance(details.get("repair_guard"), dict):
+                raise PolicyError(
+                    "a prepared repair cannot reopen another pull request"
+                )
             closed_pull = client.pull_request(policy.name, reopen_pull_request)
             if closed_pull.state != "closed":
                 raise PolicyError(
@@ -2048,6 +2112,19 @@ class Pipeline:
                 owner=head_owner,
                 branch=details["branch"],
             )
+            repair_guard = details.get("repair_guard")
+            if isinstance(repair_guard, dict):
+                if existing_pull is None or existing_pull.number != int(
+                    repair_guard.get("pull_number") or 0
+                ):
+                    raise PolicyError(
+                        "prepared repair no longer matches its original pull request"
+                    )
+                self._validate_repair_submission(
+                    client=client,
+                    policy=policy,
+                    details=details,
+                )
             if existing_pull:
                 if existing_pull.base_branch != details["base_branch"]:
                     raise PolicyError(

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -14,8 +14,8 @@ from reposteward.models import (
     AgentResult,
     VerificationResult,
 )
-from reposteward.pipeline import Pipeline
-from reposteward.policy import DiffSummary
+from reposteward.pipeline import Pipeline, _canonical_digest, _repair_feedback
+from reposteward.policy import DiffSummary, PolicyError
 
 
 def _follow(**extra: object) -> dict:
@@ -43,6 +43,35 @@ def _follow(**extra: object) -> dict:
 
 
 class RepairTests(unittest.TestCase):
+    def test_out_of_scope_feedback_is_persisted_as_a_suggestion(self) -> None:
+        actionable, suggestions = _repair_feedback(
+            _follow(
+                new_review_comments=[
+                    {"id": 1, "path": "docs/other.md", "body": "rewrite"}
+                ]
+            ),
+            ("src/example.py",),
+        )
+        pipeline = object.__new__(Pipeline)
+        pipeline.store = Mock()
+        pipeline.store.commit_github_follow_up.return_value = {"sequence": 9}
+        source = {
+            "id": "source",
+            "repository": "owner/repo",
+            "status": "submitted",
+            "stage": "pull_request",
+            "worktree": "/tmp/worktree",
+            "details": {},
+        }
+
+        pipeline._commit_repair_event_preview(
+            source, _follow(), suggestions=suggestions
+        )
+
+        self.assertEqual(actionable, ())
+        saved = pipeline.store.update_run.call_args.kwargs["details"]
+        self.assertEqual(saved["repair_suggestions"][0]["id"], 1)
+
     def test_no_new_activity_does_not_start_a_run_or_harness(self) -> None:
         pipeline = object.__new__(Pipeline)
         pipeline.config = SimpleNamespace(
@@ -165,3 +194,75 @@ class RepairTests(unittest.TestCase):
         harness.run.assert_called_once()
         pipeline.verifier.verify.assert_called_once()
         store.commit_github_follow_up.assert_called_once()
+
+
+class RepairSubmissionTests(unittest.TestCase):
+    def test_submission_guard_fails_when_events_change(self) -> None:
+        policy = RepositoryPolicy(name="owner/repo")
+        snapshot = {"head_sha": "a" * 40, "base_sha": "b" * 40}
+        guard = {
+            "source_run_id": "source",
+            "pull_number": 12,
+            "parent_commit": "a" * 40,
+            "base_sha": "b" * 40,
+            "base_branch": "main",
+            "policy_digest": repository_policy_digest(policy),
+            "event_watermark": 9,
+            "snapshot_digest": _canonical_digest(snapshot),
+        }
+        pipeline = object.__new__(Pipeline)
+        pipeline.store = Mock()
+        pipeline.store.run.return_value = {"status": "submitted"}
+        pipeline.store.ingest_github_pr_activity.return_value = {
+            "previous_sequence": 9,
+            "through_sequence": 9,
+        }
+        client = Mock()
+        client.pull_request_activity.return_value = {
+            "pull_request": {"head_sha": "a" * 40, "base_branch": "main"}
+        }
+        client.pull_request_merge_snapshot.return_value = snapshot
+
+        pipeline._validate_repair_submission(
+            client=client, policy=policy, details={"repair_guard": guard}
+        )
+        pipeline.store.ingest_github_pr_activity.return_value["through_sequence"] = 10
+
+        with self.assertRaisesRegex(PolicyError, "event_watermark"):
+            pipeline._validate_repair_submission(
+                client=client, policy=policy, details={"repair_guard": guard}
+            )
+
+    def test_submission_guard_fails_when_snapshot_changes(self) -> None:
+        policy = RepositoryPolicy(name="owner/repo")
+        snapshot = {"head_sha": "a" * 40, "base_sha": "b" * 40}
+        pipeline = object.__new__(Pipeline)
+        pipeline.store = Mock()
+        pipeline.store.run.return_value = {"status": "submitted"}
+        pipeline.store.ingest_github_pr_activity.return_value = {
+            "previous_sequence": 9,
+            "through_sequence": 9,
+        }
+        client = Mock()
+        client.pull_request_activity.return_value = {
+            "pull_request": {"head_sha": "a" * 40, "base_branch": "main"}
+        }
+        client.pull_request_merge_snapshot.return_value = {
+            **snapshot,
+            "review_decision": "CHANGES_REQUESTED",
+        }
+        guard = {
+            "source_run_id": "source",
+            "pull_number": 12,
+            "parent_commit": "a" * 40,
+            "base_sha": "b" * 40,
+            "base_branch": "main",
+            "policy_digest": repository_policy_digest(policy),
+            "event_watermark": 9,
+            "snapshot_digest": _canonical_digest(snapshot),
+        }
+
+        with self.assertRaisesRegex(PolicyError, "github_snapshot"):
+            pipeline._validate_repair_submission(
+                client=client, policy=policy, details={"repair_guard": guard}
+            )


### PR DESCRIPTION
## 关联 Issue

Closes #13

## 问题与改动

本 PR 完成 Contributor Reviewer 修复闭环的公开入口和最终写入门禁：

- 新增 `reposteward repair RUN_ID`，只准备并验证本地 successor commit，不进行 GitHub 写操作。
- diff 外行级反馈作为 `repair_suggestions` 持久保存；没有可执行反馈时保持零 Harness 调用。
- 每个 repair commit 仍停留在 `ready`，更新 fork PR 必须重新执行 `REPOSTEWARD_ENABLE_SUBMIT=1 ... submit --reviewed-by ...`，旧确认不能复用。
- repair submit 只允许更新 guard 中冻结的原 PR；原 PR 不存在、编号不匹配或试图通过 `--reopen` 改写其他 PR 时拒绝。
- push 前紧邻执行时重新读取完整 GitHub 事实，核对事件水位、head、base branch/base SHA、policy digest 与完整 snapshot digest。
- 任一事实变化都会 fail closed；head 在最后检查后的竞态继续由 `--force-with-lease=<expected SHA>` 保护。
- 不自动回复或催促 Reviewer，不合并 upstream PR，也不引入后台服务。
- README 与架构文档补充用户流程、权限边界与失效语义。

## 验证

隔离 Runner 中执行，144 项测试通过：

```text
uv run python -m unittest discover -s tests -v
uv run ruff check .
uv run ruff format --check .
uv build --no-build-isolation
```

## 风险与兼容性

无数据库迁移。普通 prepare/adopt/submit 没有 `repair_guard` 时保持原行为。repair 是显式 Contributor/fork 路径；公开 push 仍经过原有环境开关、GitHub token 身份、人工 review attestation、clean HEAD 和 fork destination 门禁。校验会额外执行一次完整 merge snapshot 与增量 activity 读取，成本发生在低频人工 submit 前，不增加常驻轮询。

## 自动化辅助

使用 Codex 辅助实现和验证。人工复核了完整 diff、原 PR 精确匹配、reopen 拒绝、suggestion 持久化、所有冻结事实的 fail-closed 校验、force-with-lease 竞态边界和普通 submit 兼容性。

## Checklist

- [x] PR 只解决一个已讨论 Issue 的最终发布门禁。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建。
- [x] 新行为有回归测试。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
