### PR TITLE
perf(context): bound incremental repair inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,17 @@ uv run reposteward merge-decision RUN_ID
 Contributor fork 收到新的失败 check、Reviewer 正文或 diff 内行级评论后，可以对最近一次
 `submitted` run 执行 `repair`。命令先按水位读取增量并做确定性范围判断：没有新增可执行信息、
 只有成功 check，或只有指向当前 diff 之外路径的建议时不会调用 Harness。确需理解代码时，Harness
-只收到受限事件批次和最近 Checkpoint，在原 worktree 修改；Runner 重新验证后生成新的本地 `ready`
+只收到统一 token 预算内的事件批次、相关 diff 片段和紧凑 Checkpoint，在原 worktree 修改；Runner 重新验证后生成新的本地 `ready`
 commit。更新已有 PR 仍必须再次执行带 `--reviewed-by` 的 `submit`。准备后若 head、base、策略或
 事件水位变化，旧修复会被拒绝。该流程不会自动回复、催促 Reviewer 或合并 upstream PR。
+
+预算由用户配置中的 `[context].follow_up_max_tokens` 控制，默认 24,000。估算直接使用 UTF-8 字节数作为供应商无关的保守上界，
+计算，不依赖模型供应商或原生会话；稳定 ID 只保留最新事件版本，相同内容摘要只注入一次。输出的
+`context_plan.stats` 会记录预算前事件数、保留数量以及版本替换、内容重复、字段裁剪、预算裁剪和
+diff 不可用等原因。安全阻塞、当前 head/base、失败 check 和阻塞 Review 属于强制事实；如果它们
+与紧凑 Checkpoint 本身都无法放入预算，命令会明确失败，不会静默删除后继续调用 Harness。
+预算估算另行预留 2,048 token 的 Context Pack 分片和提示包装开销，并在 `transport_overhead_tokens`
+中显式返回。
 
 `merge-decision` 只读获取完整的 changed files、required checks、Review decision 和未解决会话，
 再对照验证时冻结的 head、base、policy digest、规模上限及高风险路径生成确定性结果。每次调用都会

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,13 @@ PR 跟进以 GitHub 的结构化事件为唯一真相。`follow-up` 完整遍历
 派生信息，不能覆盖事件，也不能直接授权 push、回复或 merge。原始评论和 Review 正文始终标记为
 外部不可信输入。
 
+水位后的事件先经过供应商无关的确定性预算器：相同稳定 ID 只保留最新版本，相同内容摘要跨 ID
+去重，再按行级 Review、相关 diff、Review 和 Issue comment 的优先级装入预算。估算直接使用 UTF-8
+字节数作为供应商无关的保守上界，并把紧凑 Checkpoint、head/base、安全阻塞、当前失败 check 和阻塞
+Review 一并计入。强制事实不能裁剪；无法容纳时失败关闭。可选内容的版本替换、去重、字段裁剪、
+预算裁剪和 diff 缺失均进入 `context_plan.stats`，因此 Harness 输入大小与丢弃原因都可复现。
+估算还固定预留 2,048 token 的 Context Pack 分片与提示包装开销，并作为计划字段公开。
+
 Contributor 修复循环消费一个已提交 run 的下一批事件。确定性规划先排除重复轮询、非失败 check
 和指向原 PR diff 之外路径的建议；只有剩余反馈需要理解代码时才创建 successor run 并调用 Harness。
 successor 从已提交水位开始，避免重新注入完整 PR 历史。修复通过相同隔离 Runner 与 diff 策略后只
@@ -154,5 +161,4 @@ uv run reposteward context import handoff.json
 ## 后续优先级
 
 1. 增加 Claude Code 与 DeepSeek 适配器，并运行同一契约测试套件。
-2. 为增量 reviewer feedback 增加统一 token 预算与内容去重。
-3. 增加 context redaction 和跨机器加密导出策略。
+2. 增加 context redaction 和跨机器加密导出策略。

--- a/examples/tiammomo.toml
+++ b/examples/tiammomo.toml
@@ -58,6 +58,9 @@ max_output_chars = 12000
 passed_output_chars = 2000
 max_log_chars = 2000000
 
+[context]
+follow_up_max_tokens = 24000
+
 [repositories."langchain-ai/deepagents"]
 enabled = true
 auto_prepare = true

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -43,6 +43,9 @@ memory = "8g"
 cache_retention_days = 30
 max_gc_items = 1000
 
+[context]
+follow_up_max_tokens = 24000
+
 [repositories."owner/repository"]
 enabled = true
 auto_prepare = false

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -116,6 +116,11 @@ class StorageConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class ContextConfig:
+    follow_up_max_tokens: int = 24_000
+
+
+@dataclass(frozen=True, slots=True)
 class RepositoryPolicy:
     name: str
     enabled: bool = True
@@ -162,6 +167,7 @@ class AppConfig:
     agent: AgentConfig
     runner: RunnerConfig
     storage: StorageConfig
+    context: ContextConfig
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
 
 
@@ -309,6 +315,12 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
         result["storage"] = dict(user_storage)
     else:
         result.pop("storage", None)
+
+    user_context = user.get("context")
+    if isinstance(user_context, dict):
+        result["context"] = dict(user_context)
+    else:
+        result.pop("context", None)
 
     user_agent = user.get("agent")
     project_agent = project.get("agent")
@@ -551,6 +563,11 @@ def load_config(
         max_gc_items=int(storage_raw.get("max_gc_items", 1_000)),
     )
 
+    context_raw = _section(raw, "context")
+    context = ContextConfig(
+        follow_up_max_tokens=int(context_raw.get("follow_up_max_tokens", 24_000))
+    )
+
     repositories_raw = _section(raw, "repositories")
     repositories: dict[str, RepositoryPolicy] = {}
     for name, repo_value in repositories_raw.items():
@@ -657,6 +674,8 @@ def load_config(
         raise ConfigError("storage.cache_retention_days must be between 1 and 36500")
     if not 1 <= storage.max_gc_items <= 10_000:
         raise ConfigError("storage.max_gc_items must be between 1 and 10000")
+    if not 512 <= context.follow_up_max_tokens <= 100_000:
+        raise ConfigError("context.follow_up_max_tokens must be between 512 and 100000")
     if not agent.harness:
         raise ConfigError("agent.harness must not be empty")
     for repository in repositories.values():
@@ -721,5 +740,6 @@ def load_config(
         agent=agent,
         runner=runner,
         storage=storage,
+        context=context,
         repositories=repositories,
     )

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -22,8 +22,8 @@ MAX_HANDOFF_ITEM_CHARS = 500
 MAX_HANDOFF_NOTES_CHARS = 4_000
 MAX_HANDOFF_DECISIONS = 6
 MAX_HANDOFF_EVIDENCE_ITEMS = 8
-MAX_REPAIR_ITEMS = 16
-MAX_REPAIR_ITEM_CHARS = 1_200
+MAX_REPAIR_ITEMS = 96
+MAX_REPAIR_ITEM_CHARS = 1_900
 
 
 def _utc_now() -> str:
@@ -178,7 +178,7 @@ def _repository_skill_sources(worktree: Path) -> tuple[ContextSource, ...]:
     return tuple(sources)
 
 
-def _compact_handoff(checkpoint: dict[str, Any] | None) -> dict[str, Any] | None:
+def compact_checkpoint(checkpoint: dict[str, Any] | None) -> dict[str, Any] | None:
     if not checkpoint:
         return None
 
@@ -225,15 +225,15 @@ def _compact_handoff(checkpoint: dict[str, Any] | None) -> dict[str, Any] | None
             )
 
     notes = str(checkpoint.get("implementation_notes", ""))
+    prior_omitted = int(checkpoint.get("implementation_notes_omitted_chars", 0) or 0)
     return {
         "id": bounded_text(checkpoint.get("id", ""), 128),
         "status": bounded_text(checkpoint.get("status", ""), 64),
         "head_commit": bounded_text(checkpoint.get("head_commit", ""), 128),
         "completed": bounded_items("completed"),
         "implementation_notes": notes[:MAX_HANDOFF_NOTES_CHARS],
-        "implementation_notes_omitted_chars": max(
-            0, len(notes) - MAX_HANDOFF_NOTES_CHARS
-        ),
+        "implementation_notes_omitted_chars": prior_omitted
+        + max(0, len(notes) - MAX_HANDOFF_NOTES_CHARS),
         "tests_observed": bounded_items("tests_observed"),
         "risks": bounded_items("risks"),
         "remaining": bounded_items("remaining"),
@@ -269,7 +269,7 @@ def build_context_pack(
             "updated_at": issue.updated_at,
         }
     )
-    handoff = _compact_handoff(previous_checkpoint)
+    handoff = compact_checkpoint(previous_checkpoint)
     source_values = [
         ContextSource(
             kind="github_issue",
@@ -359,12 +359,20 @@ def build_repair_context_pack(
     head_commit: str,
     event_watermark: int,
     event_batch_digest: str,
-    repair_items: tuple[dict[str, Any], ...],
+    repair_context: dict[str, Any],
 ) -> ContextPack:
     """Build a bounded repair pack from one committed PR event batch."""
+    serialized_context = _canonical_json(repair_context)
+    chunk_chars = MAX_REPAIR_ITEM_CHARS - 32
+    chunks = tuple(
+        serialized_context[offset : offset + chunk_chars]
+        for offset in range(0, len(serialized_context), chunk_chars)
+    )
+    if not chunks or len(chunks) > MAX_REPAIR_ITEMS - 1:
+        raise ValueError("repair context exceeds context-pack record capacity")
     bounded_items = tuple(
-        _canonical_json(value)[:MAX_REPAIR_ITEM_CHARS]
-        for value in repair_items[:MAX_REPAIR_ITEMS]
+        f"context_plan_part={index:04d}/{len(chunks):04d}:{chunk}"
+        for index, chunk in enumerate(chunks, start=1)
     )
     base = build_context_pack(
         candidate,

--- a/src/reposteward/context_budget.py
+++ b/src/reposteward/context_budget.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any
+
+FOLLOW_UP_CONTEXT_SCHEMA_VERSION = 1
+MIN_FOLLOW_UP_TOKENS = 512
+MAX_FOLLOW_UP_TOKENS = 100_000
+MAX_EVENT_TEXT_CHARS = 600
+MAX_DIFF_SNIPPET_CHARS = 1_500
+MAX_SERIALIZED_CONTEXT_CHARS = 150_000
+CONTEXT_PACK_OVERHEAD_TOKENS = 2_048
+FAILED_CHECK_CONCLUSIONS = frozenset(
+    {"action_required", "cancelled", "failure", "stale", "timed_out"}
+)
+
+
+class ContextBudgetError(RuntimeError):
+    """Mandatory follow-up facts cannot be represented within the budget."""
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def estimate_tokens(value: object) -> int:
+    """Return a deterministic, vendor-neutral upper estimate based on UTF-8 bytes."""
+    encoded = (
+        value.encode("utf-8")
+        if isinstance(value, str)
+        else _canonical_json(value).encode("utf-8")
+    )
+    return max(1, len(encoded))
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _clip(value: object, limit: int) -> tuple[str, bool]:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text, False
+    return f"{text[:limit]}…", True
+
+
+def _content_identity(event_type: str, payload: dict[str, Any]) -> str:
+    if event_type == "check":
+        material = {
+            "name": payload.get("name"),
+            "status": payload.get("status"),
+            "conclusion": payload.get("conclusion"),
+        }
+    else:
+        material = {
+            "author": payload.get("author"),
+            "association": payload.get("association"),
+            "state": payload.get("state"),
+            "path": payload.get("path"),
+            "line": payload.get("line"),
+            "body": str(payload.get("body") or "").strip(),
+        }
+    return _digest({"event_type": event_type, "content": material})
+
+
+def _event_item(event: dict[str, Any], reasons: Counter[str]) -> dict[str, Any]:
+    payload = event["payload"]
+    event_type = str(event["event_type"])
+    item: dict[str, Any] = {
+        "kind": event_type,
+        "id": str(event["external_id"]),
+        "version_digest": str(event["version_digest"]),
+        "sequence": int(event["sequence"]),
+    }
+    for name, limit in (
+        ("author", 120),
+        ("association", 80),
+        ("state", 80),
+        ("path", 500),
+        ("url", 500),
+    ):
+        if payload.get(name) not in (None, ""):
+            item[name], clipped = _clip(payload[name], limit)
+            reasons["field_clipped"] += int(clipped)
+    if payload.get("line") is not None:
+        item["line"] = payload["line"]
+    body, clipped = _clip(payload.get("body"), MAX_EVENT_TEXT_CHARS)
+    if body:
+        item["body"] = body
+    reasons["event_body_clipped"] += int(clipped)
+    return item
+
+
+def _checkpoint_item(checkpoint: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not checkpoint:
+        return None
+
+    def text_value(name: str, limit: int) -> str:
+        return _clip(checkpoint.get(name), limit)[0]
+
+    def text_items(name: str) -> list[str]:
+        values = checkpoint.get(name)
+        if not isinstance(values, (list, tuple)):
+            return []
+        return [_clip(value, 80)[0] for value in values[:2]]
+
+    decisions = []
+    raw_decisions = checkpoint.get("decisions")
+    if isinstance(raw_decisions, (list, tuple)):
+        for value in raw_decisions[:1]:
+            if not isinstance(value, dict):
+                continue
+            evidence = value.get("evidence")
+            decisions.append(
+                {
+                    "statement": _clip(value.get("statement"), 120)[0],
+                    "rationale": _clip(value.get("rationale"), 160)[0],
+                    "evidence": [
+                        _clip(item, 80)[0]
+                        for item in (
+                            evidence[:2] if isinstance(evidence, (list, tuple)) else ()
+                        )
+                    ],
+                }
+            )
+
+    evidence_items = []
+    raw_evidence = checkpoint.get("evidence")
+    if isinstance(raw_evidence, (list, tuple)):
+        for value in raw_evidence[:2]:
+            if not isinstance(value, dict):
+                continue
+            evidence_items.append(
+                {
+                    "kind": _clip(value.get("kind"), 50)[0],
+                    "locator": _clip(value.get("locator"), 120)[0],
+                    "status": _clip(value.get("status"), 50)[0],
+                    "digest": _clip(value.get("digest"), 128)[0],
+                    "summary": _clip(value.get("summary"), 120)[0],
+                }
+            )
+    notes = str(checkpoint.get("implementation_notes") or "")
+    prior_omitted = int(checkpoint.get("implementation_notes_omitted_chars", 0) or 0)
+    return {
+        "id": text_value("id", 128),
+        "status": text_value("status", 64),
+        "head_commit": text_value("head_commit", 128),
+        "completed": text_items("completed"),
+        "implementation_notes": _clip(notes, 300)[0],
+        "implementation_notes_omitted_chars": prior_omitted + max(0, len(notes) - 300),
+        "tests_observed": text_items("tests_observed"),
+        "risks": text_items("risks"),
+        "remaining": text_items("remaining"),
+        "next_action": text_value("next_action", 160),
+        "blockers": text_items("blockers"),
+        "decisions": decisions,
+        "evidence": evidence_items,
+        "created_at": text_value("created_at", 64),
+    }
+
+
+def _fixed_estimate(plan: dict[str, Any]) -> int:
+    overhead = int(plan.get("transport_overhead_tokens", 0))
+    estimate = 0
+    for _ in range(4):
+        plan["estimated_tokens"] = estimate
+        current = estimate_tokens(plan) + overhead
+        if current == estimate:
+            return current
+        estimate = current
+    plan["estimated_tokens"] = estimate
+    return estimate_tokens(plan) + overhead
+
+
+def build_follow_up_context(
+    *,
+    activity: dict[str, Any],
+    events: list[dict[str, Any]],
+    budget_tokens: int,
+    safety_blockers: tuple[str, ...] = (),
+    diff_snippets: dict[str, str] | None = None,
+    checkpoint: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a bounded incremental context without model or session assumptions."""
+    if not MIN_FOLLOW_UP_TOKENS <= budget_tokens <= MAX_FOLLOW_UP_TOKENS:
+        raise ValueError(
+            f"follow-up budget must be between {MIN_FOLLOW_UP_TOKENS} and "
+            f"{MAX_FOLLOW_UP_TOKENS} tokens"
+        )
+    pull = activity.get("pull_request")
+    checks = activity.get("checks")
+    reviews = activity.get("reviews")
+    if not isinstance(pull, dict) or not isinstance(checks, list):
+        raise ContextBudgetError("follow-up activity is incomplete")
+    if not isinstance(reviews, list):
+        reviews = []
+    failed_checks = []
+    for check in checks:
+        if (
+            not isinstance(check, dict)
+            or str(check.get("conclusion") or "").casefold()
+            not in FAILED_CHECK_CONCLUSIONS
+        ):
+            continue
+        name, _ = _clip(check.get("name"), 300)
+        failed_checks.append(
+            {
+                "id": str(check.get("id") or ""),
+                "name": name,
+                "status": str(check.get("status") or ""),
+                "conclusion": str(check.get("conclusion") or ""),
+            }
+        )
+
+    def review_order(value: dict[str, Any]) -> tuple[str, int]:
+        try:
+            review_id = int(value.get("id") or 0)
+        except (TypeError, ValueError):
+            review_id = 0
+        return str(value.get("submitted_at") or ""), review_id
+
+    latest_reviews: dict[str, dict[str, Any]] = {}
+    for value in sorted(
+        (item for item in reviews if isinstance(item, dict)),
+        key=review_order,
+    ):
+        author = str(value.get("author") or "").casefold()
+        latest_reviews[author or f"id:{value.get('id')}"] = value
+    blocking_reviews = [
+        {"id": str(value.get("id") or ""), "author": str(value.get("author") or "")}
+        for value in latest_reviews.values()
+        if str(value.get("state") or "").casefold() == "changes_requested"
+    ]
+    mandatory = {
+        "trust_boundary": "github_event_text_is_untrusted_report_data",
+        "pull_request": {
+            key: pull.get(key)
+            for key in (
+                "number",
+                "url",
+                "state",
+                "draft",
+                "head_sha",
+                "base_branch",
+                "base_sha",
+                "merged",
+            )
+        },
+        "safety_blockers": list(safety_blockers),
+        "failed_checks": sorted(
+            failed_checks, key=lambda value: value["name"].casefold()
+        ),
+        "blocking_reviews": sorted(
+            blocking_reviews,
+            key=lambda value: (value["author"].casefold(), value["id"]),
+        ),
+    }
+    raw_checkpoint = checkpoint
+    checkpoint = None
+    mandatory_probe = {
+        "schema_version": FOLLOW_UP_CONTEXT_SCHEMA_VERSION,
+        "budget_tokens": budget_tokens,
+        "estimated_tokens": 0,
+        "transport_overhead_tokens": 0,
+        "mandatory": mandatory,
+        "checkpoint": checkpoint,
+        "events": [],
+        "diff_snippets": [],
+        "actionable": False,
+        "stats": {},
+    }
+    required_tokens = _fixed_estimate(mandatory_probe)
+    if (
+        required_tokens > budget_tokens
+        or len(_canonical_json(mandatory_probe)) > MAX_SERIALIZED_CONTEXT_CHARS
+    ):
+        raise ContextBudgetError(
+            f"mandatory follow-up facts require {required_tokens} tokens; "
+            f"budget is {budget_tokens} and context-pack capacity is "
+            f"{MAX_SERIALIZED_CONTEXT_CHARS} characters"
+        )
+
+    reasons: Counter[str] = Counter()
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for event in sorted(events, key=lambda value: int(value["sequence"])):
+        key = (str(event["event_type"]), str(event["external_id"]))
+        reasons["superseded_event_version"] += int(key in latest)
+        latest[key] = event
+    unique: list[dict[str, Any]] = []
+    content_seen: set[str] = set()
+    for event in sorted(
+        latest.values(), key=lambda value: int(value["sequence"]), reverse=True
+    ):
+        identity = _content_identity(str(event["event_type"]), event["payload"])
+        if identity in content_seen:
+            reasons["duplicate_event_content"] += 1
+            continue
+        content_seen.add(identity)
+        unique.append(event)
+
+    candidates: list[tuple[int, int, str, dict[str, Any]]] = []
+    relevant_paths: set[str] = set()
+    new_failed_checks: set[str] = set()
+    priorities = {"review_comment": 40, "review": 30, "issue_comment": 20}
+    reviewer_states_seen: set[str] = set()
+    for event in unique:
+        event_type = str(event["event_type"])
+        payload = event["payload"]
+        if event_type in {"pull_request", "check"}:
+            if (
+                event_type == "check"
+                and str(payload.get("conclusion") or "").casefold()
+                in FAILED_CHECK_CONCLUSIONS
+            ):
+                new_failed_checks.add(str(event["external_id"]))
+            reasons["deterministic_fact_only"] += 1
+            continue
+        if event_type == "review":
+            reviewer = str(payload.get("author") or "").casefold()
+            reviewer_key = reviewer or f"id:{event['external_id']}"
+            if reviewer_key in reviewer_states_seen:
+                reasons["superseded_reviewer_state"] += 1
+                continue
+            reviewer_states_seen.add(reviewer_key)
+        body = str(payload.get("body") or "").strip()
+        if (
+            event_type == "review"
+            and not body
+            and str(payload.get("state") or "").casefold() != "changes_requested"
+        ):
+            reasons["non_actionable_review"] += 1
+            continue
+        if event_type == "issue_comment" and not body:
+            reasons["non_actionable_comment"] += 1
+            continue
+        item = _event_item(event, reasons)
+        path = str(item.get("path") or "")
+        if path:
+            relevant_paths.add(path)
+        candidates.append(
+            (priorities.get(event_type, 10), int(event["sequence"]), "events", item)
+        )
+    for index, path in enumerate(sorted(relevant_paths)):
+        raw = (diff_snippets or {}).get(path)
+        if raw is None:
+            reasons["diff_snippet_unavailable"] += 1
+            continue
+        snippet, clipped = _clip(raw, MAX_DIFF_SNIPPET_CHARS)
+        reasons["diff_snippet_clipped"] += int(clipped)
+        candidates.append(
+            (35, -index, "diff_snippets", {"path": path, "snippet": snippet})
+        )
+    candidates.sort(key=lambda value: (-value[0], -value[1], _canonical_json(value[3])))
+
+    actionable_input_events = sum(
+        category == "events" for _priority, _sequence, category, _item in candidates
+    )
+    checkpoint = (
+        _checkpoint_item(raw_checkpoint)
+        if actionable_input_events or new_failed_checks
+        else None
+    )
+    mandatory_probe["checkpoint"] = checkpoint
+    mandatory_probe["transport_overhead_tokens"] = (
+        CONTEXT_PACK_OVERHEAD_TOKENS
+        if actionable_input_events or new_failed_checks
+        else 0
+    )
+    required_tokens = _fixed_estimate(mandatory_probe)
+    if (
+        required_tokens > budget_tokens
+        or len(_canonical_json(mandatory_probe)) > MAX_SERIALIZED_CONTEXT_CHARS
+    ):
+        raise ContextBudgetError(
+            f"mandatory follow-up facts require {required_tokens} tokens; "
+            f"budget is {budget_tokens} and context-pack capacity is "
+            f"{MAX_SERIALIZED_CONTEXT_CHARS} characters"
+        )
+
+    plan: dict[str, Any] = {
+        "schema_version": FOLLOW_UP_CONTEXT_SCHEMA_VERSION,
+        "budget_tokens": budget_tokens,
+        "estimated_tokens": 0,
+        "transport_overhead_tokens": mandatory_probe["transport_overhead_tokens"],
+        "mandatory": mandatory,
+        "checkpoint": checkpoint,
+        "events": [],
+        "diff_snippets": [],
+        "actionable": False,
+        "stats": {},
+    }
+    retained_order: list[str] = []
+    for _priority, _sequence, category, item in candidates:
+        if category == "diff_snippets" and not any(
+            value.get("path") == item["path"] for value in plan["events"]
+        ):
+            reasons["diff_without_retained_event"] += 1
+            continue
+        plan[category].append(item)
+        retained_order.append(category)
+        if _fixed_estimate(plan) > budget_tokens:
+            plan[category].pop()
+            retained_order.pop()
+            reasons["token_budget"] += 1
+        elif len(_canonical_json(plan)) > MAX_SERIALIZED_CONTEXT_CHARS:
+            plan[category].pop()
+            retained_order.pop()
+            reasons["context_pack_capacity"] += 1
+
+    plan["actionable"] = bool(plan["events"] or new_failed_checks)
+    plan["stats"] = {
+        "input_events": len(events),
+        "latest_event_versions": len(latest),
+        "actionable_input_events": actionable_input_events,
+        "retained_events": len(plan["events"]),
+        "retained_diff_snippets": len(plan["diff_snippets"]),
+        "new_failed_checks": len(new_failed_checks),
+        "trim_reasons": dict(
+            sorted((key, count) for key, count in reasons.items() if count)
+        ),
+    }
+    while (
+        _fixed_estimate(plan) > budget_tokens
+        or len(_canonical_json(plan)) > MAX_SERIALIZED_CONTEXT_CHARS
+    ) and retained_order:
+        category = retained_order.pop()
+        plan[category].pop()
+        plan["stats"][
+            "retained_events" if category == "events" else "retained_diff_snippets"
+        ] -= 1
+        reasons[
+            "token_budget"
+            if plan["estimated_tokens"] > budget_tokens
+            else "context_pack_capacity"
+        ] += 1
+        plan["stats"]["trim_reasons"] = dict(
+            sorted((key, count) for key, count in reasons.items() if count)
+        )
+    required_tokens = _fixed_estimate(plan)
+    if (
+        plan["stats"]["actionable_input_events"]
+        and not plan["events"]
+        and not new_failed_checks
+    ):
+        raise ContextBudgetError(
+            "follow-up budget cannot retain any actionable event; increase "
+            "context.follow_up_max_tokens"
+        )
+    if (
+        required_tokens > budget_tokens
+        or len(_canonical_json(plan)) > MAX_SERIALIZED_CONTEXT_CHARS
+    ):
+        raise ContextBudgetError(
+            f"mandatory follow-up facts require {required_tokens} tokens; "
+            f"budget is {budget_tokens} and context-pack capacity is "
+            f"{MAX_SERIALIZED_CONTEXT_CHARS} characters"
+        )
+    plan["actionable"] = bool(plan["events"] or new_failed_checks)
+    _fixed_estimate(plan)
+    return plan

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -738,6 +738,7 @@ class GitHubClient:
                 "updated_at": str(pull.get("updated_at") or ""),
                 "head_sha": head_sha,
                 "base_branch": str((pull.get("base") or {}).get("ref") or ""),
+                "base_sha": str((pull.get("base") or {}).get("sha") or ""),
                 "mergeable": pull.get("mergeable"),
                 "mergeable_state": str(pull.get("mergeable_state") or ""),
                 "merged": bool(pull.get("merged_at")),

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -25,6 +25,7 @@ from .context import (
     running_checkpoint,
     write_portable_bundle,
 )
+from .context_budget import FAILED_CHECK_CONCLUSIONS, build_follow_up_context
 from .discovery import score_issue
 from .github import GitHubClient, GitHubError, resolve_token
 from .harness import Harness, HarnessRequest, create_harness
@@ -45,10 +46,6 @@ from .store import Store
 from .verifier import DockerVerifier
 from .workspace import WorkspaceManager
 
-FAILED_CHECK_CONCLUSIONS = frozenset(
-    {"action_required", "cancelled", "failure", "stale", "timed_out"}
-)
-
 
 def _canonical_digest(value: object) -> str:
     return hashlib.sha256(
@@ -66,41 +63,29 @@ def _repair_feedback(
     actionable: list[dict[str, Any]] = []
     suggestions: list[dict[str, Any]] = []
 
-    for kind, key in (
-        ("issue_comment", "new_comments"),
-        ("review", "new_reviews"),
-        ("review_comment", "new_review_comments"),
-    ):
-        values = follow_up.get(key, ())
-        if not isinstance(values, (list, tuple)):
+    plan = follow_up.get("context_plan", {})
+    events = plan.get("events", ()) if isinstance(plan, dict) else ()
+    for value in events if isinstance(events, (list, tuple)) else ():
+        if not isinstance(value, dict):
             continue
-        for value in values:
-            if not isinstance(value, dict):
-                continue
-            item = {"kind": kind, **value}
-            path = str(value.get("path") or "")
-            if kind == "review_comment" and path and path not in allowed_paths:
-                suggestions.append(
-                    {**item, "reason": "path_outside_existing_pull_request_scope"}
-                )
-                continue
-            body = str(value.get("body") or "").strip()
-            state = str(value.get("state") or "").casefold()
-            if kind == "review" and not body and state != "changes_requested":
-                continue
-            if kind == "issue_comment" and not body:
-                continue
-            actionable.append(item)
+        item = dict(value)
+        kind = str(item.get("kind") or "")
+        path = str(item.get("path") or "")
+        if kind == "review_comment" and path and path not in allowed_paths:
+            suggestions.append(
+                {**item, "reason": "path_outside_existing_pull_request_scope"}
+            )
+            continue
+        actionable.append(item)
 
-    checks = follow_up.get("changed_checks", ())
-    if isinstance(checks, (list, tuple)):
-        for value in checks:
-            if not isinstance(value, dict):
-                continue
-            if (
-                str(value.get("conclusion") or "").casefold()
-                in FAILED_CHECK_CONCLUSIONS
-            ):
+    stats = plan.get("stats", {}) if isinstance(plan, dict) else {}
+    mandatory = plan.get("mandatory", {}) if isinstance(plan, dict) else {}
+    if isinstance(stats, dict) and int(stats.get("new_failed_checks", 0)):
+        checks = (
+            mandatory.get("failed_checks", ()) if isinstance(mandatory, dict) else ()
+        )
+        for value in checks if isinstance(checks, (list, tuple)) else ():
+            if isinstance(value, dict):
                 actionable.append({"kind": "failed_check", **value})
     return tuple(actionable), tuple(suggestions)
 
@@ -1354,6 +1339,58 @@ class Pipeline:
         )
         return {**result, "audit": [applying, completed], "applied": applied}
 
+    @staticmethod
+    def _follow_up_diff_snippets(
+        details: dict[str, Any], events: list[dict[str, Any]]
+    ) -> dict[str, str]:
+        """Read only diffs referenced by new, already in-scope review comments."""
+        changed_files = {str(value) for value in details.get("changed_files", ())}
+        paths = sorted(
+            {
+                str(value["payload"].get("path") or "")
+                for value in events
+                if value.get("event_type") == "review_comment"
+                and isinstance(value.get("payload"), dict)
+                and str(value["payload"].get("path") or "") in changed_files
+            }
+        )
+        worktree = Path(str(details.get("worktree") or "")).expanduser().resolve()
+        base_commit = str(details.get("base_commit") or "")
+        head_commit = str(details.get("commit_sha") or "")
+        if (
+            not paths
+            or not (worktree / ".git").exists()
+            or not re.fullmatch(r"[0-9a-fA-F]{40}", base_commit)
+            or not re.fullmatch(r"[0-9a-fA-F]{40}", head_commit)
+        ):
+            return {}
+        snippets: dict[str, str] = {}
+        for path in paths:
+            try:
+                result = subprocess.run(
+                    [
+                        "git",
+                        "--literal-pathspecs",
+                        "diff",
+                        "--no-ext-diff",
+                        "--unified=3",
+                        base_commit,
+                        head_commit,
+                        "--",
+                        path,
+                    ],
+                    cwd=worktree,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                continue
+            if result.returncode == 0:
+                snippets[path] = result.stdout
+        return snippets
+
     def follow_up(self, run_id: str) -> dict[str, Any]:
         """Commit and return GitHub activity changed since the previous check."""
         return self._follow_up(run_id, commit=True)
@@ -1404,43 +1441,6 @@ class Pipeline:
                 for value in activity["checks"]
             },
         }
-        activity_limit = 3
-        check_limit = 12
-
-        def compact_activity(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
-            result = []
-            for value in values[:activity_limit]:
-                item = {**value}
-                if "body" in item:
-                    body = str(item["body"])
-                    item["body"] = (
-                        body
-                        if len(body) <= 600
-                        else f"{body[:600]}… [omitted {len(body) - 600} chars]"
-                    )
-                for key, content in tuple(item.items()):
-                    if key == "body" or not isinstance(content, str):
-                        continue
-                    if len(content) > 800:
-                        item[key] = (
-                            f"{content[:800]}… [omitted {len(content) - 800} chars]"
-                        )
-                result.append(item)
-            return result
-
-        def compact_checks(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
-            result = []
-            for value in values[:check_limit]:
-                item = {**value}
-                for key in ("name", "url"):
-                    content = str(item.get(key, ""))
-                    if len(content) > 800:
-                        item[key] = (
-                            f"{content[:800]}… [omitted {len(content) - 800} chars]"
-                        )
-                result.append(item)
-            return result
-
         head_matches = pull["head_sha"] == str(details.get("commit_sha", ""))
         if not head_matches:
             next_action = "reverify_changed_head"
@@ -1460,9 +1460,31 @@ class Pipeline:
         else:
             next_action = "wait_for_activity"
 
+        context_bundle = self.store.context_bundle(run_id) if pending_events else None
+        previous_checkpoint = (
+            context_bundle.get("checkpoint")
+            if isinstance(context_bundle, dict)
+            and isinstance(context_bundle.get("checkpoint"), dict)
+            else None
+        )
+        safety_blockers = []
+        if not head_matches:
+            safety_blockers.append("pull_request_head_differs_from_verified_commit")
+        if pull.get("merged"):
+            safety_blockers.append("pull_request_is_merged")
+        elif pull["state"] != "open":
+            safety_blockers.append("pull_request_is_not_open")
+        context_plan = build_follow_up_context(
+            activity=activity,
+            events=pending_events,
+            budget_tokens=self.config.context.follow_up_max_tokens,
+            safety_blockers=tuple(safety_blockers),
+            diff_snippets=self._follow_up_diff_snippets(details, pending_events),
+            checkpoint=previous_checkpoint,
+        )
+
         checkpoint_payload = None
         if pending_events:
-            context_bundle = self.store.context_bundle(run_id)
             if context_bundle is not None:
                 checkpoint_payload = review_checkpoint(
                     context_bundle,
@@ -1524,22 +1546,58 @@ class Pipeline:
                 if isinstance(committed.get("checkpoint"), dict)
                 else ""
             ),
-            "new_comments": compact_activity(new_comments),
-            "new_comments_omitted": max(0, len(new_comments) - activity_limit),
-            "new_reviews": compact_activity(new_reviews),
-            "new_reviews_omitted": max(0, len(new_reviews) - activity_limit),
-            "new_review_comments": compact_activity(new_review_comments),
-            "new_review_comments_omitted": max(
-                0, len(new_review_comments) - activity_limit
+            "new_comments": [
+                value
+                for value in context_plan["events"]
+                if value["kind"] == "issue_comment"
+            ],
+            "new_comments_omitted": max(
+                0,
+                len(new_comments)
+                - sum(
+                    value["kind"] == "issue_comment" for value in context_plan["events"]
+                ),
             ),
-            "changed_checks": compact_checks(changed_checks),
-            "changed_checks_omitted": max(0, len(changed_checks) - check_limit),
+            "new_reviews": [
+                value for value in context_plan["events"] if value["kind"] == "review"
+            ],
+            "new_reviews_omitted": max(
+                0,
+                len(new_reviews)
+                - sum(value["kind"] == "review" for value in context_plan["events"]),
+            ),
+            "new_review_comments": [
+                value
+                for value in context_plan["events"]
+                if value["kind"] == "review_comment"
+            ],
+            "new_review_comments_omitted": max(
+                0,
+                len(new_review_comments)
+                - sum(
+                    value["kind"] == "review_comment"
+                    for value in context_plan["events"]
+                ),
+            ),
+            "changed_checks": [
+                {
+                    "id": str(value.get("id") or ""),
+                    "name": str(value.get("name") or "")[:300],
+                    "status": str(value.get("status") or ""),
+                    "conclusion": str(value.get("conclusion") or ""),
+                    "url": str(value.get("url") or "")[:500],
+                }
+                for value in changed_checks[:12]
+            ],
+            "changed_checks_omitted": max(0, len(changed_checks) - 12),
+            "context_plan": context_plan,
             "next_action": next_action,
         }
         if not commit:
             result["_previous_event_watermark"] = int(event_batch["previous_sequence"])
             result["_checkpoint_payload"] = checkpoint_payload
             result["_github_snapshot"] = snapshot
+            result["_pending_events"] = pending_events
         return result
 
     def _commit_repair_event_preview(
@@ -1603,20 +1661,18 @@ class Pipeline:
                 "next_action": follow["next_action"],
                 "public_write": False,
             }
-        omitted = sum(
-            int(follow.get(name, 0))
-            for name in (
-                "new_comments_omitted",
-                "new_reviews_omitted",
-                "new_review_comments_omitted",
-                "changed_checks_omitted",
-            )
-        )
-        if omitted:
-            raise PolicyError(
-                "incremental activity exceeds the bounded repair input; "
-                "inspect the stored events before preparing a repair"
-            )
+        context_plan = follow.get("context_plan", {})
+        if not isinstance(context_plan, dict) or not context_plan.get("actionable"):
+            self._commit_repair_event_preview(source_run, follow)
+            return {
+                "source_run_id": source_run_id,
+                "repair_prepared": False,
+                "harness_invoked": False,
+                "reason": "no_new_actionable_activity",
+                "next_action": follow["next_action"],
+                "context_stats": context_plan.get("stats", {}),
+                "public_write": False,
+            }
         changed_files = tuple(str(value) for value in details.get("changed_files", ()))
         repair_items, suggestions = _repair_feedback(follow, changed_files)
         if not repair_items:
@@ -1634,6 +1690,28 @@ class Pipeline:
                 else follow["next_action"],
                 "public_write": False,
             }
+
+        repair_paths = {
+            str(value.get("path") or "")
+            for value in repair_items
+            if value.get("kind") == "review_comment"
+        }
+        repair_context = {
+            **{
+                key: value for key, value in context_plan.items() if key != "checkpoint"
+            },
+            "events": [
+                value for value in repair_items if value.get("kind") != "failed_check"
+            ],
+            "diff_snippets": [
+                value
+                for value in context_plan.get("diff_snippets", ())
+                if isinstance(value, dict) and value.get("path") in repair_paths
+            ],
+            "scope_filter": {
+                "suggestions_recorded": len(suggestions),
+            },
+        }
 
         worktree = Path(str(details.get("worktree", ""))).expanduser().resolve()
         if not (worktree / ".git").exists():
@@ -1694,6 +1772,11 @@ class Pipeline:
             "commit_sha": parent_commit,
             "pr_url": str(details["pr_url"]),
             "repair_suggestions": list(suggestions),
+            "context_budget": {
+                "budget_tokens": context_plan.get("budget_tokens"),
+                "estimated_tokens": context_plan.get("estimated_tokens"),
+                "stats": context_plan.get("stats", {}),
+            },
         }
         try:
             context = build_repair_context_pack(
@@ -1705,12 +1788,12 @@ class Pipeline:
                 base_commit=base_commit,
                 harness=self.harness.name,
                 model=self.config.agent.model,
-                previous_checkpoint=previous_checkpoint,
+                previous_checkpoint=context_plan.get("checkpoint"),
                 pull_request_url=str(details["pr_url"]),
                 head_commit=parent_commit,
                 event_watermark=int(follow["event_watermark"]),
                 event_batch_digest=str(follow["event_batch_digest"]),
-                repair_items=repair_items,
+                repair_context=repair_context,
             )
             self.store.save_context_run(
                 pack_id=context.id,

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -98,6 +98,9 @@ max_log_chars = 2000000
 [storage]
 cache_retention_days = 30
 max_gc_items = 1000
+
+[context]
+follow_up_max_tokens = 24000
 """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,8 @@ image = "trusted-runner:latest"
 [storage]
 cache_retention_days = 45
 max_gc_items = 500
+[context]
+follow_up_max_tokens = 9000
 [agent]
 harness = "codex-cli"
 executable = "codex"
@@ -138,6 +140,8 @@ require_distinct_reviewer = false
 [storage]
 cache_retention_days = 1
 max_gc_items = 10000
+[context]
+follow_up_max_tokens = 100000
 [safety]
 max_diff_lines = 500
 require_verification = false
@@ -168,6 +172,7 @@ event_payload_retention_days = 45
         self.assertEqual(config.agent.executable, "codex")
         self.assertEqual(config.storage.cache_retention_days, 45)
         self.assertEqual(config.storage.max_gc_items, 500)
+        self.assertEqual(config.context.follow_up_max_tokens, 9_000)
         self.assertEqual(config.issue_review.project_owner, "")
         self.assertEqual(config.issue_review.project_number, 0)
         self.assertTrue(config.issue_review.require_distinct_reviewer)
@@ -211,6 +216,22 @@ event_payload_retention_days = 0
             )
 
             with self.assertRaisesRegex(ConfigError, "must be positive"):
+                load_config(path)
+
+    def test_follow_up_token_budget_is_bounded(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[context]
+follow_up_max_tokens = 511
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "between 512 and 100000"):
                 load_config(path)
 
     def test_configuration_is_not_pinned_to_one_github_login(self) -> None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,12 +15,14 @@ from reposteward.config import AgentConfig, ConfigError, RepositoryPolicy, load_
 from reposteward.context import (
     MAX_HANDOFF_ITEM_CHARS,
     MAX_REPAIR_ITEM_CHARS,
+    MAX_REPAIR_ITEMS,
     MAX_TASK_DESCRIPTION_CHARS,
     build_context_pack,
     build_repair_context_pack,
     portable_bundle,
     review_checkpoint,
 )
+from reposteward.context_budget import build_follow_up_context, estimate_tokens
 from reposteward.harness import create_harness
 from reposteward.models import (
     AgentExecution,
@@ -69,7 +71,87 @@ def _candidate(body: str = "Reproduce the bug") -> Candidate:
 
 
 class ContextPackTests(unittest.TestCase):
+    def test_repair_transport_stays_within_the_follow_up_budget(self) -> None:
+        activity = {
+            "pull_request": {
+                "number": 12,
+                "url": "https://example.test/pull/12",
+                "state": "open",
+                "draft": True,
+                "head_sha": "b" * 40,
+                "base_branch": "main",
+                "base_sha": "a" * 40,
+                "merged": False,
+            },
+            "reviews": [],
+            "checks": [],
+        }
+        events = [
+            {
+                "sequence": index,
+                "event_type": "review_comment",
+                "external_id": str(index),
+                "version_digest": f"{index:064x}",
+                "payload": {
+                    "id": index,
+                    "author": "reviewer",
+                    "path": "src/example.py",
+                    "body": f"feedback-{index}-" + "x" * 1_000,
+                },
+            }
+            for index in range(1, 20)
+        ]
+        plan = build_follow_up_context(
+            activity=activity,
+            events=events,
+            budget_tokens=8_000,
+            checkpoint={"id": "checkpoint", "status": "submitted"},
+        )
+        repair_context = {
+            key: value for key, value in plan.items() if key != "checkpoint"
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            pack = build_repair_context_pack(
+                _candidate(),
+                RepositoryPolicy(name="owner/repo"),
+                work_item_id="work-1",
+                run_id="run-2",
+                worktree=Path(directory),
+                base_commit="a" * 40,
+                harness="codex-cli",
+                model="gpt-example",
+                previous_checkpoint=plan["checkpoint"],
+                pull_request_url="https://example.test/pull/12",
+                head_commit="b" * 40,
+                event_watermark=19,
+                event_batch_digest="c" * 64,
+                repair_context=repair_context,
+            )
+
+        transported = {
+            "handoff": pack.handoff,
+            "current_follow_up": pack.task.acceptance_criteria,
+        }
+        self.assertLessEqual(estimate_tokens(transported), plan["budget_tokens"])
+
     def test_repair_context_keeps_bounded_incremental_feedback(self) -> None:
+        repair_context = {
+            "schema_version": 1,
+            "budget_tokens": 12_000,
+            "estimated_tokens": 4_000,
+            "mandatory": {"safety_blockers": [], "failed_checks": []},
+            "events": [
+                {
+                    "kind": "review_comment",
+                    "id": str(index),
+                    "body": "x" * 600,
+                }
+                for index in range(30)
+            ],
+            "diff_snippets": [],
+            "actionable": True,
+            "stats": {},
+        }
         with tempfile.TemporaryDirectory() as directory:
             pack = build_repair_context_pack(
                 _candidate(),
@@ -85,15 +167,18 @@ class ContextPackTests(unittest.TestCase):
                 head_commit="b" * 40,
                 event_watermark=9,
                 event_batch_digest="c" * 64,
-                repair_items=tuple(
-                    {"kind": "review_comment", "body": "x" * 10_000} for _ in range(100)
-                ),
+                repair_context=repair_context,
             )
 
-        self.assertEqual(len(pack.task.acceptance_criteria), 17)
+        self.assertGreater(len(pack.task.acceptance_criteria), 2)
+        self.assertLessEqual(len(pack.task.acceptance_criteria), MAX_REPAIR_ITEMS)
         self.assertLessEqual(
             len(pack.task.acceptance_criteria[-1]), MAX_REPAIR_ITEM_CHARS
         )
+        encoded = "".join(
+            value.split(":", 1)[1] for value in pack.task.acceptance_criteria[1:]
+        )
+        self.assertEqual(json.loads(encoded), repair_context)
         self.assertEqual(pack.sources[-1].kind, "github_pr_event_batch")
         self.assertEqual(pack.sources[-1].digest, "c" * 64)
         self.assertIn("current_follow_up", build_harness_prompt(pack))

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import unittest
+
+from reposteward.context_budget import (
+    ContextBudgetError,
+    build_follow_up_context,
+    estimate_tokens,
+)
+
+
+def _activity(
+    *, checks: list[dict] | None = None, reviews: list[dict] | None = None
+) -> dict:
+    return {
+        "pull_request": {
+            "number": 12,
+            "url": "https://example.test/pull/12",
+            "state": "open",
+            "draft": True,
+            "head_sha": "a" * 40,
+            "base_branch": "main",
+            "merged": False,
+        },
+        "comments": [],
+        "reviews": reviews or [],
+        "review_comments": [],
+        "checks": checks or [],
+    }
+
+
+def _event(
+    sequence: int,
+    *,
+    event_id: int = 1,
+    kind: str = "review_comment",
+    body: str = "Handle this case.",
+) -> dict:
+    return {
+        "sequence": sequence,
+        "event_type": kind,
+        "external_id": str(event_id),
+        "version_digest": f"{sequence:064x}",
+        "payload": {
+            "id": event_id,
+            "author": "reviewer",
+            "association": "MEMBER",
+            "path": "src/example.py",
+            "line": 10,
+            "body": body,
+        },
+    }
+
+
+class ContextBudgetTests(unittest.TestCase):
+    def test_latest_version_and_repeated_content_are_deduplicated(self) -> None:
+        plan = build_follow_up_context(
+            activity=_activity(),
+            events=[
+                _event(1, body="old"),
+                _event(2, body="current"),
+                _event(3, event_id=2, body="current"),
+            ],
+            budget_tokens=5_000,
+        )
+
+        self.assertEqual([item["sequence"] for item in plan["events"]], [3])
+        self.assertEqual(plan["stats"]["trim_reasons"]["superseded_event_version"], 1)
+        self.assertEqual(plan["stats"]["trim_reasons"]["duplicate_event_content"], 1)
+        self.assertEqual(
+            plan["estimated_tokens"],
+            estimate_tokens(plan) + plan["transport_overhead_tokens"],
+        )
+
+    def test_latest_review_state_replaces_an_older_change_request(self) -> None:
+        old = _event(1, event_id=10, kind="review", body="Please change this.")
+        old["payload"].update({"state": "changes_requested", "author": "reviewer"})
+        approved = _event(2, event_id=11, kind="review", body="")
+        approved["payload"].update({"state": "approved", "author": "reviewer"})
+        plan = build_follow_up_context(
+            activity=_activity(
+                reviews=[
+                    {
+                        "id": 10,
+                        "author": "reviewer",
+                        "state": "changes_requested",
+                        "submitted_at": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "id": 11,
+                        "author": "reviewer",
+                        "state": "approved",
+                        "submitted_at": "2026-01-02T00:00:00Z",
+                    },
+                ]
+            ),
+            events=[old, approved],
+            budget_tokens=2_000,
+        )
+
+        self.assertEqual(plan["mandatory"]["blocking_reviews"], [])
+        self.assertEqual(plan["events"], [])
+        self.assertFalse(plan["actionable"])
+        self.assertEqual(plan["stats"]["trim_reasons"]["superseded_reviewer_state"], 1)
+
+    def test_failed_checks_and_safety_facts_are_never_budget_trimmed(self) -> None:
+        plan = build_follow_up_context(
+            activity=_activity(
+                checks=[
+                    {
+                        "id": 9,
+                        "name": "quality",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    }
+                ]
+            ),
+            events=[
+                _event(index, event_id=index, body=f"{index}-" + "x" * 2_000)
+                for index in range(1, 20)
+            ],
+            budget_tokens=5_000,
+            safety_blockers=("head_changed",),
+        )
+
+        self.assertEqual(plan["mandatory"]["failed_checks"][0]["name"], "quality")
+        self.assertEqual(plan["mandatory"]["safety_blockers"], ["head_changed"])
+        self.assertLessEqual(plan["estimated_tokens"], 5_000)
+        self.assertGreater(plan["stats"]["trim_reasons"]["token_budget"], 0)
+
+    def test_impossibly_small_mandatory_set_fails_clearly(self) -> None:
+        checks = [
+            {
+                "id": index,
+                "name": f"required-{index}-" + "x" * 300,
+                "status": "completed",
+                "conclusion": "failure",
+            }
+            for index in range(30)
+        ]
+
+        with self.assertRaisesRegex(ContextBudgetError, "mandatory.*require"):
+            build_follow_up_context(
+                activity=_activity(checks=checks),
+                events=[],
+                budget_tokens=3_000,
+            )
+
+    def test_budget_never_turns_trimmed_feedback_into_no_activity(self) -> None:
+        with self.assertRaisesRegex(ContextBudgetError, "cannot retain any actionable"):
+            build_follow_up_context(
+                activity=_activity(),
+                events=[_event(1, body="x" * 4_000)],
+                budget_tokens=3_000,
+                checkpoint={"implementation_notes": "x" * 100},
+            )
+
+    def test_synthetic_long_pr_is_deterministic_and_bounded(self) -> None:
+        events = []
+        for index in range(1, 10_001):
+            if index % 10 == 0:
+                kind = "check"
+            elif index % 5 == 0:
+                kind = "issue_comment"
+            elif index % 3 == 0:
+                kind = "review"
+            else:
+                kind = "review_comment"
+            body = (
+                "repeated feedback"
+                if index % 7 == 0
+                else f"feedback-{index}-" + "x" * 4_000
+            )
+            events.append(_event(index, event_id=index, kind=kind, body=body))
+
+        first = build_follow_up_context(
+            activity=_activity(), events=events, budget_tokens=5_000
+        )
+        second = build_follow_up_context(
+            activity=_activity(), events=events, budget_tokens=5_000
+        )
+
+        self.assertEqual(first, second)
+        self.assertLessEqual(first["estimated_tokens"], 5_000)
+        self.assertLess(len(first["events"]), len(events))
+        self.assertEqual(first["stats"]["input_events"], 10_000)
+        self.assertGreater(first["stats"]["trim_reasons"]["duplicate_event_content"], 0)
+        self.assertGreater(first["stats"]["trim_reasons"]["deterministic_fact_only"], 0)
+
+    def test_related_diff_is_bounded_and_audited(self) -> None:
+        plan = build_follow_up_context(
+            activity=_activity(),
+            events=[_event(1)],
+            budget_tokens=7_000,
+            diff_snippets={"src/example.py": "diff\n" + "x" * 10_000},
+        )
+
+        self.assertEqual(plan["diff_snippets"][0]["path"], "src/example.py")
+        self.assertEqual(plan["stats"]["trim_reasons"]["diff_snippet_clipped"], 1)
+
+    def test_compact_checkpoint_is_included_in_the_total_budget(self) -> None:
+        checkpoint = {
+            "id": "checkpoint-1",
+            "status": "submitted",
+            "implementation_notes": "verified earlier behavior",
+            "remaining": ["address reviewer feedback"],
+        }
+        plan = build_follow_up_context(
+            activity=_activity(),
+            events=[_event(1)],
+            budget_tokens=5_000,
+            checkpoint=checkpoint,
+        )
+
+        self.assertEqual(plan["checkpoint"]["id"], checkpoint["id"])
+        self.assertEqual(
+            plan["checkpoint"]["implementation_notes"],
+            checkpoint["implementation_notes"],
+        )
+        self.assertEqual(plan["transport_overhead_tokens"], 2_048)
+        self.assertLessEqual(plan["estimated_tokens"], plan["budget_tokens"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -39,6 +39,33 @@ def _follow(**extra: object) -> dict:
         "_github_snapshot": {},
     }
     value.update(extra)
+    events = []
+    for kind, key in (
+        ("issue_comment", "new_comments"),
+        ("review", "new_reviews"),
+        ("review_comment", "new_review_comments"),
+    ):
+        events.extend({"kind": kind, **item} for item in value[key])
+    failed_checks = [
+        item
+        for item in value["changed_checks"]
+        if str(item.get("conclusion") or "").casefold()
+        in {"action_required", "cancelled", "failure", "stale", "timed_out"}
+    ]
+    value["context_plan"] = {
+        "schema_version": 1,
+        "budget_tokens": 12_000,
+        "estimated_tokens": 100,
+        "mandatory": {
+            "failed_checks": failed_checks,
+            "safety_blockers": [],
+            "blocking_reviews": [],
+        },
+        "events": events,
+        "diff_snippets": [],
+        "actionable": bool(events or failed_checks),
+        "stats": {"new_failed_checks": len(failed_checks)},
+    }
     return value
 
 
@@ -92,6 +119,76 @@ class RepairTests(unittest.TestCase):
 
         pipeline.prepare_repair("source")
         pipeline.harness.run.assert_not_called()
+
+    def test_successful_check_only_advances_watermark_without_harness(self) -> None:
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": RepositoryPolicy(name="owner/repo")}
+        )
+        pipeline.store = Mock()
+        pipeline.store.run.return_value = {
+            "id": "source",
+            "repository": "owner/repo",
+            "issue_number": 7,
+            "status": "submitted",
+            "stage": "pull_request",
+            "worktree": "/tmp/worktree",
+            "details": {"pr_url": "https://example.test/pull/12"},
+        }
+        pipeline.store.commit_github_follow_up.return_value = {
+            "sequence": 9,
+            "checkpoint": None,
+        }
+        pipeline._follow_up = Mock(
+            return_value=_follow(
+                changed_checks=[
+                    {
+                        "id": "check-1",
+                        "name": "tests",
+                        "status": "completed",
+                        "conclusion": "success",
+                    }
+                ],
+                next_action="wait_for_activity",
+            )
+        )
+        pipeline.harness = Mock()
+
+        result = pipeline.prepare_repair("source")
+
+        self.assertEqual(result["reason"], "no_new_actionable_activity")
+        pipeline.store.commit_github_follow_up.assert_called_once()
+        pipeline.harness.run.assert_not_called()
+
+    def test_diff_reader_only_uses_verified_changed_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            worktree = Path(directory)
+            (worktree / ".git").mkdir()
+            details = {
+                "worktree": str(worktree),
+                "base_commit": "a" * 40,
+                "commit_sha": "b" * 40,
+                "changed_files": ["src/allowed.py"],
+            }
+            events = [
+                {
+                    "event_type": "review_comment",
+                    "payload": {"path": "src/allowed.py"},
+                },
+                {
+                    "event_type": "review_comment",
+                    "payload": {"path": "../outside.py"},
+                },
+            ]
+            completed = SimpleNamespace(returncode=0, stdout="bounded diff")
+
+            with patch(
+                "reposteward.pipeline.subprocess.run", return_value=completed
+            ) as run:
+                snippets = Pipeline._follow_up_diff_snippets(details, events)
+
+        self.assertEqual(snippets, {"src/allowed.py": "bounded diff"})
+        self.assertEqual(run.call_args.args[0][-1], "src/allowed.py")
 
     def test_in_scope_feedback_is_verified_and_left_ready(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -41,6 +41,7 @@ class SetupTests(unittest.TestCase):
         self.assertTrue(parsed["issue_review"]["require_distinct_reviewer"])
         self.assertEqual(parsed["storage"]["cache_retention_days"], 30)
         self.assertEqual(parsed["storage"]["max_gc_items"], 1000)
+        self.assertEqual(parsed["context"]["follow_up_max_tokens"], 24_000)
         self.assertEqual(
             parsed["project"]["state_dir"], str(root / "state" / "reposteward")
         )


### PR DESCRIPTION
Closes #11

## 做了什么

- 新增供应商无关的 follow-up 上下文预算器，以 UTF-8 字节数作为确定、保守的 token 上界。
- 按稳定 ID 保留最新事件版本，并按内容摘要跨 ID 去重；同一 Reviewer 的较旧 Review 状态不再重复进入上下文。
- 只选择水位后的可执行事件、Reviewer 指向的已验证路径 diff 和紧凑 Checkpoint，并返回完整裁剪统计与原因。
- 将预算结果接入 contributor repair；成功 check、空 Review 等无可执行增量只推进水位，不启动 Harness。
- 强制保留 head/base、安全阻塞、当前失败 check 和阻塞 Review；强制事实或任一可执行事件无法容纳时明确失败。
- 在总预算中预留 2,048 token 的 Context Pack 分片与提示包装开销，并显式返回该数值。
- Repair Context Pack 分片保存完整预算结果，避免原有 `16 × 1200` 字符二次静默截断。

## 安全与性能边界

- diff 只允许读取上一次已验证变更中的精确路径，使用参数数组、literal pathspec 和 `--no-ext-diff`，不执行 Reviewer 文本。
- 预算、去重、排序和裁剪全部由确定性代码完成，不依赖 Harness 会话或模型供应商。
- 10,000 条混合评论、Reviews、checks、重复正文和长正文的合成回归不访问真实模型，并验证结果确定且大小有界。
- 本 PR 不增加自动回复、自动 push 或自动 merge 能力。

## 验证

- `uv run python -m unittest discover -s tests -v`（156 tests）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build --no-build-isolation`
- RepoSteward 隔离 Runner adopt 验证通过

## 建议重点 Review

- `context_plan` 的优先级和“至少保留一条可执行反馈，否则失败”语义。
- 紧凑 Checkpoint 是否覆盖恢复所需事实，同时不突破统一预算。
- Repair Context Pack 分片重组与现有 schema 上限的兼容性。

Implementation assistance: an external coding workspace was used to prepare the change and its tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility for this contribution.
