### PR TITLE
feat(merge): execute fresh maintainer decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,32 @@ diff 不可用等原因。安全阻塞、当前 head/base、失败 check 和阻�
 Runner、数据库、依赖发布和安全风险规则不能被项目配置削弱；项目只能通过 `merge_risk_paths` 追加
 需要人工合并的路径。
 
+Maintainer 可以为单个仓库显式启用合并执行器；默认仍关闭：
+
+```toml
+[repositories."owner/repository"]
+mode = "maintainer"
+submission_strategy = "same-repository"
+auto_merge = true
+auto_merge_method = "squash"
+```
+
+执行器只消费一次指定的 eligible 决策，不会自己生成资格。先运行 `merge-decision`，人工检查返回的
+决策和 `audit.id`，再显式执行：
+
+```bash
+REPOSTEWARD_ENABLE_MERGE=1 \
+  uv run reposteward merge RUN_ID \
+  --decision-id MERGE_DECISION_AUDIT_ID \
+  --reviewed-by your-github-login
+```
+
+命令会核对配置身份、token 实际身份和仓库 push 权限，并在写入前两次读取完整 PR 活动与合并快照。
+任何评论或 Review 编辑、check、会话、head/base、策略、规模或风险变化都会使旧决策失效；请求还会
+绑定精确 head SHA。网络结果不确定时先回读 GitHub，已在相同 head 合并则作为幂等成功，否则失败
+关闭。每次尝试的意图和结果都追加到本地审计。Contributor mode、高风险路径、超限 PR、后台轮询、
+Reviewer 回复和自动开启 GitHub auto-merge 均不在该执行器范围内。
+
 本地占用可以按仓库、数据类别和时间范围只读查看：
 
 ```bash
@@ -356,7 +382,7 @@ uv run reposteward storage gc --repo owner/repository
 默认候选只有超过用户级 `cache_retention_days` 且已有终态 Checkpoint 的验证日志。原始 GitHub
 事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且每个 run 水位
 都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并始终保护事件
-索引、Checkpoint、Merge Decision 和 GC 审计。
+索引、Checkpoint、Merge Decision、Merge Execution 和 GC 审计。
 
 实际应用需要命令参数和独立环境开关同时存在：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,9 +91,11 @@ Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
 验证日志是唯一默认可回收类别，期限和单次最大对象数由用户级 `[storage]` 配置拥有，项目层不能
 静默缩短。GC 默认 dry-run；apply 同时要求 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后
-追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Merge Decision 或自身审计。
+追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Merge Decision、Merge Execution 或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
+- `merge_executions`：按 attempt 追加保存执行身份、指定决策、精确 head、方法、写入前意图与最终
+  GitHub 结果；`applying` 没有对应 `completed` 时表示进程可能在外部写入期间中断，重试必须先回读。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。
@@ -120,6 +122,14 @@ Merge Decision Engine 位于执行器之前。它完整分页读取 GitHub 结�
 head/base、策略摘要、审批、required checks、未解决会话、规模和不可削弱的高风险路径。结果只表示
 当前快照是否具备资格，不执行 merge，也不以 Harness 推理替代确定性事实。任何不完整快照都失败
 关闭；策略、head 或 base 在验证后变化时必须重新验证。
+
+Maintainer Merge Executor 是独立、默认关闭的 CLI 写入边界。仓库必须同时配置 Maintainer、
+same-repository 和 `auto_merge = true`，进程还必须设置一次性环境开关并声明与 token 一致的身份。
+执行器要求调用者指定一条已审计的 eligible 决策，随后重新计算完整活动摘要和 Merge Snapshot；
+真正调用 GitHub 前再读取一次，且 PUT 请求绑定验证过的 head SHA。任何摘要不一致、高风险、超限、
+不完整事实或权限问题都阻止写入。网络超时或 GitHub 返回不确定结果时先回读；相同 head 已合并视为
+幂等成功，其他状态不会盲目重试。执行器不回复 Reviewer、不服务 Contributor mode，也没有常驻
+调度器。
 
 三类协议文档都使用 Draft 2020-12 JSON Schema，schema 随 Python 包发布。持久化和导入边界会
 拒绝未知字段、未来版本、跨 work item/run 的关联错配及不一致摘要。Bundle digest 只能检测意外

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -49,6 +49,8 @@ follow_up_max_tokens = 24000
 [repositories."owner/repository"]
 enabled = true
 auto_prepare = false
+auto_merge = false
+auto_merge_method = "squash"
 mode = "contributor"
 submission_strategy = "fork"
 require_no_competing_work = true

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -206,6 +206,13 @@ def _parser() -> argparse.ArgumentParser:
     )
     merge_decision.add_argument("run_id")
 
+    merge = subparsers.add_parser(
+        "merge", help="execute one fresh opt-in maintainer merge decision"
+    )
+    merge.add_argument("run_id")
+    merge.add_argument("--decision-id", required=True)
+    merge.add_argument("--reviewed-by", required=True)
+
     submit = subparsers.add_parser(
         "submit", help="push a reviewed change and create or reopen a PR"
     )
@@ -438,6 +445,15 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "merge-decision":
             _json(pipeline.merge_decision(args.run_id))
+            return 0
+        if args.command == "merge":
+            _json(
+                pipeline.execute_merge(
+                    args.run_id,
+                    decision_id=args.decision_id,
+                    reviewed_by=args.reviewed_by,
+                )
+            )
             return 0
         if args.command == "submit":
             _json(

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -125,6 +125,8 @@ class RepositoryPolicy:
     name: str
     enabled: bool = True
     auto_prepare: bool = False
+    auto_merge: bool = False
+    auto_merge_method: str = "squash"
     mode: str = "contributor"
     submission_strategy: str = "fork"
     min_stars: int = 1_000
@@ -579,6 +581,10 @@ def load_config(
             name=name,
             enabled=_boolean(repo_value.get("enabled"), True),
             auto_prepare=_boolean(repo_value.get("auto_prepare"), False),
+            auto_merge=_boolean(repo_value.get("auto_merge"), False),
+            auto_merge_method=str(
+                repo_value.get("auto_merge_method", "squash")
+            ).strip(),
             mode=str(repo_value.get("mode", "contributor")).strip(),
             submission_strategy=str(
                 repo_value.get("submission_strategy", "fork")
@@ -682,6 +688,19 @@ def load_config(
         if repository.mode not in {"contributor", "maintainer"}:
             raise ConfigError(
                 f"unsupported mode for {repository.name}: {repository.mode!r}"
+            )
+        if repository.auto_merge_method not in {"merge", "squash", "rebase"}:
+            raise ConfigError(
+                f"unsupported auto_merge_method for {repository.name}: "
+                f"{repository.auto_merge_method!r}"
+            )
+        if repository.auto_merge and (
+            repository.mode != "maintainer"
+            or repository.submission_strategy != "same-repository"
+        ):
+            raise ConfigError(
+                f"{repository.name} may enable auto_merge only in maintainer "
+                "same-repository mode"
             )
         if repository.submission_strategy not in {"fork", "same-repository"}:
             raise ConfigError(

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -22,6 +23,13 @@ MAX_REST_PAGES = 1_000
 
 class GitHubError(RuntimeError):
     """A GitHub API request failed."""
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
@@ -819,6 +827,7 @@ class GitHubClient:
                     pullRequest(number: $number) {
                       number state isDraft mergeable reviewDecision
                       headRefOid baseRefOid additions deletions changedFiles
+                      mergeCommit { oid }
                       files(first: 100, after: $files) {
                         totalCount
                         nodes { path }
@@ -939,6 +948,16 @@ class GitHubClient:
                         "required": bool(value.get("isRequired")),
                     }
                 )
+        conversation_state = sorted(
+            (
+                {
+                    "id": str(value.get("id") or ""),
+                    "resolved": bool(value.get("isResolved")),
+                }
+                for value in values["threads"]
+            ),
+            key=lambda value: value["id"],
+        )
         return {
             "repository": upstream.casefold(),
             "pull_number": int(pull["number"]),
@@ -951,6 +970,7 @@ class GitHubClient:
             "unresolved_conversations": sum(
                 not bool(value.get("isResolved")) for value in values["threads"]
             ),
+            "conversation_digest": _canonical_digest(conversation_state),
             "files": sorted(
                 {
                     str(value.get("path") or "")
@@ -964,6 +984,31 @@ class GitHubClient:
             "files_complete": True,
             "conversations_complete": True,
             "checks_complete": True,
+            "merge_commit_sha": str(((pull.get("mergeCommit") or {}).get("oid")) or ""),
+        }
+
+    def merge_pull_request(
+        self,
+        upstream: str,
+        number: int,
+        *,
+        head_sha: str,
+        method: str,
+    ) -> dict[str, Any]:
+        """Merge one exact PR head and return GitHub's normalized result."""
+        if method not in {"merge", "squash", "rebase"}:
+            raise ValueError(f"unsupported merge method: {method!r}")
+        payload, _ = self._request(
+            "PUT",
+            f"/repos/{upstream}/pulls/{number}/merge",
+            data={"sha": head_sha, "merge_method": method},
+        )
+        if not isinstance(payload, dict):
+            raise GitHubError("GitHub merge response was not an object")
+        return {
+            "merged": bool(payload.get("merged")),
+            "sha": str(payload.get("sha") or ""),
+            "message": str(payload.get("message") or ""),
         }
 
     def reopen_pull_request(

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -78,6 +78,7 @@ class MergeSnapshot:
     additions: int
     deletions: int
     checks: tuple[MergeCheck, ...]
+    activity_digest: str = ""
     files_complete: bool = True
     conversations_complete: bool = True
     checks_complete: bool = True
@@ -167,6 +168,8 @@ def evaluate_merge(
         block("conversations_incomplete", "Review-conversation data is incomplete.")
     if not snapshot.checks_complete:
         block("checks_incomplete", "Check data is incomplete.")
+    if not snapshot.activity_digest:
+        block("activity_incomplete", "Pull-request activity digest is unavailable.")
     if snapshot.review_decision.casefold() != "approved":
         block("review_not_approved", "The current review decision is not approved.")
     if snapshot.unresolved_conversations:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -6,6 +6,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import uuid
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -37,7 +38,7 @@ from .issues import (
     render_issue_body,
     validate_issue_title,
 )
-from .merge import MergeCheck, MergeSnapshot, evaluate_merge
+from .merge import MergeCheck, MergeDecision, MergeSnapshot, evaluate_merge
 from .models import AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
 from .protocol import read_context_bundle, validate_context_bundle
@@ -1273,6 +1274,7 @@ class Pipeline:
                 "checkpoint",
                 "github_event_index",
                 "merge_decision_audit",
+                "merge_execution_audit",
                 "storage_gc_audit",
             ],
             "public_write": False,
@@ -2001,8 +2003,18 @@ class Pipeline:
                 + "); run follow-up and prepare a new repair"
             )
 
-    def merge_decision(self, run_id: str) -> dict[str, Any]:
-        """Evaluate and audit current merge eligibility without writing to GitHub."""
+    def _current_merge_evaluation(
+        self, run_id: str
+    ) -> tuple[
+        dict[str, Any],
+        dict[str, Any],
+        RepositoryPolicy,
+        int,
+        MergeSnapshot,
+        MergeDecision,
+        dict[str, Any],
+    ]:
+        """Read all current facts and produce one deterministic merge evaluation."""
         run = self.store.run(run_id)
         if run is None:
             raise KeyError(f"run not found: {run_id}")
@@ -2020,6 +2032,7 @@ class Pipeline:
         if not isinstance(project, dict):
             raise PolicyError("the verified context pack has no project policy")
         expected_policy_digest = str(project.get("policy_digest") or "")
+        activity = self.github.pull_request_activity(repository, pull_number)
         raw = self.github.pull_request_merge_snapshot(repository, pull_number)
         snapshot = MergeSnapshot(
             repository=repository,
@@ -2036,6 +2049,12 @@ class Pipeline:
             additions=int(raw["additions"]),
             deletions=int(raw["deletions"]),
             checks=tuple(MergeCheck(**value) for value in raw["checks"]),
+            activity_digest=_canonical_digest(
+                {
+                    "activity": activity,
+                    "conversation_digest": str(raw["conversation_digest"]),
+                }
+            ),
             files_complete=bool(raw["files_complete"]),
             conversations_complete=bool(raw["conversations_complete"]),
             checks_complete=bool(raw["checks_complete"]),
@@ -2057,6 +2076,20 @@ class Pipeline:
             ),
             extra_risk_patterns=policy.merge_risk_paths,
         )
+        return run, details, policy, pull_number, snapshot, decision, raw
+
+    def merge_decision(self, run_id: str) -> dict[str, Any]:
+        """Evaluate and audit current merge eligibility without writing to GitHub."""
+        (
+            _run,
+            _details,
+            _policy,
+            pull_number,
+            snapshot,
+            decision,
+            _raw,
+        ) = self._current_merge_evaluation(run_id)
+        repository = snapshot.repository
         payload = decision.to_dict()
         audit_payload = {**payload, "snapshot": asdict(snapshot)}
         audit = self.store.append_merge_decision(
@@ -2074,6 +2107,304 @@ class Pipeline:
             **payload,
             "audit": audit,
             "public_write": False,
+        }
+
+    def execute_merge(
+        self, run_id: str, *, decision_id: str, reviewed_by: str
+    ) -> dict[str, Any]:
+        """Execute one fresh eligible maintainer decision behind explicit gates."""
+        run = self.store.run(run_id)
+        if run is None:
+            raise KeyError(f"run not found: {run_id}")
+        repository = str(run["repository"])
+        policy = self.policy(repository)
+        details = run.get("details", {})
+        match = re.search(r"/pull/(\d+)/?$", str(details.get("pr_url", "")))
+        if not match:
+            raise PolicyError("the selected run has no submitted pull request")
+        pull_number = int(match.group(1))
+        stored = self.store.merge_decision(decision_id)
+        if stored is None:
+            raise PolicyError(f"merge decision not found: {decision_id}")
+        if (
+            str(stored["repository"]).casefold() != repository.casefold()
+            or int(stored["pull_number"]) != pull_number
+        ):
+            raise PolicyError("merge decision belongs to a different pull request")
+        attempt_id = uuid.uuid4().hex
+        actor = str(reviewed_by).strip()
+        if not actor:
+            raise PolicyError("--reviewed-by must not be empty")
+        method = policy.auto_merge_method
+        audits: list[dict[str, Any]] = []
+
+        def record(
+            *, stage: str, outcome: str, reason: str, payload: dict[str, Any]
+        ) -> None:
+            audits.append(
+                self.store.append_merge_execution(
+                    attempt_id=attempt_id,
+                    run_id=run_id,
+                    decision_id=decision_id,
+                    repository=repository,
+                    pull_number=pull_number,
+                    actor=actor,
+                    merge_method=method,
+                    stage=stage,
+                    outcome=outcome,
+                    reason=reason,
+                    decision_digest=str(stored["decision_digest"]),
+                    head_sha=str(stored["head_sha"]),
+                    payload=payload,
+                )
+            )
+
+        def block(reason: str, *, payload: dict[str, Any] | None = None) -> None:
+            record(
+                stage="completed",
+                outcome="blocked",
+                reason=reason,
+                payload=payload or {},
+            )
+            raise PolicyError(reason)
+
+        if os.environ.get("REPOSTEWARD_ENABLE_MERGE") != "1":
+            block(
+                "merge execution is disabled; set REPOSTEWARD_ENABLE_MERGE=1 "
+                "for this command"
+            )
+        if not policy.auto_merge:
+            block("repository auto_merge is not explicitly enabled")
+        if (
+            policy.mode != "maintainer"
+            or policy.submission_strategy != "same-repository"
+        ):
+            block("auto merge requires maintainer same-repository mode")
+        if str(run.get("status")) != "submitted":
+            block("auto merge requires a submitted run")
+        if actor.casefold() != self.config.github.login.casefold():
+            block("--reviewed-by must match the configured GitHub login")
+        if not bool(stored["eligible"]):
+            block("merge decision is not eligible")
+        stored_snapshot = stored["payload"].get("snapshot")
+        if not isinstance(stored_snapshot, dict) or not stored_snapshot.get(
+            "activity_digest"
+        ):
+            block("merge decision predates activity freshness checks; evaluate again")
+        expected_head = str(details.get("commit_sha") or "")
+        expected_base = str(details.get("base_commit") or "")
+        current_policy_digest = repository_policy_digest(policy)
+        if (
+            str(stored["head_sha"]) != expected_head
+            or str(stored["base_sha"]) != expected_base
+            or str(stored["policy_digest"]) != current_policy_digest
+        ):
+            block(
+                "merge decision scope differs from the verified run or current policy"
+            )
+
+        try:
+            authenticated = self.github.authenticated_login()
+            repository_info = self.github.repository(repository)
+        except GitHubError as exc:
+            record(
+                stage="completed",
+                outcome="failed",
+                reason="GitHub execution identity could not be confirmed",
+                payload={"error": str(exc)},
+            )
+            raise PolicyError(
+                "GitHub execution identity could not be confirmed"
+            ) from exc
+        if authenticated.casefold() != actor.casefold():
+            block("authenticated GitHub login differs from the reviewed identity")
+        if not repository_info.can_push:
+            block("authenticated GitHub login cannot push to the repository")
+
+        def read_current(
+            stage: str,
+        ) -> tuple[
+            dict[str, Any],
+            dict[str, Any],
+            RepositoryPolicy,
+            int,
+            MergeSnapshot,
+            MergeDecision,
+            dict[str, Any],
+        ]:
+            try:
+                return self._current_merge_evaluation(run_id)
+            except (GitHubError, KeyError, PolicyError, TypeError, ValueError) as exc:
+                reason = f"GitHub facts could not be confirmed during {stage}"
+                record(
+                    stage="completed",
+                    outcome="failed",
+                    reason=reason,
+                    payload={"error": str(exc)},
+                )
+                raise PolicyError(reason) from exc
+
+        current = read_current("merge preflight")
+        snapshot, decision, raw = current[4], current[5], current[6]
+        if snapshot.state.casefold() == "merged":
+            if snapshot.head_sha != expected_head:
+                block("merged pull request head differs from the verified commit")
+            record(
+                stage="completed",
+                outcome="already_merged",
+                reason="pull request is already merged at the verified head",
+                payload={"merge_commit_sha": str(raw.get("merge_commit_sha") or "")},
+            )
+            return {
+                "run_id": run_id,
+                "repository": repository,
+                "pull_number": pull_number,
+                "merged": True,
+                "idempotent": True,
+                "merge_commit_sha": str(raw.get("merge_commit_sha") or ""),
+                "attempt_id": attempt_id,
+                "audit": audits,
+                "public_write": False,
+            }
+        if (
+            not decision.eligible
+            or decision.decision_digest != str(stored["decision_digest"])
+            or decision.snapshot_digest != str(stored["snapshot_digest"])
+        ):
+            block(
+                "merge decision is stale; run merge-decision again",
+                payload={"current_decision": decision.to_dict()},
+            )
+
+        record(
+            stage="applying",
+            outcome="pending",
+            reason="fresh eligible decision accepted for execution",
+            payload={"decision": decision.to_dict(), "snapshot": asdict(snapshot)},
+        )
+        just_in_time = read_current("just-in-time merge validation")
+        latest_snapshot, latest_decision = just_in_time[4], just_in_time[5]
+        if latest_snapshot.state.casefold() == "merged":
+            if latest_snapshot.head_sha != expected_head:
+                reason = "merged pull request head differs from the verified commit"
+                record(
+                    stage="completed",
+                    outcome="blocked",
+                    reason=reason,
+                    payload={"snapshot": asdict(latest_snapshot)},
+                )
+                raise PolicyError(reason)
+            latest_raw = just_in_time[6]
+            record(
+                stage="completed",
+                outcome="already_merged",
+                reason="pull request was merged concurrently at the verified head",
+                payload={
+                    "merge_commit_sha": str(latest_raw.get("merge_commit_sha") or "")
+                },
+            )
+            return {
+                "run_id": run_id,
+                "repository": repository,
+                "pull_number": pull_number,
+                "merged": True,
+                "idempotent": True,
+                "merge_commit_sha": str(latest_raw.get("merge_commit_sha") or ""),
+                "attempt_id": attempt_id,
+                "audit": audits,
+                "public_write": False,
+            }
+        if (
+            not latest_decision.eligible
+            or latest_decision.decision_digest != str(stored["decision_digest"])
+            or latest_decision.snapshot_digest != str(stored["snapshot_digest"])
+        ):
+            reason = (
+                "merge decision changed during execution; no merge request was sent"
+            )
+            record(
+                stage="completed",
+                outcome="blocked",
+                reason=reason,
+                payload={"current_decision": latest_decision.to_dict()},
+            )
+            raise PolicyError(reason)
+
+        public_write = False
+        try:
+            public_write = True
+            result = self.github.merge_pull_request(
+                repository,
+                pull_number,
+                head_sha=latest_snapshot.head_sha,
+                method=method,
+            )
+            if not result["merged"]:
+                raise GitHubError(
+                    f"GitHub declined the merge: {result.get('message') or 'unknown'}"
+                )
+        except GitHubError as exc:
+            try:
+                reconciled = self._current_merge_evaluation(run_id)
+                reconciled_snapshot, reconciled_raw = reconciled[4], reconciled[6]
+            except (
+                GitHubError,
+                KeyError,
+                PolicyError,
+                TypeError,
+                ValueError,
+            ) as check_exc:
+                reason = (
+                    "merge result is uncertain and GitHub state could not be confirmed"
+                )
+                record(
+                    stage="completed",
+                    outcome="failed",
+                    reason=reason,
+                    payload={
+                        "merge_error": str(exc),
+                        "reconcile_error": str(check_exc),
+                    },
+                )
+                raise PolicyError(reason) from exc
+            if (
+                reconciled_snapshot.state.casefold() == "merged"
+                and reconciled_snapshot.head_sha == expected_head
+            ):
+                result = {
+                    "merged": True,
+                    "sha": str(reconciled_raw.get("merge_commit_sha") or ""),
+                    "message": "merge confirmed after an uncertain API result",
+                }
+            else:
+                reason = "GitHub did not merge the verified pull request head"
+                record(
+                    stage="completed",
+                    outcome="failed",
+                    reason=reason,
+                    payload={
+                        "merge_error": str(exc),
+                        "state": asdict(reconciled_snapshot),
+                    },
+                )
+                raise PolicyError(reason) from exc
+
+        record(
+            stage="completed",
+            outcome="merged",
+            reason=str(result.get("message") or "pull request merged"),
+            payload={"github_result": result},
+        )
+        return {
+            "run_id": run_id,
+            "repository": repository,
+            "pull_number": pull_number,
+            "merged": True,
+            "idempotent": False,
+            "merge_commit_sha": str(result.get("sha") or ""),
+            "attempt_id": attempt_id,
+            "audit": audits,
+            "public_write": public_write,
         }
 
     def submit(

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -203,6 +203,8 @@ def add_repository(
     section = f"""[repositories.{_toml_string(repository)}]
 enabled = true
 auto_prepare = false
+auto_merge = false
+auto_merge_method = "squash"
 mode = {_toml_string(mode)}
 submission_strategy = {_toml_string("same-repository" if mode == "maintainer" else "fork")}
 require_no_competing_work = true

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -318,6 +318,41 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         """
         CREATE INDEX IF NOT EXISTS storage_gc_runs_recent
         ON storage_gc_runs(created_at DESC)
+        """,
+    ),
+    10: (
+        """
+        CREATE TABLE IF NOT EXISTS merge_executions (
+            id TEXT PRIMARY KEY,
+            attempt_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            decision_id TEXT NOT NULL,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            actor TEXT NOT NULL,
+            merge_method TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            decision_digest TEXT NOT NULL,
+            head_sha TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id),
+            FOREIGN KEY(decision_id) REFERENCES merge_decisions(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS merge_executions_for_pull
+        ON merge_executions(repository, pull_number, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS merge_executions_for_attempt
+        ON merge_executions(attempt_id, created_at)
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS merge_executions_stage_once
+        ON merge_executions(attempt_id, stage)
         """,
     ),
 }
@@ -1404,6 +1439,17 @@ class Store:
                 """,
             ),
             (
+                "merge_execution_audit",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM merge_executions
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
                 "storage_gc_audit",
                 """
                 SELECT CASE WHEN repository='' THEN '*' ELSE repository END AS repository,
@@ -2134,6 +2180,190 @@ class Store:
             value = dict(row)
             value["eligible"] = bool(value["eligible"])
             value["payload"] = json.loads(value["payload"])
+            result.append(value)
+        return result
+
+    def merge_decision(self, decision_id: str) -> dict[str, Any] | None:
+        """Read one merge decision and reject any materialized audit mismatch."""
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM merge_decisions WHERE id=?", (decision_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        value = dict(row)
+        payload = json.loads(str(value["payload"]))
+        snapshot = payload.get("snapshot")
+        if not isinstance(snapshot, dict):
+            raise StoreError("merge decision audit has no snapshot")
+        if _json_digest(snapshot) != str(value["snapshot_digest"]):
+            raise StoreError("merge decision audit snapshot was modified")
+        scope = {
+            "repository": str(value["repository"]),
+            "pull_number": int(value["pull_number"]),
+            "head_sha": str(value["head_sha"]),
+            "base_sha": str(value["base_sha"]),
+            "policy_digest": str(value["policy_digest"]),
+        }
+        if any(snapshot.get(key) != expected for key, expected in scope.items()):
+            raise StoreError("merge decision audit scope was modified")
+        material = {
+            key: payload.get(key)
+            for key in (
+                "eligible",
+                "reasons",
+                "risk_categories",
+                "risk_files",
+                "snapshot_digest",
+            )
+        }
+        if _json_digest(material) != str(value["decision_digest"]):
+            raise StoreError("merge decision audit result was modified")
+        if bool(value["eligible"]) != bool(payload.get("eligible")):
+            raise StoreError("merge decision audit eligibility was modified")
+        value["eligible"] = bool(value["eligible"])
+        value["payload"] = payload
+        return value
+
+    def append_merge_execution(
+        self,
+        *,
+        attempt_id: str,
+        run_id: str,
+        decision_id: str,
+        repository: str,
+        pull_number: int,
+        actor: str,
+        merge_method: str,
+        stage: str,
+        outcome: str,
+        reason: str,
+        decision_digest: str,
+        head_sha: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Append one intent or result record for a merge execution attempt."""
+        if not attempt_id or not run_id or not decision_id:
+            raise ValueError("merge execution identities must not be empty")
+        repository = repository.casefold()
+        actor = actor.strip()
+        if not repository or not actor or not decision_digest or not head_sha:
+            raise ValueError("merge execution audit fields must not be empty")
+        if pull_number < 1:
+            raise ValueError("pull_number must be positive")
+        if stage not in {"applying", "completed"}:
+            raise ValueError(f"unsupported merge execution stage: {stage!r}")
+        if outcome not in {"pending", "merged", "already_merged", "blocked", "failed"}:
+            raise ValueError(f"unsupported merge execution outcome: {outcome!r}")
+        if (stage == "applying") != (outcome == "pending"):
+            raise ValueError("merge execution stage and outcome do not match")
+        if merge_method not in {"merge", "squash", "rebase"}:
+            raise ValueError(f"unsupported merge method: {merge_method!r}")
+        if not isinstance(payload, dict):
+            raise TypeError("merge execution payload must be an object")
+        record_id = uuid.uuid4().hex
+        now = utc_now()
+        with self._connection() as connection:
+            run = connection.execute(
+                "SELECT repository FROM runs WHERE id=?", (run_id,)
+            ).fetchone()
+            decision = connection.execute(
+                """
+                SELECT repository, pull_number, decision_digest, head_sha
+                FROM merge_decisions WHERE id=?
+                """,
+                (decision_id,),
+            ).fetchone()
+            if run is None or decision is None:
+                raise StoreError("merge execution references missing audit material")
+            expected = {
+                "repository": repository,
+                "pull_number": pull_number,
+                "decision_digest": decision_digest,
+                "head_sha": head_sha,
+            }
+            if str(run["repository"]) != repository or any(
+                decision[key] != value for key, value in expected.items()
+            ):
+                raise StoreError("merge execution does not match its run and decision")
+            previous = connection.execute(
+                """
+                SELECT run_id, decision_id, repository, pull_number, actor,
+                       merge_method, decision_digest, head_sha
+                FROM merge_executions WHERE attempt_id=? LIMIT 1
+                """,
+                (attempt_id,),
+            ).fetchone()
+            identity = {
+                "run_id": run_id,
+                "decision_id": decision_id,
+                "repository": repository,
+                "pull_number": pull_number,
+                "actor": actor,
+                "merge_method": merge_method,
+                "decision_digest": decision_digest,
+                "head_sha": head_sha,
+            }
+            if previous is not None and any(
+                previous[key] != value for key, value in identity.items()
+            ):
+                raise StoreError("merge execution attempt identity changed")
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO merge_executions(
+                        id, attempt_id, run_id, decision_id, repository,
+                        pull_number, actor, merge_method, stage, outcome,
+                        reason, decision_digest, head_sha, payload, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record_id,
+                        attempt_id,
+                        run_id,
+                        decision_id,
+                        repository,
+                        pull_number,
+                        actor,
+                        merge_method,
+                        stage,
+                        outcome,
+                        str(reason)[:2_000],
+                        decision_digest,
+                        head_sha,
+                        _canonical_json(payload),
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise StoreError(
+                    "merge execution attempt already contains this stage"
+                ) from exc
+        return {
+            "id": record_id,
+            "attempt_id": attempt_id,
+            "stage": stage,
+            "outcome": outcome,
+            "created_at": now,
+        }
+
+    def merge_executions(
+        self, repository: str, pull_number: int, *, limit: int = 30
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 100)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM merge_executions
+                WHERE repository=? AND pull_number=?
+                ORDER BY created_at DESC LIMIT ?
+                """,
+                (repository.casefold(), pull_number, limit),
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = dict(row)
+            value["payload"] = json.loads(str(value["payload"]))
             result.append(value)
         return result
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -371,6 +371,57 @@ submission_strategy = "same-repository"
             with self.assertRaisesRegex(ConfigError, "only in maintainer mode"):
                 load_config(path)
 
+    def test_auto_merge_requires_explicit_maintainer_same_repository_mode(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+auto_merge = true
+mode = "contributor"
+submission_strategy = "fork"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "auto_merge only"):
+                load_config(path)
+
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+auto_merge = true
+auto_merge_method = "squash"
+mode = "maintainer"
+submission_strategy = "same-repository"
+""",
+                encoding="utf-8",
+            )
+            config = load_config(path)
+
+        self.assertTrue(config.repositories["owner/repo"].auto_merge)
+        self.assertEqual(config.repositories["owner/repo"].auto_merge_method, "squash")
+
+    def test_auto_merge_method_is_restricted(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+auto_merge_method = "octopus"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "auto_merge_method"):
+                load_config(path)
+
     def test_quoted_boolean_is_rejected_instead_of_becoming_true(self) -> None:
         with TemporaryDirectory() as directory:
             path = Path(directory) / "config.toml"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -230,6 +230,7 @@ class GitHubPullRequestTests(unittest.TestCase):
                         "additions": 10,
                         "deletions": 2,
                         "changedFiles": 2,
+                        "mergeCommit": {"oid": "f" * 40},
                         "files": {
                             "totalCount": 2,
                             "nodes": files,
@@ -302,11 +303,29 @@ class GitHubPullRequestTests(unittest.TestCase):
 
         self.assertEqual(snapshot["files"], ["src/a.py", "src/b.py"])
         self.assertEqual(snapshot["unresolved_conversations"], 1)
+        self.assertEqual(len(snapshot["conversation_digest"]), 64)
         self.assertEqual(snapshot["checks"][0]["name"], "legacy-ci")
         self.assertEqual(snapshot["checks"][0]["status"], "pending")
         self.assertTrue(snapshot["checks"][1]["required"])
+        self.assertEqual(snapshot["merge_commit_sha"], "f" * 40)
         self.assertEqual(graphql.call_args_list[1].args[1]["files"], "file-1")
         self.assertEqual(graphql.call_args_list[1].args[1]["threads"], "thread-end")
+
+    def test_merge_request_is_pinned_to_one_head_and_method(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        payload = {"merged": True, "sha": "c" * 40, "message": "merged"}
+
+        with patch.object(client, "_request", return_value=(payload, None)) as request:
+            result = client.merge_pull_request(
+                "owner/repo", 12, head_sha="a" * 40, method="squash"
+            )
+
+        self.assertTrue(result["merged"])
+        request.assert_called_once_with(
+            "PUT",
+            "/repos/owner/repo/pulls/12/merge",
+            data={"sha": "a" * 40, "merge_method": "squash"},
+        )
 
     def test_merge_snapshot_rejects_incomplete_connection_data(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -23,6 +23,7 @@ class MergeDecisionTests(unittest.TestCase):
             additions=20,
             deletions=5,
             checks=(MergeCheck("quality", "COMPLETED", "SUCCESS"),),
+            activity_digest="d" * 64,
         )
 
     def evaluate(self, snapshot: MergeSnapshot | None = None, **kwargs):
@@ -55,6 +56,12 @@ class MergeDecisionTests(unittest.TestCase):
                 conversations_complete=False,
                 checks_complete=False,
             )
+        )
+
+        missing_activity = self.evaluate(replace(self.snapshot, activity_digest=""))
+        self.assertEqual(
+            [reason.code for reason in missing_activity.reasons],
+            ["activity_incomplete"],
         )
 
         self.assertFalse(result.eligible)

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -1,22 +1,29 @@
 from __future__ import annotations
 
+import os
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from reposteward.config import RepositoryPolicy
 from reposteward.context import repository_policy_digest
+from reposteward.github import GitHubError
 from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
 
 
 class StubStore:
     def __init__(self, policy: RepositoryPolicy) -> None:
         self.policy = policy
         self.audits: list[dict] = []
+        self.decisions: dict[str, dict] = {}
+        self.executions: list[dict] = []
 
     def run(self, run_id: str) -> dict:
         return {
             "id": run_id,
             "repository": "owner/repo",
+            "status": "submitted",
             "details": {
                 "pr_url": "https://github.com/owner/repo/pull/12",
                 "commit_sha": "a" * 40,
@@ -33,21 +40,75 @@ class StubStore:
 
     def append_merge_decision(self, **kwargs) -> dict:
         self.audits.append(kwargs)
-        return {"id": f"audit-{len(self.audits)}"}
+        decision_id = f"audit-{len(self.audits)}"
+        decision = kwargs["decision"]
+        self.decisions[decision_id] = {
+            "id": decision_id,
+            "repository": kwargs["repository"],
+            "pull_number": kwargs["pull_number"],
+            "head_sha": kwargs["head_sha"],
+            "base_sha": kwargs["base_sha"],
+            "policy_digest": kwargs["policy_digest"],
+            "snapshot_digest": decision["snapshot_digest"],
+            "eligible": decision["eligible"],
+            "decision_digest": decision["decision_digest"],
+            "payload": decision,
+        }
+        return {"id": decision_id}
+
+    def merge_decision(self, decision_id: str) -> dict | None:
+        return self.decisions.get(decision_id)
+
+    def append_merge_execution(self, **kwargs) -> dict:
+        self.executions.append(kwargs)
+        return {
+            "id": f"execution-{len(self.executions)}",
+            "attempt_id": kwargs["attempt_id"],
+            "stage": kwargs["stage"],
+            "outcome": kwargs["outcome"],
+        }
 
 
 class StubGitHub:
+    def __init__(self) -> None:
+        self.activity_marker = "initial"
+        self.state = "OPEN"
+        self.merge_commit_sha = ""
+        self.merge_calls: list[dict] = []
+        self.fail_after_merge = False
+        self.fail_without_merge = False
+        self.activity_calls = 0
+        self.mutate_on_activity_call = 0
+        self.conversation_marker = "initial"
+
+    def pull_request_activity(self, repository: str, number: int) -> dict:
+        self.activity_calls += 1
+        if self.activity_calls == self.mutate_on_activity_call:
+            self.activity_marker = "changed-during-execution"
+        return {
+            "pull_request": {
+                "number": number,
+                "head_sha": "a" * 40,
+                "marker": self.activity_marker,
+            },
+            "comments": [],
+            "reviews": [],
+            "review_comments": [],
+            "checks": [],
+        }
+
     def pull_request_merge_snapshot(self, repository: str, number: int) -> dict:
         return {
             "repository": repository,
             "pull_number": number,
             "head_sha": "a" * 40,
             "base_sha": "b" * 40,
-            "state": "OPEN",
+            "state": self.state,
             "draft": False,
             "mergeable": "MERGEABLE",
             "review_decision": "APPROVED",
             "unresolved_conversations": 0,
+            "conversation_digest": self.conversation_marker,
             "files": ["src/example.py"],
             "additions": 10,
             "deletions": 2,
@@ -62,10 +123,54 @@ class StubGitHub:
             "files_complete": True,
             "conversations_complete": True,
             "checks_complete": True,
+            "merge_commit_sha": self.merge_commit_sha,
         }
+
+    def authenticated_login(self) -> str:
+        return "alice"
+
+    def repository(self, _repository: str) -> SimpleNamespace:
+        return SimpleNamespace(can_push=True)
+
+    def merge_pull_request(
+        self, repository: str, number: int, *, head_sha: str, method: str
+    ) -> dict:
+        self.merge_calls.append(
+            {
+                "repository": repository,
+                "number": number,
+                "head_sha": head_sha,
+                "method": method,
+            }
+        )
+        if self.fail_without_merge:
+            raise GitHubError("network unavailable")
+        self.state = "MERGED"
+        self.merge_commit_sha = "f" * 40
+        if self.fail_after_merge:
+            raise GitHubError("network timeout")
+        return {"merged": True, "sha": self.merge_commit_sha, "message": "merged"}
 
 
 class MergePipelineTests(unittest.TestCase):
+    @staticmethod
+    def pipeline(*, auto_merge: bool = False) -> Pipeline:
+        policy = RepositoryPolicy(
+            name="owner/repo",
+            auto_merge=auto_merge,
+            mode="maintainer",
+            submission_strategy="same-repository",
+        )
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": policy},
+            safety=SimpleNamespace(max_files_changed=18, max_diff_lines=700),
+            github=SimpleNamespace(login="alice"),
+        )
+        pipeline.store = StubStore(policy)
+        pipeline.github = StubGitHub()
+        return pipeline
+
     def test_decision_reads_current_snapshot_and_appends_every_audit(self) -> None:
         policy = RepositoryPolicy(name="owner/repo")
         pipeline = object.__new__(Pipeline)
@@ -88,3 +193,141 @@ class MergePipelineTests(unittest.TestCase):
             pipeline.store.audits[0]["decision"]["snapshot"]["head_sha"],
             "a" * 40,
         )
+
+    def test_opted_in_fresh_decision_merges_once_and_audits_intent_and_result(
+        self,
+    ) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}):
+            result = pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertTrue(result["merged"])
+        self.assertFalse(result["idempotent"])
+        self.assertTrue(result["public_write"])
+        self.assertEqual(len(pipeline.github.merge_calls), 1)
+        self.assertEqual(
+            [value["stage"] for value in pipeline.store.executions],
+            ["applying", "completed"],
+        )
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "merged")
+
+    def test_executor_is_disabled_by_default_and_records_the_block(self) -> None:
+        pipeline = self.pipeline(auto_merge=False)
+        decision = pipeline.merge_decision("run-1")
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}),
+            self.assertRaisesRegex(PolicyError, "auto_merge is not explicitly enabled"),
+        ):
+            pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "blocked")
+        self.assertEqual(pipeline.github.merge_calls, [])
+
+    def test_activity_change_makes_the_decision_stale_without_public_write(
+        self,
+    ) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.activity_marker = "new-review"
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}),
+            self.assertRaisesRegex(PolicyError, "decision is stale"),
+        ):
+            pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertEqual(pipeline.github.merge_calls, [])
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "blocked")
+
+    def test_conversation_change_makes_the_decision_stale_without_public_write(
+        self,
+    ) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.conversation_marker = "thread-resolution-changed"
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}),
+            self.assertRaisesRegex(PolicyError, "decision is stale"),
+        ):
+            pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertEqual(pipeline.github.merge_calls, [])
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "blocked")
+
+    def test_already_merged_verified_head_is_idempotent(self) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.state = "MERGED"
+        pipeline.github.merge_commit_sha = "f" * 40
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}):
+            result = pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertTrue(result["idempotent"])
+        self.assertFalse(result["public_write"])
+        self.assertEqual(result["merge_commit_sha"], "f" * 40)
+        self.assertEqual(pipeline.github.merge_calls, [])
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "already_merged")
+
+    def test_uncertain_merge_response_is_reconciled_before_retry(self) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.fail_after_merge = True
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}):
+            result = pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertTrue(result["merged"])
+        self.assertEqual(len(pipeline.github.merge_calls), 1)
+        self.assertIn("uncertain", pipeline.store.executions[-1]["reason"])
+
+    def test_just_in_time_activity_change_blocks_after_intent_audit(self) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.mutate_on_activity_call = 3
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}),
+            self.assertRaisesRegex(PolicyError, "changed during execution"),
+        ):
+            pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertEqual(pipeline.github.merge_calls, [])
+        self.assertEqual(
+            [value["outcome"] for value in pipeline.store.executions],
+            ["pending", "blocked"],
+        )
+
+    def test_failed_merge_is_not_blindly_retried_while_pr_remains_open(self) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        decision = pipeline.merge_decision("run-1")
+        pipeline.github.fail_without_merge = True
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}),
+            self.assertRaisesRegex(PolicyError, "did not merge"),
+        ):
+            pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertEqual(len(pipeline.github.merge_calls), 1)
+        self.assertEqual(pipeline.store.executions[-1]["outcome"], "failed")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -131,6 +131,8 @@ class SetupTests(unittest.TestCase):
         policy = config.repositories["owner/repo"]
         self.assertEqual(policy.mode, "maintainer")
         self.assertEqual(policy.submission_strategy, "same-repository")
+        self.assertFalse(policy.auto_merge)
+        self.assertEqual(policy.auto_merge_method, "squash")
 
     def test_repo_add_excludes_local_config_without_changing_gitignore(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -136,6 +136,7 @@ class StorageGcTests(unittest.TestCase):
         self.assertEqual(result["estimated_reclaimable_bytes"], 12)
         self.assertEqual(store.audit, [])
         self.assertIn("merge_decision_audit", result["protected_categories"])
+        self.assertIn("merge_execution_audit", result["protected_categories"])
 
     def test_gc_apply_requires_switch_then_audits_and_deletes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -218,6 +218,30 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
             self.assertIsNotNone(table)
 
+    def test_version_nine_database_receives_merge_execution_audit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE merge_executions")
+                connection.execute("PRAGMA user_version=9")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE name='merge_executions'"
+                ).fetchone()
+                unique_stage = connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type='index' AND name='merge_executions_stage_once'
+                    """
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIsNotNone(unique_stage)
+
     def test_version_six_database_moves_event_payloads_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "state.sqlite3"
@@ -484,6 +508,7 @@ class StoreTests(unittest.TestCase):
                 additions=1,
                 deletions=0,
                 checks=(MergeCheck("quality", "COMPLETED", "SUCCESS"),),
+                activity_digest="f" * 64,
             )
             evaluated = evaluate_merge(
                 snapshot,
@@ -512,10 +537,101 @@ class StoreTests(unittest.TestCase):
                 decision=decision,
             )
             audit = store.merge_decisions("owner/repo", 12)
+            loaded = store.merge_decision(first["id"])
+            run_id = store.start_run("owner/repo", 7, "merge")
+            intent = store.append_merge_execution(
+                attempt_id="attempt-1",
+                run_id=run_id,
+                decision_id=first["id"],
+                repository="owner/repo",
+                pull_number=12,
+                actor="alice",
+                merge_method="squash",
+                stage="applying",
+                outcome="pending",
+                reason="fresh decision",
+                decision_digest=evaluated.decision_digest,
+                head_sha="c" * 40,
+                payload={"phase": "before_write"},
+            )
+            completed = store.append_merge_execution(
+                attempt_id="attempt-1",
+                run_id=run_id,
+                decision_id=first["id"],
+                repository="owner/repo",
+                pull_number=12,
+                actor="alice",
+                merge_method="squash",
+                stage="completed",
+                outcome="merged",
+                reason="merged",
+                decision_digest=evaluated.decision_digest,
+                head_sha="c" * 40,
+                payload={"sha": "f" * 40},
+            )
+            executions = store.merge_executions("owner/repo", 12)
+            statistics = store.storage_statistics(repository="owner/repo")
+            with self.assertRaisesRegex(ValueError, "stage and outcome"):
+                store.append_merge_execution(
+                    attempt_id="attempt-invalid-stage",
+                    run_id=run_id,
+                    decision_id=first["id"],
+                    repository="owner/repo",
+                    pull_number=12,
+                    actor="alice",
+                    merge_method="squash",
+                    stage="applying",
+                    outcome="merged",
+                    reason="invalid",
+                    decision_digest=evaluated.decision_digest,
+                    head_sha="c" * 40,
+                    payload={},
+                )
+            with self.assertRaisesRegex(StoreError, "run and decision"):
+                store.append_merge_execution(
+                    attempt_id="attempt-mismatched-decision",
+                    run_id=run_id,
+                    decision_id=first["id"],
+                    repository="owner/repo",
+                    pull_number=12,
+                    actor="alice",
+                    merge_method="squash",
+                    stage="completed",
+                    outcome="blocked",
+                    reason="invalid",
+                    decision_digest="0" * 64,
+                    head_sha="c" * 40,
+                    payload={},
+                )
+            with self.assertRaisesRegex(StoreError, "already contains"):
+                store.append_merge_execution(
+                    attempt_id="attempt-1",
+                    run_id=run_id,
+                    decision_id=first["id"],
+                    repository="owner/repo",
+                    pull_number=12,
+                    actor="alice",
+                    merge_method="squash",
+                    stage="applying",
+                    outcome="pending",
+                    reason="duplicate intent",
+                    decision_digest=evaluated.decision_digest,
+                    head_sha="c" * 40,
+                    payload={},
+                )
 
         self.assertNotEqual(first["id"], second["id"])
         self.assertEqual(len(audit), 2)
         self.assertTrue(all(value["eligible"] for value in audit))
+        assert loaded is not None
+        self.assertEqual(loaded["decision_digest"], evaluated.decision_digest)
+        self.assertNotEqual(intent["id"], completed["id"])
+        self.assertEqual(len(executions), 2)
+        self.assertEqual(
+            {value["stage"] for value in executions}, {"applying", "completed"}
+        )
+        by_category = {value["category"]: value for value in statistics}
+        self.assertEqual(by_category["merge_execution_audit"]["records"], 2)
 
     def test_merge_decision_audit_rejects_tampered_material(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -539,6 +655,51 @@ class StoreTests(unittest.TestCase):
                     policy_digest="e" * 64,
                     decision=decision,
                 )
+
+    def test_merge_decision_reader_rejects_database_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            snapshot = MergeSnapshot(
+                repository="owner/repo",
+                pull_number=12,
+                head_sha="c" * 40,
+                base_sha="d" * 40,
+                policy_digest="e" * 64,
+                state="OPEN",
+                draft=False,
+                mergeable="MERGEABLE",
+                review_decision="APPROVED",
+                unresolved_conversations=0,
+                files=("src/example.py",),
+                additions=1,
+                deletions=0,
+                checks=(MergeCheck("quality", "COMPLETED", "SUCCESS"),),
+                activity_digest="f" * 64,
+            )
+            evaluated = evaluate_merge(
+                snapshot,
+                expected_head_sha="c" * 40,
+                expected_base_sha="d" * 40,
+                expected_policy_digest="e" * 64,
+                max_files_changed=18,
+                max_diff_lines=700,
+            )
+            audit = store.append_merge_decision(
+                repository="owner/repo",
+                pull_number=12,
+                head_sha="c" * 40,
+                base_sha="d" * 40,
+                policy_digest="e" * 64,
+                decision={**evaluated.to_dict(), "snapshot": asdict(snapshot)},
+            )
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                connection.execute(
+                    "UPDATE merge_decisions SET decision_digest=? WHERE id=?",
+                    ("0" * 64, audit["id"]),
+                )
+
+            with self.assertRaisesRegex(StoreError, "result was modified"):
+                store.merge_decision(audit["id"])
 
     def test_candidate_round_trip_and_status_preservation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Closes #14

## 做了什么

为 Maintainer 模式增加默认关闭、仓库级显式授权的合并执行器。执行器只消费指定的、已经审计且仍为 eligible 的 Merge Decision；调用 GitHub 前会重新核对 PR 活动、Review 会话、checks、head/base、策略、规模和风险，并把请求绑定到精确 head SHA。

## 安全与幂等

- 同时要求 `auto_merge = true`、Maintainer mode、same-repository、命令级环境开关、配置身份、token 实际身份和 push 权限。
- 内置高风险路径、规模超限、不完整事实或任何决策摘要变化都会 fail closed。
- 写入前记录 `applying` 意图，结束后追加结果；审计记录校验 run、decision、PR、head 和 digest 的一致性，普通 GC 不删除。
- GitHub 结果不确定时先回读状态；相同 head 已合并视为幂等成功，其他状态不盲目重试。
- 不用于 Contributor mode，不回复 Reviewer，也不引入后台常驻服务。

## 验证

- `uv run python -m unittest discover -s tests -v`（169 项通过）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build --no-build-isolation`

## 审查声明

本变更使用外部 coding workspace 辅助完成。`tiammomo` 已检查最终 diff，理解并对本次贡献负责。
