### PR TITLE
feat(portfolio): inspect pull request overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ RepoSteward 把一次代码维护任务拆成八个可审计步骤：
 - 在无凭据、无网络的容器中执行允许的验证命令；
 - 生成紧凑的 Review Packet，并在人工确认后创建 Draft PR；
 - 使用 Context Pack 和 Checkpoint 在账号、机器或 Harness 之间交接任务。
+- 只读汇总仓库全部开放 PR，并标出文件重叠、CI、Review 与事实完整性。
 
 Claude Code、DeepSeek 等 Harness 目前只有统一接入契约，尚未提供内置适配器。配置格式和公开
 接口在稳定版本发布前仍可能调整。
@@ -229,6 +230,32 @@ uv run reposteward prepare owner/repository 123
 Docker socket。
 
 如果改动已经在外部工作区完成，可以使用 `adopt` 将现有 commit 纳入同一验证与审阅流程。
+
+## PR 组合快照
+
+在同时维护多个 PR 时，可以先生成仓库级只读快照：
+
+```bash
+uv run reposteward portfolio inspect owner/repository --format text
+uv run reposteward portfolio inspect owner/repository --format json
+```
+
+命令会完整分页读取全部开放 PR，再汇总每个 PR 的 head/base、Draft 状态、changed files、diff
+规模、required checks、Review decision 和未解决会话。文件重叠通过倒排索引构建，不会逐对重新扫描
+所有 changed files。任何权限不足、分页不完整或采集期间的状态变化都会把快照标记为不完整，并在
+结果中保留对应 PR 和错误原因。
+
+每个快照都有基于规范化事实生成的稳定 SHA-256。需要在后续动作前检查事实是否仍未变化时，可传入
+上一次摘要：
+
+```bash
+uv run reposteward portfolio inspect owner/repository \
+  --expected-digest SNAPSHOT_DIGEST \
+  --format text
+```
+
+该命令不调用 Harness、不修改 workspace、不持久化快照，也不执行任何 GitHub 写操作。JSON 适合
+自动化消费，文本输出只展示紧凑的人类审阅摘要。
 
 ## 审阅与日志
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,18 @@ local draft ── explicit stage ──► Project Draft Issue
 - Runner 只安装依赖并执行已允许的验证命令，不接触宿主凭据。
 - 人类审阅者决定是否发布，并对最终提交负责。
 
+## 仓库级 PR 组合视图
+
+单个 run 的 Checkpoint 不能回答多个开放 PR 是否修改同一批文件。Portfolio Inspector 因此从
+GitHub 当前事实临时构建仓库级快照：先完整分页枚举开放 PR，再复用 Merge Snapshot 的完整分页读取
+获得每个 PR 的 head/base、文件、规模、required checks、Review 和未解决会话。采集错误、权限不足
+或过程中检测到的 head/state 变化都会显式降低完整性，不会被当成“没有冲突”。
+
+重叠关系按 changed file 建立倒排索引，只为实际共同修改文件的 PR 组合生成边；成本与读取的文件
+引用和最终输出边数相关，不对所有 PR 两两重扫文件列表。规范化后的完整快照生成稳定摘要，调用方
+可以用 expected digest 检测后续读取是否已经陈旧。v1 不把快照写入数据库、不调用 Harness，也不
+修改 workspace 或 GitHub；它是后续依赖排序、WIP 策略和单步协调器的只读事实层。
+
 ## 持久数据模型
 
 SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化数据库会原地升级；高于当前

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -12,6 +12,7 @@ from .discovery import DiscoveryService
 from .doctor import run_doctor
 from .issues import read_details
 from .pipeline import Pipeline
+from .portfolio import render_portfolio_text
 from .setup import add_repository, initialize_user_config
 
 
@@ -188,6 +189,23 @@ def _parser() -> argparse.ArgumentParser:
     )
     storage_gc.add_argument("--repo", default="", help="limit to owner/name")
     storage_gc.add_argument("--apply", action="store_true")
+
+    portfolio = subparsers.add_parser(
+        "portfolio", help="inspect repository-wide pull request state"
+    )
+    portfolio_commands = portfolio.add_subparsers(
+        dest="portfolio_command", required=True
+    )
+    portfolio_inspect = portfolio_commands.add_parser(
+        "inspect", help="build a read-only open pull request snapshot"
+    )
+    portfolio_inspect.add_argument("repository")
+    portfolio_inspect.add_argument(
+        "--expected-digest",
+        default="",
+        help="report whether current facts still match this snapshot digest",
+    )
+    portfolio_inspect.add_argument("--format", choices=("json", "text"), default="json")
 
     follow_up = subparsers.add_parser(
         "follow-up",
@@ -437,6 +455,19 @@ def main(argv: list[str] | None = None) -> int:
                 _json(pipeline.storage_gc(repository=args.repo, apply=args.apply))
                 return 0
             raise AssertionError(f"unhandled storage command: {args.storage_command}")
+        if args.command == "portfolio":
+            if args.portfolio_command == "inspect":
+                result = pipeline.portfolio_snapshot(
+                    args.repository, expected_digest=args.expected_digest
+                )
+                if args.format == "text":
+                    print(render_portfolio_text(result))
+                else:
+                    _json(result)
+                return 0
+            raise AssertionError(
+                f"unhandled portfolio command: {args.portfolio_command}"
+            )
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
             return 0

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -38,10 +38,13 @@ class PullRequest:
     url: str
     state: str
     draft: bool
+    title: str = ""
+    updated_at: str = ""
     head_owner: str = ""
     head_branch: str = ""
     head_sha: str = ""
     base_branch: str = ""
+    base_sha: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,13 +188,19 @@ class GitHubClient:
         return any('rel="next"' in value for value in link.split(",") if value.strip())
 
     def _paginated_rest_values(
-        self, path: str, *, container: str = ""
+        self,
+        path: str,
+        *,
+        container: str = "",
+        query: dict[str, str | int] | None = None,
     ) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         page = 1
         while True:
             payload, response = self._request(
-                "GET", path, query={"per_page": 100, "page": page}
+                "GET",
+                path,
+                query={**(query or {}), "per_page": 100, "page": page},
             )
             values = (
                 payload.get(container)
@@ -701,6 +710,18 @@ class GitHubClient:
             return None
         return self._parse_pull_request(payload[0])
 
+    def open_pull_requests(self, upstream: str) -> tuple[PullRequest, ...]:
+        """Return every open pull request by following REST pagination."""
+        values = self._paginated_rest_values(
+            f"/repos/{upstream}/pulls", query={"state": "open"}
+        )
+        return tuple(
+            sorted(
+                (self._parse_pull_request(value) for value in values),
+                key=lambda value: value.number,
+            )
+        )
+
     @staticmethod
     def _parse_pull_request(item: dict[str, Any]) -> PullRequest:
         head = item.get("head") or {}
@@ -711,10 +732,13 @@ class GitHubClient:
             url=str(item["html_url"]),
             state=str(item["state"]),
             draft=bool(item.get("draft", False)),
+            title=str(item.get("title") or ""),
+            updated_at=str(item.get("updated_at") or ""),
             head_owner=str(head_owner),
             head_branch=str(head.get("ref") or ""),
             head_sha=str(head.get("sha") or ""),
             base_branch=str(base.get("ref") or ""),
+            base_sha=str(base.get("sha") or ""),
         )
 
     def pull_request(self, upstream: str, number: int) -> PullRequest:
@@ -825,7 +849,8 @@ class GitHubClient:
                 ) {
                   repository(owner: $owner, name: $name) {
                     pullRequest(number: $number) {
-                      number state isDraft mergeable reviewDecision
+                      number title url updatedAt state isDraft mergeable reviewDecision
+                      headRefName baseRefName
                       headRefOid baseRefOid additions deletions changedFiles
                       mergeCommit { oid }
                       files(first: 100, after: $files) {
@@ -961,7 +986,12 @@ class GitHubClient:
         return {
             "repository": upstream.casefold(),
             "pull_number": int(pull["number"]),
+            "title": str(pull.get("title") or ""),
+            "url": str(pull.get("url") or ""),
+            "updated_at": str(pull.get("updatedAt") or ""),
+            "head_branch": str(pull.get("headRefName") or ""),
             "head_sha": str(pull.get("headRefOid") or ""),
+            "base_branch": str(pull.get("baseRefName") or ""),
             "base_sha": str(pull.get("baseRefOid") or ""),
             "state": str(pull.get("state") or ""),
             "draft": bool(pull.get("isDraft")),

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -40,6 +40,7 @@ from .issues import (
 from .merge import MergeCheck, MergeDecision, MergeSnapshot, evaluate_merge
 from .models import AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
+from .portfolio import build_portfolio_snapshot
 from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
@@ -109,6 +110,79 @@ class Pipeline:
             return self.config.repositories[repository.casefold()]
         except KeyError as exc:
             raise PolicyError(f"repository is not allowlisted: {repository}") from exc
+
+    def portfolio_snapshot(
+        self, repository: str, *, expected_digest: str = ""
+    ) -> dict[str, Any]:
+        """Read every open PR and return one deterministic portfolio snapshot."""
+        policy = self.policy(repository)
+        if expected_digest and not re.fullmatch(r"[a-f0-9]{64}", expected_digest):
+            raise ValueError("expected portfolio digest must be 64 lowercase hex chars")
+        pulls = self.github.open_pull_requests(policy.name)
+        snapshots: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        for pull in pulls:
+            try:
+                snapshot = self.github.pull_request_merge_snapshot(
+                    policy.name, pull.number
+                )
+                if str(snapshot.get("state") or "").casefold() != "open":
+                    errors.append(
+                        {
+                            "pull_number": pull.number,
+                            "message": "pull request changed state during snapshot",
+                        }
+                    )
+                elif pull.head_sha and snapshot.get("head_sha") != pull.head_sha:
+                    errors.append(
+                        {
+                            "pull_number": pull.number,
+                            "message": "pull request head changed during snapshot",
+                        }
+                    )
+                elif pull.base_sha and snapshot.get("base_sha") != pull.base_sha:
+                    errors.append(
+                        {
+                            "pull_number": pull.number,
+                            "message": "pull request base changed during snapshot",
+                        }
+                    )
+                snapshots.append(snapshot)
+            except GitHubError as exc:
+                errors.append({"pull_number": pull.number, "message": str(exc)[:500]})
+                snapshots.append(
+                    {
+                        "repository": policy.name.casefold(),
+                        "pull_number": pull.number,
+                        "title": pull.title,
+                        "url": pull.url,
+                        "state": pull.state,
+                        "draft": pull.draft,
+                        "updated_at": pull.updated_at,
+                        "head_branch": pull.head_branch,
+                        "head_sha": pull.head_sha,
+                        "base_branch": pull.base_branch,
+                        "base_sha": pull.base_sha,
+                        "files": [],
+                        "checks": [],
+                        "files_complete": False,
+                        "conversations_complete": False,
+                        "checks_complete": False,
+                    }
+                )
+        snapshot = build_portfolio_snapshot(policy.name, snapshots, errors=errors)
+        digest = str(snapshot.pop("snapshot_digest"))
+        return {
+            "snapshot_digest": digest,
+            "expected_digest": expected_digest,
+            "matches_expected_digest": (
+                digest == expected_digest if expected_digest else None
+            ),
+            "snapshot": snapshot,
+            "harness_invoked": False,
+            "workspace_modified": False,
+            "public_write": False,
+        }
 
     def _publication_target(
         self, client: GitHubClient, policy: RepositoryPolicy

--- a/src/reposteward/portfolio.py
+++ b/src/reposteward/portfolio.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from itertools import combinations
+from typing import Any
+
+PORTFOLIO_SCHEMA_VERSION = 1
+MAX_TEXT_OVERLAP_FILES = 5
+MAX_TEXT_PULL_REQUESTS = 50
+MAX_TEXT_OVERLAPS = 50
+MAX_TEXT_ERRORS = 20
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _normalized_check(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": str(value.get("name") or ""),
+        "status": str(value.get("status") or ""),
+        "conclusion": str(value.get("conclusion") or ""),
+        "required": bool(value.get("required")),
+    }
+
+
+def _normalized_pull(value: dict[str, Any]) -> dict[str, Any]:
+    checks = sorted(
+        (
+            _normalized_check(check)
+            for check in value.get("checks", ())
+            if isinstance(check, dict)
+        ),
+        key=lambda check: (
+            check["name"].casefold(),
+            check["status"].casefold(),
+            check["conclusion"].casefold(),
+            check["required"],
+        ),
+    )
+    files = sorted(
+        {str(path) for path in value.get("files", ()) if isinstance(path, str) and path}
+    )
+    files_complete = bool(value.get("files_complete"))
+    conversations_complete = bool(value.get("conversations_complete"))
+    checks_complete = bool(value.get("checks_complete"))
+    return {
+        "number": int(value["pull_number"]),
+        "title": str(value.get("title") or ""),
+        "url": str(value.get("url") or ""),
+        "state": str(value.get("state") or ""),
+        "draft": bool(value.get("draft")),
+        "updated_at": str(value.get("updated_at") or ""),
+        "head_branch": str(value.get("head_branch") or ""),
+        "head_sha": str(value.get("head_sha") or ""),
+        "base_branch": str(value.get("base_branch") or ""),
+        "base_sha": str(value.get("base_sha") or ""),
+        "mergeable": str(value.get("mergeable") or ""),
+        "review_decision": str(value.get("review_decision") or ""),
+        "unresolved_conversations": int(value.get("unresolved_conversations") or 0),
+        "files": files,
+        "additions": int(value.get("additions") or 0),
+        "deletions": int(value.get("deletions") or 0),
+        "checks": checks,
+        "files_complete": files_complete,
+        "conversations_complete": conversations_complete,
+        "checks_complete": checks_complete,
+        "facts_complete": bool(
+            files_complete and conversations_complete and checks_complete
+        ),
+    }
+
+
+def build_portfolio_snapshot(
+    repository: str,
+    pull_requests: list[dict[str, Any]],
+    *,
+    errors: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a stable repository-wide snapshot without model assumptions."""
+    pulls = sorted(
+        (_normalized_pull(value) for value in pull_requests),
+        key=lambda value: value["number"],
+    )
+    numbers = [value["number"] for value in pulls]
+    if len(numbers) != len(set(numbers)):
+        raise ValueError("portfolio snapshot contains duplicate pull requests")
+
+    pulls_by_file: dict[str, list[int]] = defaultdict(list)
+    for pull in pulls:
+        if not pull["files_complete"]:
+            continue
+        for path in pull["files"]:
+            pulls_by_file[path].append(pull["number"])
+
+    files_by_pair: dict[tuple[int, int], list[str]] = defaultdict(list)
+    for path, pull_numbers in pulls_by_file.items():
+        for pair in combinations(sorted(set(pull_numbers)), 2):
+            files_by_pair[pair].append(path)
+    overlaps = [
+        {
+            "left": pair[0],
+            "right": pair[1],
+            "file_count": len(paths),
+            "files": sorted(paths),
+        }
+        for pair, paths in sorted(files_by_pair.items())
+    ]
+    normalized_errors = sorted(
+        (
+            {
+                "pull_number": int(value.get("pull_number") or 0),
+                "message": str(value.get("message") or "")[:500],
+            }
+            for value in (errors or ())
+        ),
+        key=lambda value: (value["pull_number"], value["message"]),
+    )
+    snapshot = {
+        "schema_version": PORTFOLIO_SCHEMA_VERSION,
+        "repository": repository.casefold(),
+        "complete": not normalized_errors
+        and all(value["facts_complete"] for value in pulls),
+        "pull_requests": pulls,
+        "overlaps": overlaps,
+        "errors": normalized_errors,
+        "stats": {
+            "pull_requests": len(pulls),
+            "draft_pull_requests": sum(value["draft"] for value in pulls),
+            "overlapping_pairs": len(overlaps),
+            "files_in_overlaps": sum(
+                len(set(pull_numbers)) > 1 for pull_numbers in pulls_by_file.values()
+            ),
+            "incomplete_pull_requests": sum(
+                not value["facts_complete"] for value in pulls
+            ),
+        },
+    }
+    return {**snapshot, "snapshot_digest": _digest(snapshot)}
+
+
+def render_portfolio_text(result: dict[str, Any]) -> str:
+    snapshot = result["snapshot"]
+    stats = snapshot["stats"]
+    lines = [
+        f"Portfolio: {snapshot['repository']}",
+        f"Snapshot: {result['snapshot_digest']}",
+        f"Complete: {'yes' if snapshot['complete'] else 'no'}",
+        (
+            "Pull requests: "
+            f"{stats['pull_requests']} ({stats['draft_pull_requests']} draft); "
+            f"overlapping pairs: {stats['overlapping_pairs']}"
+        ),
+    ]
+    expected = result.get("expected_digest")
+    if expected:
+        state = "current" if result.get("matches_expected_digest") else "stale"
+        lines.append(f"Expected snapshot: {state}")
+    pulls = snapshot["pull_requests"]
+    for pull in pulls[:MAX_TEXT_PULL_REQUESTS]:
+        required = [value for value in pull["checks"] if value["required"]]
+        successful = sum(
+            str(value["conclusion"]).casefold() in {"success", "neutral", "skipped"}
+            for value in required
+        )
+        lines.append(
+            f"#{pull['number']} "
+            f"{'draft' if pull['draft'] else 'open'} "
+            f"base={pull['base_branch']}@{pull['base_sha'][:10]} "
+            f"head={pull['head_sha'][:10]} files={len(pull['files'])} "
+            f"required_checks={successful}/{len(required)} "
+            f"review={pull['review_decision'] or 'NONE'} "
+            f"threads={pull['unresolved_conversations']}"
+        )
+    if len(pulls) > MAX_TEXT_PULL_REQUESTS:
+        lines.append(
+            f"... {len(pulls) - MAX_TEXT_PULL_REQUESTS} additional pull requests "
+            "omitted; use --format json for complete facts"
+        )
+    overlaps = snapshot["overlaps"]
+    for overlap in overlaps[:MAX_TEXT_OVERLAPS]:
+        shown = overlap["files"][:MAX_TEXT_OVERLAP_FILES]
+        omitted = overlap["file_count"] - len(shown)
+        suffix = f" (+{omitted} more)" if omitted else ""
+        lines.append(
+            f"#{overlap['left']} <-> #{overlap['right']}: {', '.join(shown)}{suffix}"
+        )
+    if len(overlaps) > MAX_TEXT_OVERLAPS:
+        lines.append(
+            f"... {len(overlaps) - MAX_TEXT_OVERLAPS} additional overlaps omitted; "
+            "use --format json for complete facts"
+        )
+    errors = snapshot["errors"]
+    for error in errors[:MAX_TEXT_ERRORS]:
+        lines.append(f"Incomplete #{error['pull_number']}: {error['message']}")
+    if len(errors) > MAX_TEXT_ERRORS:
+        lines.append(
+            f"... {len(errors) - MAX_TEXT_ERRORS} additional errors omitted; "
+            "use --format json for complete facts"
+        )
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from reposteward.cli import main
 from reposteward.config import load_config
@@ -122,6 +122,49 @@ class CliSetupTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertFalse(payload["public_write"])
         self.assertIn("## Summary", payload["body"])
+
+    def test_portfolio_inspect_supports_json_and_text(self) -> None:
+        result = {
+            "snapshot_digest": "a" * 64,
+            "expected_digest": "",
+            "matches_expected_digest": None,
+            "snapshot": {
+                "repository": "owner/repo",
+                "complete": True,
+                "pull_requests": [],
+                "overlaps": [],
+                "errors": [],
+                "stats": {
+                    "pull_requests": 0,
+                    "draft_pull_requests": 0,
+                    "overlapping_pairs": 0,
+                },
+            },
+            "harness_invoked": False,
+            "workspace_modified": False,
+            "public_write": False,
+        }
+        pipeline = MagicMock()
+        pipeline.portfolio_snapshot.return_value = result
+
+        json_output = io.StringIO()
+        text_output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+        ):
+            with redirect_stdout(json_output):
+                json_code = main(["portfolio", "inspect", "owner/repo"])
+            with redirect_stdout(text_output):
+                text_code = main(
+                    ["portfolio", "inspect", "owner/repo", "--format", "text"]
+                )
+
+        self.assertEqual(json_code, 0)
+        self.assertEqual(text_code, 0)
+        self.assertEqual(json.loads(json_output.getvalue()), result)
+        self.assertIn("Portfolio: owner/repo", text_output.getvalue())
+        pipeline.portfolio_snapshot.assert_called_with("owner/repo", expected_digest="")
 
 
 if __name__ == "__main__":

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -95,6 +95,45 @@ class GitHubCompetingWorkTests(unittest.TestCase):
         )
 
 
+class GitHubPullRequestPaginationTests(unittest.TestCase):
+    def test_open_pull_requests_follows_every_rest_page(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+
+        def pull(number: int) -> dict[str, object]:
+            return {
+                "number": number,
+                "html_url": f"https://example.test/pulls/{number}",
+                "state": "open",
+                "draft": number == 2,
+                "title": f"Pull {number}",
+                "updated_at": "2026-08-22T00:00:00Z",
+                "head": {
+                    "ref": f"change-{number}",
+                    "sha": str(number) * 40,
+                    "repo": {"owner": {"login": "alice"}},
+                },
+                "base": {"ref": "main", "sha": "b" * 40},
+            }
+
+        first_response = SimpleNamespace(
+            headers={"Link": '<https://api.test/pulls?page=2>; rel="next"'}
+        )
+        final_response = SimpleNamespace(headers={})
+        with patch.object(
+            client,
+            "_request",
+            side_effect=[([pull(2)], first_response), ([pull(1)], final_response)],
+        ) as request:
+            pulls = client.open_pull_requests("owner/repo")
+
+        self.assertEqual([value.number for value in pulls], [1, 2])
+        self.assertEqual(pulls[1].base_sha, "b" * 40)
+        self.assertEqual(request.call_count, 2)
+        self.assertEqual(request.call_args_list[0].kwargs["query"]["state"], "open")
+        self.assertEqual(request.call_args_list[0].kwargs["query"]["page"], 1)
+        self.assertEqual(request.call_args_list[1].kwargs["query"]["page"], 2)
+
+
 class GitHubIssueSearchTests(unittest.TestCase):
     def test_similar_issue_search_is_read_only_and_compact(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from reposteward.config import RepositoryPolicy
+from reposteward.github import GitHubError, PullRequest
+from reposteward.pipeline import Pipeline
+from reposteward.portfolio import build_portfolio_snapshot, render_portfolio_text
+
+
+def _pull(
+    number: int,
+    files: list[str],
+    *,
+    head_sha: str = "a" * 40,
+    complete: bool = True,
+) -> dict[str, object]:
+    return {
+        "repository": "owner/repo",
+        "pull_number": number,
+        "title": f"Pull {number}",
+        "url": f"https://example.test/pulls/{number}",
+        "state": "OPEN",
+        "draft": number == 2,
+        "updated_at": "2026-08-22T00:00:00Z",
+        "head_branch": f"change-{number}",
+        "head_sha": head_sha,
+        "base_branch": "main",
+        "base_sha": "b" * 40,
+        "mergeable": "MERGEABLE",
+        "review_decision": "APPROVED" if number == 1 else "",
+        "unresolved_conversations": 0,
+        "files": files,
+        "additions": number,
+        "deletions": 0,
+        "checks": [
+            {
+                "name": "test",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "required": True,
+            }
+        ],
+        "files_complete": complete,
+        "conversations_complete": complete,
+        "checks_complete": complete,
+    }
+
+
+class PortfolioSnapshotTests(unittest.TestCase):
+    def test_snapshot_is_stable_and_indexes_only_actual_overlaps(self) -> None:
+        pulls = [
+            _pull(3, ["shared/b.py", "only-three.py"]),
+            _pull(1, ["only-one.py", "shared/a.py"]),
+            _pull(2, ["shared/b.py", "shared/a.py", "only-two.py"]),
+            _pull(4, ["shared/a.py"], complete=False),
+        ]
+
+        first = build_portfolio_snapshot("Owner/Repo", pulls)
+        second = build_portfolio_snapshot(
+            "owner/repo",
+            [
+                {
+                    **pulls[2],
+                    "files": list(reversed(pulls[2]["files"])),
+                    "checks": list(reversed(pulls[2]["checks"])),
+                },
+                pulls[3],
+                pulls[1],
+                pulls[0],
+            ],
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            first["overlaps"],
+            [
+                {"left": 1, "right": 2, "file_count": 1, "files": ["shared/a.py"]},
+                {"left": 2, "right": 3, "file_count": 1, "files": ["shared/b.py"]},
+            ],
+        )
+        self.assertEqual(first["stats"]["files_in_overlaps"], 2)
+        self.assertEqual(first["stats"]["incomplete_pull_requests"], 1)
+        self.assertFalse(first["complete"])
+
+    def test_digest_changes_when_decision_facts_change(self) -> None:
+        first = build_portfolio_snapshot("owner/repo", [_pull(1, ["a.py"])])
+        second = build_portfolio_snapshot(
+            "owner/repo", [_pull(1, ["a.py"], head_sha="c" * 40)]
+        )
+
+        self.assertEqual(len(first["snapshot_digest"]), 64)
+        self.assertNotEqual(first["snapshot_digest"], second["snapshot_digest"])
+
+    def test_disjoint_files_produce_no_overlap_edges(self) -> None:
+        snapshot = build_portfolio_snapshot(
+            "owner/repo", [_pull(1, ["a.py"]), _pull(2, ["b.py"])]
+        )
+
+        self.assertEqual(snapshot["overlaps"], [])
+        self.assertEqual(snapshot["stats"]["files_in_overlaps"], 0)
+
+    def test_duplicate_pull_numbers_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duplicate pull requests"):
+            build_portfolio_snapshot(
+                "owner/repo", [_pull(1, ["a.py"]), _pull(1, ["b.py"])]
+            )
+
+    def test_text_output_is_compact_and_reports_staleness(self) -> None:
+        shared = [f"shared/{number}.py" for number in range(7)]
+        snapshot = build_portfolio_snapshot(
+            "owner/repo", [_pull(1, shared), _pull(2, list(reversed(shared)))]
+        )
+        digest = str(snapshot.pop("snapshot_digest"))
+        text = render_portfolio_text(
+            {
+                "snapshot_digest": digest,
+                "expected_digest": "0" * 64,
+                "matches_expected_digest": False,
+                "snapshot": snapshot,
+            }
+        )
+
+        self.assertIn("Expected snapshot: stale", text)
+        self.assertIn("#1 <-> #2:", text)
+        self.assertIn("(+2 more)", text)
+
+    def test_text_output_bounds_large_portfolios(self) -> None:
+        snapshot = build_portfolio_snapshot(
+            "owner/repo",
+            [_pull(number, ["shared.py"]) for number in range(1, 53)],
+            errors=[
+                {"pull_number": number, "message": "unavailable"}
+                for number in range(1, 23)
+            ],
+        )
+        digest = str(snapshot.pop("snapshot_digest"))
+        text = render_portfolio_text(
+            {"snapshot_digest": digest, "expected_digest": "", "snapshot": snapshot}
+        )
+
+        self.assertIn("2 additional pull requests omitted", text)
+        self.assertIn("additional overlaps omitted", text)
+        self.assertIn("2 additional errors omitted", text)
+
+
+class _PortfolioGitHub:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def open_pull_requests(self, _repository: str) -> tuple[PullRequest, ...]:
+        return (
+            PullRequest(
+                number=1,
+                url="https://example.test/pulls/1",
+                state="open",
+                draft=False,
+                title="Complete",
+                head_sha="a" * 40,
+                base_branch="main",
+                base_sha="b" * 40,
+            ),
+            PullRequest(
+                number=2,
+                url="https://example.test/pulls/2",
+                state="open",
+                draft=True,
+                title="Unavailable",
+                head_sha="c" * 40,
+                base_branch="main",
+                base_sha="b" * 40,
+            ),
+        )
+
+    def pull_request_merge_snapshot(
+        self, _repository: str, number: int
+    ) -> dict[str, object]:
+        self.calls.append(number)
+        if number == 2:
+            raise GitHubError("permission denied")
+        return _pull(1, ["src/a.py"])
+
+
+class PortfolioPipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pipeline = object.__new__(Pipeline)
+        self.pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": RepositoryPolicy(name="Owner/Repo")}
+        )
+        self.pipeline.github = _PortfolioGitHub()
+
+    def test_pipeline_surfaces_incomplete_facts_without_side_effects(self) -> None:
+        result = self.pipeline.portfolio_snapshot("OWNER/REPO")
+
+        self.assertEqual(self.pipeline.github.calls, [1, 2])
+        self.assertFalse(result["snapshot"]["complete"])
+        self.assertEqual(result["snapshot"]["stats"]["pull_requests"], 2)
+        self.assertEqual(result["snapshot"]["errors"][0]["pull_number"], 2)
+        self.assertFalse(result["harness_invoked"])
+        self.assertFalse(result["workspace_modified"])
+        self.assertFalse(result["public_write"])
+
+    def test_expected_digest_is_compared_to_current_facts(self) -> None:
+        current = self.pipeline.portfolio_snapshot("owner/repo")
+        repeated = self.pipeline.portfolio_snapshot(
+            "owner/repo", expected_digest=current["snapshot_digest"]
+        )
+
+        self.assertTrue(repeated["matches_expected_digest"])
+
+    def test_state_change_during_collection_marks_snapshot_incomplete(self) -> None:
+        github = self.pipeline.github
+
+        def changed_state(_repository: str, number: int) -> dict[str, object]:
+            snapshot = _pull(number, [f"src/{number}.py"])
+            snapshot["state"] = "CLOSED" if number == 1 else "OPEN"
+            return snapshot
+
+        github.pull_request_merge_snapshot = changed_state
+        result = self.pipeline.portfolio_snapshot("owner/repo")
+
+        self.assertFalse(result["snapshot"]["complete"])
+        self.assertIn("changed state", result["snapshot"]["errors"][0]["message"])
+
+    def test_invalid_expected_digest_is_rejected_before_github_reads(self) -> None:
+        with self.assertRaisesRegex(ValueError, "64 lowercase hex"):
+            self.pipeline.portfolio_snapshot("owner/repo", expected_digest="invalid")
+
+        self.assertEqual(self.pipeline.github.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #32

新增仓库级只读 PR 组合快照、稳定摘要和文件重叠关系图。

---

完整分页枚举开放 PR，复用完整 Merge Snapshot；用 changed-file 倒排索引生成实际重叠边；失败或采集竞态显式降级完整性；JSON 保留完整事实，文本输出有边界；不调用 Harness、不持久化快照、不执行公开写入。

Verified with `uv run ruff check .`, `uv run ruff format --check .`, `uv run python -m unittest discover -s tests -v`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
