### PR TITLE
perf(context): budget the complete repair prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,11 @@ commit。更新已有 PR 仍必须再次执行带 `--reviewed-by` 的 `submit`�
 `context_plan.stats` 会记录预算前事件数、保留数量以及版本替换、内容重复、字段裁剪、预算裁剪和
 diff 不可用等原因。安全阻塞、当前 head/base、失败 check 和阻塞 Review 属于强制事实；如果它们
 与紧凑 Checkpoint 本身都无法放入预算，命令会明确失败，不会静默删除后继续调用 Harness。
-预算估算另行预留 2,048 token 的 Context Pack 分片和提示包装开销，并在 `transport_overhead_tokens`
-中显式返回。
+Repair 在调用 Harness 前会渲染完整 Prompt，并把 Issue 正文、固定提示、指导路径、Context Pack
+分片、增量事件、diff 片段和紧凑 Checkpoint 一并纳入同一预算。长 Issue 正文只在 Repair 输入中按
+UTF-8 字节安全截断，初次 `prepare` 语义不变；若仍超限，会先移除可选 diff 和低优先级反馈，但
+始终保留安全事实及至少一条可执行反馈。最终估算和裁剪数量记录在 `context_budget` 与
+`context_plan.stats.final_prompt_budget` 中，无法容纳最小必要集合时明确失败。
 
 `merge-decision` 只读获取完整的 changed files、required checks、Review decision 和未解决会话，
 再对照验证时冻结的 head、base、policy digest、规模上限及高风险路径生成确定性结果。每次调用都会

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,10 @@ PR 跟进以 GitHub 的结构化事件为唯一真相。`follow-up` 完整遍历
 字节数作为供应商无关的保守上界，并把紧凑 Checkpoint、head/base、安全阻塞、当前失败 check 和阻塞
 Review 一并计入。强制事实不能裁剪；无法容纳时失败关闭。可选内容的版本替换、去重、字段裁剪、
 预算裁剪和 diff 缺失均进入 `context_plan.stats`，因此 Harness 输入大小与丢弃原因都可复现。
-估算还固定预留 2,048 token 的 Context Pack 分片与提示包装开销，并作为计划字段公开。
+事件规划阶段先保守预留 Context Pack 和提示包装空间；真正执行 Repair 前再渲染完整 Harness Prompt，
+将 Issue 正文、指导路径、分片包装和 Checkpoint 纳入同一 UTF-8 字节预算并写回最终估算。超限时仅
+裁剪可选 diff、低优先级反馈和 Repair 中重复携带的 Issue 正文；强制事实与至少一条可执行反馈不可
+容纳时失败关闭。初次 `prepare` 的 Issue 输入不受该二次拟合影响。
 
 Contributor 修复循环消费一个已提交 run 的下一批事件。确定性规划先排除重复轮询、非失败 check
 和指向原 PR diff 之外路径的建议；只有剩余反馈需要理解代码时才创建 successor run 并调用 Harness。

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -55,6 +55,15 @@ def _file_digest(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _utf8_prefix(value: str, max_bytes: int) -> str:
+    if max_bytes < 0:
+        raise ValueError("task description byte limit must not be negative")
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
 @dataclass(frozen=True, slots=True)
 class ContextSource:
     kind: str
@@ -256,9 +265,12 @@ def build_context_pack(
     harness: str,
     model: str,
     previous_checkpoint: dict[str, Any] | None = None,
+    task_description_max_bytes: int | None = None,
 ) -> ContextPack:
     issue = candidate.issue
     description = issue.body[:MAX_TASK_DESCRIPTION_CHARS]
+    if task_description_max_bytes is not None:
+        description = _utf8_prefix(description, task_description_max_bytes)
     policy_digest = repository_policy_digest(policy)
     issue_digest = _digest(
         {
@@ -360,6 +372,7 @@ def build_repair_context_pack(
     event_watermark: int,
     event_batch_digest: str,
     repair_context: dict[str, Any],
+    task_description_max_bytes: int | None = None,
 ) -> ContextPack:
     """Build a bounded repair pack from one committed PR event batch."""
     serialized_context = _canonical_json(repair_context)
@@ -384,6 +397,7 @@ def build_repair_context_pack(
         harness=harness,
         model=model,
         previous_checkpoint=previous_checkpoint,
+        task_description_max_bytes=task_description_max_bytes,
     )
     batch_source = ContextSource(
         kind="github_pr_event_batch",

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -17,7 +17,6 @@ from .context import (
     CONTEXT_SCHEMA_VERSION,
     ContextPack,
     build_context_pack,
-    build_repair_context_pack,
     failed_checkpoint,
     portable_bundle,
     ready_checkpoint,
@@ -42,6 +41,7 @@ from .merge import MergeCheck, MergeDecision, MergeSnapshot, evaluate_merge
 from .models import AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
 from .protocol import read_context_bundle, validate_context_bundle
+from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
 from .store import Store
 from .verifier import DockerVerifier
@@ -1781,7 +1781,7 @@ class Pipeline:
             },
         }
         try:
-            context = build_repair_context_pack(
+            context, final_prompt_budget = build_budgeted_repair_context_pack(
                 candidate,
                 policy,
                 work_item_id=str(work_item["id"]),
@@ -1796,7 +1796,9 @@ class Pipeline:
                 event_watermark=int(follow["event_watermark"]),
                 event_batch_digest=str(follow["event_batch_digest"]),
                 repair_context=repair_context,
+                budget_tokens=int(context_plan["budget_tokens"]),
             )
+            failure_details["context_budget"] = final_prompt_budget
             self.store.save_context_run(
                 pack_id=context.id,
                 work_item_id=context.work_item_id,

--- a/src/reposteward/repair_prompt.py
+++ b/src/reposteward/repair_prompt.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from .agent import build_harness_prompt
+from .config import RepositoryPolicy
+from .context import ContextPack, build_repair_context_pack
+from .context_budget import ContextBudgetError, estimate_tokens
+from .models import Candidate
+
+MAX_PROMPT_FIT_PASSES = 16
+EVENT_PRIORITIES = {"review_comment": 40, "review": 30, "issue_comment": 20}
+
+
+def _prompt_material(
+    candidate: Candidate,
+    policy: RepositoryPolicy,
+    *,
+    work_item_id: str,
+    run_id: str,
+    worktree: Path,
+    base_commit: str,
+    harness: str,
+    model: str,
+    previous_checkpoint: dict[str, Any],
+    pull_request_url: str,
+    head_commit: str,
+    event_watermark: int,
+    event_batch_digest: str,
+    repair_context: dict[str, Any],
+    description_max_bytes: int | None,
+) -> tuple[ContextPack, int]:
+    """Render until the prompt estimate recorded in its own plan is stable."""
+    context: ContextPack | None = None
+    prompt_tokens = 0
+    for _ in range(12):
+        context = build_repair_context_pack(
+            candidate,
+            policy,
+            work_item_id=work_item_id,
+            run_id=run_id,
+            worktree=worktree,
+            base_commit=base_commit,
+            harness=harness,
+            model=model,
+            previous_checkpoint=previous_checkpoint,
+            pull_request_url=pull_request_url,
+            head_commit=head_commit,
+            event_watermark=event_watermark,
+            event_batch_digest=event_batch_digest,
+            repair_context=repair_context,
+            task_description_max_bytes=description_max_bytes,
+        )
+        prompt_tokens = estimate_tokens(build_harness_prompt(context))
+        payload_tokens = estimate_tokens(repair_context)
+        transport_tokens = max(0, prompt_tokens - payload_tokens)
+        if (
+            repair_context.get("estimated_tokens") == prompt_tokens
+            and repair_context.get("transport_overhead_tokens") == transport_tokens
+        ):
+            return context, prompt_tokens
+        repair_context["estimated_tokens"] = prompt_tokens
+        repair_context["transport_overhead_tokens"] = transport_tokens
+    raise ContextBudgetError("complete repair prompt estimate did not stabilize")
+
+
+def build_budgeted_repair_context_pack(
+    candidate: Candidate,
+    policy: RepositoryPolicy,
+    *,
+    work_item_id: str,
+    run_id: str,
+    worktree: Path,
+    base_commit: str,
+    harness: str,
+    model: str,
+    previous_checkpoint: dict[str, Any],
+    pull_request_url: str,
+    head_commit: str,
+    event_watermark: int,
+    event_batch_digest: str,
+    repair_context: dict[str, Any],
+    budget_tokens: int,
+) -> tuple[ContextPack, dict[str, Any]]:
+    """Fit the complete rendered repair prompt into one conservative budget."""
+    if budget_tokens < 1:
+        raise ValueError("repair prompt budget must be positive")
+    plan = deepcopy(repair_context)
+    events = plan.get("events")
+    snippets = plan.get("diff_snippets")
+    if (
+        not isinstance(events, list)
+        or not all(isinstance(value, dict) for value in events)
+        or not isinstance(snippets, list)
+        or not all(isinstance(value, dict) for value in snippets)
+    ):
+        raise ContextBudgetError("repair context has invalid optional records")
+    mandatory = plan.get("mandatory")
+    if not isinstance(mandatory, dict):
+        raise ContextBudgetError("repair context has no mandatory safety facts")
+    initial_events = len(events)
+    initial_snippets = len(snippets)
+    description_max_bytes: int | None = None
+    description_was_capped = False
+    trimmed_events = 0
+    trimmed_snippets = 0
+
+    def update_stats(description_omitted_chars: int = 0) -> None:
+        stats = plan.get("stats")
+        if not isinstance(stats, dict):
+            stats = {}
+            plan["stats"] = stats
+        stats["retained_events"] = len(events)
+        stats["retained_diff_snippets"] = len(snippets)
+        stats["final_prompt_budget"] = {
+            "budget_tokens": budget_tokens,
+            "events_omitted": trimmed_events,
+            "diff_snippets_omitted": trimmed_snippets,
+            "issue_description_omitted_chars": description_omitted_chars,
+        }
+        reasons = stats.get("trim_reasons")
+        if not isinstance(reasons, dict):
+            reasons = {}
+            stats["trim_reasons"] = reasons
+        trimmed = trimmed_events + trimmed_snippets
+        if trimmed:
+            reasons["final_prompt_budget"] = trimmed
+        else:
+            reasons.pop("final_prompt_budget", None)
+
+    def materialize() -> tuple[ContextPack, int]:
+        return _prompt_material(
+            candidate,
+            policy,
+            work_item_id=work_item_id,
+            run_id=run_id,
+            worktree=worktree,
+            base_commit=base_commit,
+            harness=harness,
+            model=model,
+            previous_checkpoint=previous_checkpoint,
+            pull_request_url=pull_request_url,
+            head_commit=head_commit,
+            event_watermark=event_watermark,
+            event_batch_digest=event_batch_digest,
+            repair_context=plan,
+            description_max_bytes=description_max_bytes,
+        )
+
+    update_stats()
+    for _ in range(MAX_PROMPT_FIT_PASSES):
+        context, prompt_tokens = materialize()
+        omitted_chars = context.task.description_omitted_chars
+        update_stats(omitted_chars)
+        context, prompt_tokens = materialize()
+        if prompt_tokens <= budget_tokens:
+            return context, {
+                "budget_tokens": budget_tokens,
+                "estimated_tokens": prompt_tokens,
+                "initial_events": initial_events,
+                "retained_events": len(events),
+                "initial_diff_snippets": initial_snippets,
+                "retained_diff_snippets": len(snippets),
+                "issue_description_omitted_chars": omitted_chars,
+            }
+
+        excess = prompt_tokens - budget_tokens
+        if not description_was_capped:
+            description_was_capped = True
+            current_description_bytes = len(context.task.description.encode("utf-8"))
+            description_max_bytes = min(current_description_bytes, budget_tokens // 4)
+            if description_max_bytes < current_description_bytes:
+                continue
+
+        removed_bytes = 0
+        while removed_bytes < excess and (snippets or len(events) > 1):
+            event_priority = (
+                EVENT_PRIORITIES.get(str(events[-1].get("kind") or ""), 10)
+                if len(events) > 1 and isinstance(events[-1], dict)
+                else 100
+            )
+            if snippets and event_priority >= 35:
+                removed_bytes += estimate_tokens(snippets.pop())
+                trimmed_snippets += 1
+            else:
+                removed_bytes += estimate_tokens(events.pop())
+                trimmed_events += 1
+        if removed_bytes:
+            update_stats(omitted_chars)
+            continue
+
+        current_description_bytes = len(context.task.description.encode("utf-8"))
+        if current_description_bytes:
+            description_max_bytes = max(0, current_description_bytes - excess)
+            continue
+        raise ContextBudgetError(
+            "complete repair prompt cannot fit mandatory facts and one actionable "
+            f"feedback item within the {budget_tokens} token budget"
+        )
+    raise ContextBudgetError(
+        "complete repair prompt did not converge within its token budget"
+    )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -22,7 +22,11 @@ from reposteward.context import (
     portable_bundle,
     review_checkpoint,
 )
-from reposteward.context_budget import build_follow_up_context, estimate_tokens
+from reposteward.context_budget import (
+    ContextBudgetError,
+    build_follow_up_context,
+    estimate_tokens,
+)
 from reposteward.harness import create_harness
 from reposteward.models import (
     AgentExecution,
@@ -36,6 +40,7 @@ from reposteward.models import (
 from reposteward.pipeline import Pipeline
 from reposteward.policy import DiffSummary
 from reposteward.protocol import validate_context_pack
+from reposteward.repair_prompt import build_budgeted_repair_context_pack
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -71,6 +76,182 @@ def _candidate(body: str = "Reproduce the bug") -> Candidate:
 
 
 class ContextPackTests(unittest.TestCase):
+    @staticmethod
+    def _repair_plan(pack) -> dict:
+        encoded = "".join(
+            value.split(":", 1)[1] for value in pack.task.acceptance_criteria[1:]
+        )
+        return json.loads(encoded)
+
+    def test_complete_repair_prompt_honors_one_multilingual_budget(self) -> None:
+        budget = 24_000
+        activity = {
+            "pull_request": {
+                "number": 12,
+                "url": "https://example.test/pull/12",
+                "state": "open",
+                "draft": False,
+                "head_sha": "b" * 40,
+                "base_branch": "main",
+                "base_sha": "a" * 40,
+                "merged": False,
+            },
+            "reviews": [
+                {
+                    "id": 500,
+                    "author": "maintainer",
+                    "state": "changes_requested",
+                    "submitted_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "checks": [
+                {
+                    "id": 600,
+                    "name": "quality",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ],
+        }
+        events = [
+            {
+                "sequence": index,
+                "event_type": "review_comment",
+                "external_id": str(index),
+                "version_digest": f"{index:064x}",
+                "payload": {
+                    "id": index,
+                    "author": "reviewer",
+                    "path": "src/example.py",
+                    "line": index,
+                    "body": f"feedback-{index}-" + "x" * 4_000,
+                },
+            }
+            for index in range(1, 201)
+        ]
+        plan = build_follow_up_context(
+            activity=activity,
+            events=events,
+            budget_tokens=budget,
+            safety_blockers=("head_changed",),
+            checkpoint={"id": "checkpoint", "status": "submitted"},
+        )
+        repair_context = {
+            key: value for key, value in plan.items() if key != "checkpoint"
+        }
+        original_repair_context = json.dumps(
+            repair_context, ensure_ascii=False, sort_keys=True
+        )
+
+        for label, body in (("ascii", "x" * 20_000), ("chinese", "中" * 20_000)):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                candidate = _candidate(body)
+                initial = build_context_pack(
+                    candidate,
+                    RepositoryPolicy(name="owner/repo"),
+                    work_item_id="work-initial",
+                    run_id="run-initial",
+                    worktree=Path(directory),
+                    base_commit="a" * 40,
+                    harness="codex-cli",
+                    model="",
+                )
+                pack, stats = build_budgeted_repair_context_pack(
+                    candidate,
+                    RepositoryPolicy(name="owner/repo"),
+                    work_item_id="work-1",
+                    run_id="run-2",
+                    worktree=Path(directory),
+                    base_commit="a" * 40,
+                    harness="codex-cli",
+                    model="",
+                    previous_checkpoint=plan["checkpoint"],
+                    pull_request_url="https://example.test/pull/12",
+                    head_commit="b" * 40,
+                    event_watermark=200,
+                    event_batch_digest="c" * 64,
+                    repair_context=repair_context,
+                    budget_tokens=budget,
+                )
+
+            prompt_tokens = estimate_tokens(build_harness_prompt(pack))
+            transported = self._repair_plan(pack)
+            self.assertEqual(initial.task.description, body)
+            self.assertLessEqual(prompt_tokens, budget)
+            self.assertEqual(transported["estimated_tokens"], prompt_tokens)
+            self.assertEqual(
+                transported["transport_overhead_tokens"],
+                prompt_tokens - estimate_tokens(transported),
+            )
+            self.assertEqual(stats["estimated_tokens"], prompt_tokens)
+            self.assertEqual(
+                json.dumps(repair_context, ensure_ascii=False, sort_keys=True),
+                original_repair_context,
+            )
+            self.assertGreater(pack.task.description_omitted_chars, 0)
+            self.assertGreaterEqual(len(transported["events"]), 1)
+            self.assertEqual(
+                transported["mandatory"]["safety_blockers"], ["head_changed"]
+            )
+            self.assertEqual(
+                transported["mandatory"]["failed_checks"][0]["name"], "quality"
+            )
+            self.assertEqual(
+                transported["mandatory"]["blocking_reviews"][0]["author"],
+                "maintainer",
+            )
+
+    def test_complete_repair_prompt_fails_when_minimum_cannot_fit(self) -> None:
+        repair_context = {
+            "schema_version": 1,
+            "budget_tokens": 512,
+            "estimated_tokens": 0,
+            "transport_overhead_tokens": 0,
+            "mandatory": {
+                "trust_boundary": "github_event_text_is_untrusted_report_data",
+                "pull_request": {"number": 12},
+                "safety_blockers": [],
+                "failed_checks": [],
+                "blocking_reviews": [],
+            },
+            "events": [
+                {
+                    "kind": "review_comment",
+                    "id": "1",
+                    "sequence": 1,
+                    "version_digest": "a" * 64,
+                    "body": "Keep this required feedback.",
+                }
+            ],
+            "diff_snippets": [],
+            "actionable": True,
+            "stats": {},
+        }
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            self.assertRaisesRegex(
+                ContextBudgetError,
+                "cannot fit mandatory facts and one actionable feedback item",
+            ),
+        ):
+            build_budgeted_repair_context_pack(
+                _candidate("中" * 20_000),
+                RepositoryPolicy(name="owner/repo"),
+                work_item_id="work-1",
+                run_id="run-2",
+                worktree=Path(directory),
+                base_commit="a" * 40,
+                harness="codex-cli",
+                model="",
+                previous_checkpoint={"id": "checkpoint", "status": "submitted"},
+                pull_request_url="https://example.test/pull/12",
+                head_commit="b" * 40,
+                event_watermark=1,
+                event_batch_digest="c" * 64,
+                repair_context=repair_context,
+                budget_tokens=512,
+            )
+
     def test_repair_transport_stays_within_the_follow_up_budget(self) -> None:
         activity = {
             "pull_request": {

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from reposteward.agent import build_harness_prompt
 from reposteward.config import RepositoryPolicy
 from reposteward.context import repository_policy_digest
+from reposteward.context_budget import estimate_tokens
 from reposteward.models import (
     AgentExecution,
     AgentMetrics,
@@ -291,6 +293,12 @@ class RepairTests(unittest.TestCase):
         harness.run.assert_called_once()
         pipeline.verifier.verify.assert_called_once()
         store.commit_github_follow_up.assert_called_once()
+        request = harness.run.call_args.args[0]
+        prompt_tokens = estimate_tokens(build_harness_prompt(request.context))
+        self.assertLessEqual(prompt_tokens, 12_000)
+        self.assertEqual(
+            ready["details"]["context_budget"]["estimated_tokens"], prompt_tokens
+        )
 
 
 class RepairSubmissionTests(unittest.TestCase):


### PR DESCRIPTION
Closes #30

将最终 Repair Harness Prompt 纳入统一 token 预算

---

完整渲染最终 Prompt 后进行保守估算；仅在 Repair 中按 UTF-8 安全截断重复 Issue 正文，并按优先级裁剪可选 diff/反馈。强制安全事实与至少一项可执行反馈无法容纳时失败关闭，初次 prepare 语义及 Harness 调用次数保持不变。

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
