### PR TITLE
feat(portfolio): plan pull request dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,44 @@ uv run reposteward portfolio inspect owner/repository \
 该命令不调用 Harness、不修改 workspace、不持久化快照，也不执行任何 GitHub 写操作。JSON 适合
 自动化消费，文本输出只展示紧凑的人类审阅摘要。
 
+需要表达权威依赖时，在 PR 正文中使用独立行；引用、代码块或普通句子中的相似文字不会生效：
+
+```text
+Depends on #123
+```
+
+生成依赖图、循环检测和确定性建议顺序：
+
+```bash
+uv run reposteward portfolio plan owner/repository --format text
+```
+
+PR 正文的显式声明和维护者确认属于权威边；changed-file 重叠只显示为无方向建议，不能单独阻止
+Ready 或 merge。缺失、跨仓库、未合并或循环依赖会进入 `ready_blockers`；已经合并的前置 PR 会进入
+`revalidation_recommended`，提示重新核验 base 和验证证据。`merge-decision` 同样读取当前 PR 的直接
+依赖，未满足或无法完整确认时失败关闭。
+
+正文声明绑定当前 head、PR 作者和稳定来源摘要，编辑历史仍由 GitHub 保存；`portfolio plan` 不把
+外部正文复制到本地数据库，因此保持只读。只有维护者 confirm/revoke 会写入本地追加审计表。
+
+当依赖不是由 PR 作者写入正文时，维护者可以追加一条只保存在本机审计数据库、并绑定当前 head 的
+确认；撤销会追加新事件，不覆盖历史：
+
+```bash
+REPOSTEWARD_ENABLE_DEPENDENCY_ATTESTATION=1 \
+  uv run reposteward portfolio dependency confirm owner/repository 124 123 \
+  --reviewed-by your-github-login
+
+REPOSTEWARD_ENABLE_DEPENDENCY_ATTESTATION=1 \
+  uv run reposteward portfolio dependency revoke owner/repository 124 123 \
+  --reviewed-by your-github-login
+
+uv run reposteward portfolio dependency list owner/repository --pull-number 124
+```
+
+该操作要求 Maintainer same-repository 配置，并同时核对配置身份、GitHub token 身份和仓库 push 权限；
+它不会修改 GitHub。PR head 改变后，旧确认自动失效并成为显式 blocker，必须重新确认或撤销。
+
 ## 审阅与日志
 
 `prepare` 和 `adopt` 返回紧凑 Review Packet，其中包括 commit SHA、diffstat、风险、验证

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,21 @@ GitHub 当前事实临时构建仓库级快照：先完整分页枚举开放 PR�
 可以用 expected digest 检测后续读取是否已经陈旧。v1 不把快照写入数据库、不调用 Harness，也不
 修改 workspace 或 GitHub；它是后续依赖排序、WIP 策略和单步协调器的只读事实层。
 
+Dependency Planner 在该快照上叠加两类权威边：PR 正文中严格、独立的 `Depends on #N` 声明，以及
+维护者通过显式本地门禁确认的 head-bound attestation。外部正文仍是不可信输入，解析器只接受仓库和
+数字引用，不执行其中的其他语义；changed-file 重叠只形成建议，绝不自动升级为门禁。规划器以稳定
+SCC、拓扑和反向邻接遍历以 O(V+E) 检测循环、传播阻塞，并识别缺失、跨仓库、关闭未合并和开放
+依赖，最后生成规范化摘要。已合并依赖不再阻塞顺序，但会提示依赖方的 base 或验证证据可能需要刷新。
+
+正文声明绑定当前 head、PR 作者和来源摘要，其编辑历史由 GitHub 保管；只读规划不会复制外部正文
+或为它新增本地事件。维护者显式确认与撤销才进入本地追加审计，两种来源在计划中分别标识。
+
+维护者确认与撤销都是本地追加事件，绑定仓库、依赖双方、当前 head、身份、来源和前一事件。相同
+动作可并发幂等重试，撤销不删除历史；head 变化使旧确认失效。Portfolio plan 不调用 Harness 或写
+GitHub，Merge Decision 只在当前 PR 存在直接依赖时读取目标 PR，并把依赖摘要和 blocker 纳入已有
+的两次 freshness 检查。RepoSteward 不能阻止维护者绕过它直接在 GitHub 点击 Ready，但所有由
+RepoSteward 产生的 Ready 判断和 merge 决策都会失败关闭。
+
 ## 持久数据模型
 
 SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化数据库会原地升级；高于当前
@@ -103,11 +118,14 @@ Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
 验证日志是唯一默认可回收类别，期限和单次最大对象数由用户级 `[storage]` 配置拥有，项目层不能
 静默缩短。GC 默认 dry-run；apply 同时要求 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后
-追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Merge Decision、Merge Execution 或自身审计。
+追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Portfolio Dependency、Merge Decision、
+Merge Execution 或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 - `merge_executions`：按 attempt 追加保存执行身份、指定决策、精确 head、方法、写入前意图与最终
   GitHub 结果；`applying` 没有对应 `completed` 时表示进程可能在外部写入期间中断，重试必须先回读。
+- `portfolio_dependency_events`：按依赖对追加保存维护者 confirm/revoke、当前 head、身份、来源和
+  前一事件；事件 digest 唯一，读取时会同时校验物化列与规范化载荷。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 from .config import ConfigError, load_config
+from .dependencies import render_dependency_plan_text
 from .discovery import DiscoveryService
 from .doctor import run_doctor
 from .issues import read_details
@@ -206,6 +207,36 @@ def _parser() -> argparse.ArgumentParser:
         help="report whether current facts still match this snapshot digest",
     )
     portfolio_inspect.add_argument("--format", choices=("json", "text"), default="json")
+    portfolio_plan = portfolio_commands.add_parser(
+        "plan", help="plan authoritative pull request dependencies"
+    )
+    portfolio_plan.add_argument("repository")
+    portfolio_plan.add_argument(
+        "--expected-digest",
+        default="",
+        help="report whether current dependency facts still match this plan digest",
+    )
+    portfolio_plan.add_argument("--format", choices=("json", "text"), default="json")
+    portfolio_dependency = portfolio_commands.add_parser(
+        "dependency", help="manage local maintainer dependency attestations"
+    )
+    dependency_commands = portfolio_dependency.add_subparsers(
+        dest="dependency_command", required=True
+    )
+    for action in ("confirm", "revoke"):
+        dependency_action = dependency_commands.add_parser(
+            action, help=f"{action} one head-bound dependency"
+        )
+        dependency_action.add_argument("repository")
+        dependency_action.add_argument("pull_number", type=int)
+        dependency_action.add_argument("dependency_number", type=int)
+        dependency_action.add_argument("--reviewed-by", required=True)
+    dependency_list = dependency_commands.add_parser(
+        "list", help="read recent local dependency audit events"
+    )
+    dependency_list.add_argument("repository")
+    dependency_list.add_argument("--pull-number", type=int, default=0)
+    dependency_list.add_argument("--limit", type=int, default=100)
 
     follow_up = subparsers.add_parser(
         "follow-up",
@@ -464,6 +495,35 @@ def main(argv: list[str] | None = None) -> int:
                     print(render_portfolio_text(result))
                 else:
                     _json(result)
+                return 0
+            if args.portfolio_command == "plan":
+                result = pipeline.portfolio_dependency_plan(
+                    args.repository, expected_digest=args.expected_digest
+                )
+                if args.format == "text":
+                    print(render_dependency_plan_text(result))
+                else:
+                    _json(result)
+                return 0
+            if args.portfolio_command == "dependency":
+                if args.dependency_command == "list":
+                    _json(
+                        pipeline.portfolio_dependency_events(
+                            args.repository,
+                            pull_number=args.pull_number,
+                            limit=args.limit,
+                        )
+                    )
+                    return 0
+                _json(
+                    pipeline.attest_portfolio_dependency(
+                        args.repository,
+                        pull_number=args.pull_number,
+                        dependency_number=args.dependency_number,
+                        action=args.dependency_command,
+                        reviewed_by=args.reviewed_by,
+                    )
+                )
                 return 0
             raise AssertionError(
                 f"unhandled portfolio command: {args.portfolio_command}"

--- a/src/reposteward/dependencies.py
+++ b/src/reposteward/dependencies.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import re
+from collections import defaultdict
+from typing import Any
+
+DEPENDENCY_SCHEMA_VERSION = 1
+MAX_SUGGESTION_FILES = 20
+MAX_TEXT_EDGES = 50
+MAX_TEXT_SUGGESTIONS = 20
+MAX_TEXT_ORDER = 50
+MAX_TEXT_BLOCKED_PULLS = 50
+MAX_TEXT_BLOCKERS_PER_PULL = 10
+
+_DECLARATION = re.compile(
+    r"(?:[-*][ \t]+)?depends[ \t]+on[ \t]+"
+    r"(?:(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?"
+    r"#(?P<number>[1-9][0-9]*)",
+    re.IGNORECASE,
+)
+
+
+def _canonical_digest(value: object) -> str:
+    payload = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def parse_dependency_declarations(
+    repository: str,
+    pull_number: int,
+    head_sha: str,
+    body: str,
+    *,
+    actor: str = "",
+) -> list[dict[str, Any]]:
+    """Parse only strict, standalone dependency lines outside quotes and fences."""
+    normalized_repository = repository.casefold()
+    declarations: dict[tuple[str, int], dict[str, Any]] = {}
+    fence_character = ""
+    fence_length = 0
+    html_comment = False
+    for line_number, line in enumerate(body.splitlines(), start=1):
+        stripped = line.strip()
+        if html_comment:
+            if "-->" in line:
+                html_comment = False
+            continue
+        if "<!--" in line:
+            html_comment = "-->" not in line.split("<!--", 1)[1]
+            continue
+        fence = re.match(r"^(`{3,}|~{3,})", stripped)
+        if fence_character:
+            if re.fullmatch(
+                re.escape(fence_character) + "{" + str(fence_length) + r",}\s*",
+                stripped,
+            ):
+                fence_character = ""
+                fence_length = 0
+            continue
+        if fence is not None:
+            marker = fence.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+            continue
+        if line.lstrip().startswith(">"):
+            continue
+        match = _DECLARATION.fullmatch(stripped)
+        if match is None:
+            continue
+        target_repository = str(
+            match.group("repository") or normalized_repository
+        ).casefold()
+        dependency_number = int(match.group("number"))
+        key = (target_repository, dependency_number)
+        declarations.setdefault(
+            key,
+            {
+                "pull_number": pull_number,
+                "dependency_repository": target_repository,
+                "dependency_number": dependency_number,
+                "head_sha": head_sha,
+                "source": "explicit_pr_body",
+                "actor": actor,
+                "line": line_number,
+                "source_digest": _canonical_digest(
+                    {
+                        "repository": normalized_repository,
+                        "pull_number": pull_number,
+                        "head_sha": head_sha,
+                        "actor": actor,
+                        "dependency_repository": target_repository,
+                        "dependency_number": dependency_number,
+                    }
+                ),
+            },
+        )
+    return sorted(
+        declarations.values(),
+        key=lambda value: (
+            value["pull_number"],
+            value["dependency_repository"],
+            value["dependency_number"],
+        ),
+    )
+
+
+def _authoritative_edges(
+    repository: str,
+    pulls: dict[int, dict[str, Any]],
+    declarations: list[dict[str, Any]],
+    attestations: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    normalized_repository = repository.casefold()
+    sources_by_edge: dict[tuple[int, str, int], list[dict[str, Any]]] = defaultdict(
+        list
+    )
+    for value in declarations:
+        pull_number = int(value["pull_number"])
+        if pull_number not in pulls:
+            continue
+        key = (
+            pull_number,
+            str(value["dependency_repository"]).casefold(),
+            int(value["dependency_number"]),
+        )
+        sources_by_edge[key].append(
+            {
+                "source": "explicit_pr_body",
+                "actor": str(value.get("actor") or ""),
+                "head_sha": str(value["head_sha"]),
+                "source_digest": str(value["source_digest"]),
+            }
+        )
+
+    stale: list[dict[str, Any]] = []
+    for value in attestations:
+        if str(value.get("action") or "") != "confirm":
+            continue
+        pull_number = int(value["pull_number"])
+        pull = pulls.get(pull_number)
+        if pull is None:
+            continue
+        expected_head = str(value["head_sha"])
+        if str(pull.get("head_sha") or "") != expected_head:
+            current_key = (
+                pull_number,
+                normalized_repository,
+                int(value["dependency_number"]),
+            )
+            if current_key not in sources_by_edge:
+                stale.append(
+                    {
+                        "pull_number": pull_number,
+                        "dependency_number": int(value["dependency_number"]),
+                        "confirmed_head_sha": expected_head,
+                        "current_head_sha": str(pull.get("head_sha") or ""),
+                        "actor": str(value.get("actor") or ""),
+                        "event_digest": str(value.get("event_digest") or ""),
+                    }
+                )
+            continue
+        key = (
+            pull_number,
+            normalized_repository,
+            int(value["dependency_number"]),
+        )
+        sources_by_edge[key].append(
+            {
+                "source": "maintainer_confirmed",
+                "actor": str(value.get("actor") or ""),
+                "head_sha": expected_head,
+                "source_digest": str(value.get("event_digest") or ""),
+            }
+        )
+
+    edges = []
+    for (pull_number, dependency_repository, dependency_number), sources in sorted(
+        sources_by_edge.items()
+    ):
+        unique_sources = {
+            (
+                str(value["source"]),
+                str(value["actor"]),
+                str(value["head_sha"]),
+                str(value["source_digest"]),
+            ): value
+            for value in sources
+        }
+        edges.append(
+            {
+                "pull_number": pull_number,
+                "dependency_repository": dependency_repository,
+                "dependency_number": dependency_number,
+                "sources": [
+                    unique_sources[key]
+                    for key in sorted(unique_sources, key=lambda value: value)
+                ],
+            }
+        )
+    stale.sort(key=lambda value: (value["pull_number"], value["dependency_number"]))
+    return edges, stale
+
+
+def _classify_edges(
+    repository: str,
+    pulls: dict[int, dict[str, Any]],
+    edges: list[dict[str, Any]],
+    target_states: dict[tuple[str, int], dict[str, Any]],
+) -> list[dict[str, Any]]:
+    normalized_repository = repository.casefold()
+    classified = []
+    for edge in edges:
+        pull_number = int(edge["pull_number"])
+        dependency_repository = str(edge["dependency_repository"]).casefold()
+        dependency_number = int(edge["dependency_number"])
+        if dependency_repository != normalized_repository:
+            status = "cross_repository"
+        elif pull_number == dependency_number:
+            status = "self_dependency"
+        elif dependency_number in pulls:
+            status = "open"
+        else:
+            target = target_states.get(
+                (dependency_repository, dependency_number), {"state": "unknown"}
+            )
+            state = str(target.get("state") or "unknown").casefold()
+            if bool(target.get("merged")) or state == "merged":
+                status = "merged"
+            elif state == "open":
+                status = "open"
+            elif state == "closed":
+                status = "closed_unmerged"
+            elif state == "missing":
+                status = "missing"
+            else:
+                status = "unknown"
+        classified.append({**edge, "status": status})
+    return classified
+
+
+def _dependency_cycles(
+    nodes: list[int], adjacency: dict[int, set[int]]
+) -> list[list[int]]:
+    """Return stable strongly connected dependency components without recursion."""
+    visited: set[int] = set()
+    finished: list[int] = []
+    for root in sorted(nodes):
+        if root in visited:
+            continue
+        visited.add(root)
+        stack: list[tuple[int, Any]] = [(root, iter(sorted(adjacency.get(root, ()))))]
+        while stack:
+            node, targets = stack[-1]
+            try:
+                target = next(targets)
+            except StopIteration:
+                finished.append(node)
+                stack.pop()
+                continue
+            if target not in visited:
+                visited.add(target)
+                stack.append((target, iter(sorted(adjacency.get(target, ())))))
+
+    reverse: dict[int, set[int]] = defaultdict(set)
+    for source, targets in adjacency.items():
+        for target in targets:
+            reverse[target].add(source)
+    assigned: set[int] = set()
+    components: list[list[int]] = []
+    for root in reversed(finished):
+        if root in assigned:
+            continue
+        assigned.add(root)
+        component = []
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            component.append(node)
+            for target in sorted(reverse.get(node, ()), reverse=True):
+                if target not in assigned:
+                    assigned.add(target)
+                    stack.append(target)
+        component.sort()
+        if len(component) > 1 or component[0] in adjacency.get(component[0], set()):
+            components.append(component)
+    return sorted(components)
+
+
+def _topological_order(
+    nodes: list[int], adjacency: dict[int, set[int]]
+) -> tuple[list[int], list[int]]:
+    prerequisites = {node: set(adjacency.get(node, ())) for node in nodes}
+    dependents: dict[int, set[int]] = defaultdict(set)
+    for source, targets in prerequisites.items():
+        for target in targets:
+            dependents[target].add(source)
+    ready = [node for node in nodes if not prerequisites[node]]
+    heapq.heapify(ready)
+    order = []
+    while ready:
+        node = heapq.heappop(ready)
+        order.append(node)
+        for dependent in sorted(dependents.get(node, ())):
+            prerequisites[dependent].discard(node)
+            if not prerequisites[dependent]:
+                heapq.heappush(ready, dependent)
+    scheduled = set(order)
+    return order, sorted(node for node in nodes if node not in scheduled)
+
+
+def build_dependency_plan(
+    portfolio_snapshot: dict[str, Any],
+    declarations: list[dict[str, Any]],
+    attestations: list[dict[str, Any]],
+    target_states: dict[tuple[str, int], dict[str, Any]],
+) -> dict[str, Any]:
+    repository = str(portfolio_snapshot["repository"]).casefold()
+    pulls = {
+        int(value["number"]): value for value in portfolio_snapshot["pull_requests"]
+    }
+    edges, stale = _authoritative_edges(repository, pulls, declarations, attestations)
+    classified = _classify_edges(repository, pulls, edges, target_states)
+    adjacency: dict[int, set[int]] = defaultdict(set)
+    blockers: dict[int, list[str]] = {number: [] for number in pulls}
+    revalidation: dict[int, list[int]] = defaultdict(list)
+    complete = bool(portfolio_snapshot.get("complete"))
+    for edge in classified:
+        pull_number = int(edge["pull_number"])
+        dependency_number = int(edge["dependency_number"])
+        status = str(edge["status"])
+        if status in {"open", "self_dependency"}:
+            adjacency[pull_number].add(dependency_number)
+            blockers[pull_number].append(f"dependency_{status}:#{dependency_number}")
+        elif status == "merged":
+            revalidation[pull_number].append(dependency_number)
+        elif status != "merged":
+            blockers[pull_number].append(f"dependency_{status}:#{dependency_number}")
+            if status == "unknown":
+                complete = False
+    for value in stale:
+        blockers[int(value["pull_number"])].append(
+            f"dependency_confirmation_stale:#{value['dependency_number']}"
+        )
+    cycles = _dependency_cycles(sorted(pulls), adjacency)
+    for cycle in cycles:
+        label = ",".join(f"#{number}" for number in cycle)
+        for number in cycle:
+            blockers[number].append(f"dependency_cycle:{label}")
+    if not bool(portfolio_snapshot.get("complete")):
+        for values in blockers.values():
+            values.append("portfolio_snapshot_incomplete")
+    initially_hard_blocked = {
+        number
+        for number, values in blockers.items()
+        if any(not value.startswith("dependency_open:") for value in values)
+    }
+    dependents: dict[int, set[int]] = defaultdict(set)
+    for source, dependencies in adjacency.items():
+        for dependency in dependencies:
+            dependents[dependency].add(source)
+    hard_blocked = set(initially_hard_blocked)
+    pending_blocked = list(initially_hard_blocked)
+    heapq.heapify(pending_blocked)
+    while pending_blocked:
+        dependency = heapq.heappop(pending_blocked)
+        for dependent in sorted(dependents.get(dependency, ())):
+            if dependent in hard_blocked:
+                continue
+            hard_blocked.add(dependent)
+            heapq.heappush(pending_blocked, dependent)
+    for source, dependencies in adjacency.items():
+        if source in initially_hard_blocked:
+            continue
+        blockers[source].extend(
+            f"dependency_prerequisite_blocked:#{value}"
+            for value in sorted(dependencies & hard_blocked)
+        )
+    normalized_blockers = {
+        str(number): sorted(set(values))
+        for number, values in sorted(blockers.items())
+        if values
+    }
+    raw_order, cyclic_or_downstream = _topological_order(sorted(pulls), adjacency)
+    order = [number for number in raw_order if number not in hard_blocked]
+    unscheduled = sorted(set(cyclic_or_downstream) | hard_blocked)
+    suggestions = [
+        {
+            "left": int(value["left"]),
+            "right": int(value["right"]),
+            "kind": "file_overlap",
+            "file_count": int(value["file_count"]),
+            "files": list(value["files"][:MAX_SUGGESTION_FILES]),
+            "files_omitted": max(0, len(value["files"]) - MAX_SUGGESTION_FILES),
+            "authoritative": False,
+        }
+        for value in portfolio_snapshot.get("overlaps", ())
+    ]
+    material = {
+        "schema_version": DEPENDENCY_SCHEMA_VERSION,
+        "repository": repository,
+        "portfolio_snapshot_digest": str(
+            portfolio_snapshot.get("snapshot_digest") or ""
+        ),
+        "complete": complete,
+        "authoritative_edges": classified,
+        "stale_confirmations": stale,
+        "cycles": cycles,
+        "suggested_merge_order": order,
+        "unscheduled_pull_requests": unscheduled,
+        "dependency_ready_pull_requests": [
+            number for number in sorted(pulls) if str(number) not in normalized_blockers
+        ],
+        "ready_blockers": normalized_blockers,
+        "revalidation_recommended": {
+            str(number): sorted(set(values))
+            for number, values in sorted(revalidation.items())
+        },
+        "suggestions": suggestions,
+    }
+    return {**material, "plan_digest": _canonical_digest(material)}
+
+
+def direct_dependency_requirements(
+    *,
+    repository: str,
+    pull_number: int,
+    head_sha: str,
+    body: str,
+    attestations: list[dict[str, Any]],
+    target_states: dict[tuple[str, int], dict[str, Any]],
+) -> dict[str, Any]:
+    pull = {"number": pull_number, "head_sha": head_sha}
+    declarations = parse_dependency_declarations(
+        repository, pull_number, head_sha, body
+    )
+    edges, stale = _authoritative_edges(
+        repository, {pull_number: pull}, declarations, attestations
+    )
+    classified = _classify_edges(repository, {pull_number: pull}, edges, target_states)
+    blockers = []
+    complete = True
+    for edge in classified:
+        status = str(edge["status"])
+        dependency_number = int(edge["dependency_number"])
+        if status == "merged":
+            continue
+        blockers.append(f"dependency_{status}:#{dependency_number}")
+        if status == "unknown":
+            complete = False
+    blockers.extend(
+        f"dependency_confirmation_stale:#{value['dependency_number']}"
+        for value in stale
+    )
+    material = {
+        "edges": classified,
+        "stale_confirmations": stale,
+        "complete": complete,
+        "blockers": sorted(set(blockers)),
+    }
+    return {**material, "dependency_digest": _canonical_digest(material)}
+
+
+def render_dependency_plan_text(result: dict[str, Any]) -> str:
+    plan = result["plan"]
+    lines = [
+        f"Dependency plan: {plan['repository']}",
+        f"Plan: {result['plan_digest']}",
+        f"Portfolio snapshot: {plan['portfolio_snapshot_digest']}",
+        f"Complete: {'yes' if plan['complete'] else 'no'}",
+        "Suggested merge order: "
+        + (
+            " -> ".join(
+                f"#{value}" for value in plan["suggested_merge_order"][:MAX_TEXT_ORDER]
+            )
+            or "none"
+        ),
+    ]
+    expected = result.get("expected_digest")
+    if expected:
+        state = "current" if result.get("matches_expected_digest") else "stale"
+        lines.append(f"Expected plan: {state}")
+    edges = plan["authoritative_edges"]
+    for edge in edges[:MAX_TEXT_EDGES]:
+        sources = ",".join(value["source"] for value in edge["sources"])
+        lines.append(
+            f"#{edge['pull_number']} depends on "
+            f"{edge['dependency_repository']}#{edge['dependency_number']} "
+            f"[{edge['status']}; {sources}]"
+        )
+    if len(edges) > MAX_TEXT_EDGES:
+        lines.append(f"... {len(edges) - MAX_TEXT_EDGES} dependency edges omitted")
+    order = plan["suggested_merge_order"]
+    if len(order) > MAX_TEXT_ORDER:
+        lines.append(f"... {len(order) - MAX_TEXT_ORDER} merge-order entries omitted")
+    blocked = list(plan["ready_blockers"].items())
+    for pull_number, blockers in blocked[:MAX_TEXT_BLOCKED_PULLS]:
+        shown = blockers[:MAX_TEXT_BLOCKERS_PER_PULL]
+        omitted = len(blockers) - len(shown)
+        suffix = f" (+{omitted} more)" if omitted else ""
+        lines.append(f"Blocked #{pull_number}: {', '.join(shown)}{suffix}")
+    if len(blocked) > MAX_TEXT_BLOCKED_PULLS:
+        lines.append(
+            f"... {len(blocked) - MAX_TEXT_BLOCKED_PULLS} blocked pull requests omitted"
+        )
+    suggestions = plan["suggestions"]
+    for value in suggestions[:MAX_TEXT_SUGGESTIONS]:
+        lines.append(
+            f"Suggestion #{value['left']} <-> #{value['right']}: "
+            f"{value['file_count']} overlapping file(s), not authoritative"
+        )
+    if len(suggestions) > MAX_TEXT_SUGGESTIONS:
+        lines.append(
+            f"... {len(suggestions) - MAX_TEXT_SUGGESTIONS} suggestions omitted"
+        )
+    return "\n".join(lines)

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -39,7 +39,10 @@ class PullRequest:
     state: str
     draft: bool
     title: str = ""
+    body: str = ""
     updated_at: str = ""
+    author: str = ""
+    merged: bool = False
     head_owner: str = ""
     head_branch: str = ""
     head_sha: str = ""
@@ -733,7 +736,10 @@ class GitHubClient:
             state=str(item["state"]),
             draft=bool(item.get("draft", False)),
             title=str(item.get("title") or ""),
+            body=str(item.get("body") or ""),
             updated_at=str(item.get("updated_at") or ""),
+            author=str((item.get("user") or {}).get("login") or ""),
+            merged=bool(item.get("merged_at")),
             head_owner=str(head_owner),
             head_branch=str(head.get("ref") or ""),
             head_sha=str(head.get("sha") or ""),
@@ -745,7 +751,9 @@ class GitHubClient:
         payload, _ = self._request("GET", f"/repos/{upstream}/pulls/{number}")
         return self._parse_pull_request(payload)
 
-    def pull_request_activity(self, upstream: str, number: int) -> dict[str, Any]:
+    def pull_request_activity(
+        self, upstream: str, number: int, *, include_body: bool = False
+    ) -> dict[str, Any]:
         pull, _ = self._request("GET", f"/repos/{upstream}/pulls/{number}")
         comments = self._paginated_rest_values(
             f"/repos/{upstream}/issues/{number}/comments"
@@ -761,20 +769,24 @@ class GitHubClient:
             f"/repos/{upstream}/commits/{head_sha}/check-runs",
             container="check_runs",
         )
+        pull_state = {
+            "number": int(pull["number"]),
+            "url": str(pull["html_url"]),
+            "state": str(pull["state"]),
+            "draft": bool(pull.get("draft", False)),
+            "updated_at": str(pull.get("updated_at") or ""),
+            "head_sha": head_sha,
+            "base_branch": str((pull.get("base") or {}).get("ref") or ""),
+            "base_sha": str((pull.get("base") or {}).get("sha") or ""),
+            "mergeable": pull.get("mergeable"),
+            "mergeable_state": str(pull.get("mergeable_state") or ""),
+            "merged": bool(pull.get("merged_at")),
+        }
+        if include_body:
+            pull_state["body"] = str(pull.get("body") or "")
+            pull_state["author"] = str((pull.get("user") or {}).get("login") or "")
         return {
-            "pull_request": {
-                "number": int(pull["number"]),
-                "url": str(pull["html_url"]),
-                "state": str(pull["state"]),
-                "draft": bool(pull.get("draft", False)),
-                "updated_at": str(pull.get("updated_at") or ""),
-                "head_sha": head_sha,
-                "base_branch": str((pull.get("base") or {}).get("ref") or ""),
-                "base_sha": str((pull.get("base") or {}).get("sha") or ""),
-                "mergeable": pull.get("mergeable"),
-                "mergeable_state": str(pull.get("mergeable_state") or ""),
-                "merged": bool(pull.get("merged_at")),
-            },
+            "pull_request": pull_state,
             "comments": [
                 {
                     "id": int(value["id"]),

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -82,6 +82,9 @@ class MergeSnapshot:
     files_complete: bool = True
     conversations_complete: bool = True
     checks_complete: bool = True
+    dependency_digest: str = ""
+    dependency_blockers: tuple[str, ...] = ()
+    dependencies_complete: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,6 +171,10 @@ def evaluate_merge(
         block("conversations_incomplete", "Review-conversation data is incomplete.")
     if not snapshot.checks_complete:
         block("checks_incomplete", "Check data is incomplete.")
+    if not snapshot.dependencies_complete:
+        block("dependencies_incomplete", "Dependency data is incomplete.")
+    for dependency_blocker in snapshot.dependency_blockers:
+        block("dependency_blocked", dependency_blocker)
     if not snapshot.activity_digest:
         block("activity_incomplete", "Pull-request activity digest is unavailable.")
     if snapshot.review_decision.casefold() != "approved":

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -26,8 +26,13 @@ from .context import (
     write_portable_bundle,
 )
 from .context_budget import FAILED_CHECK_CONCLUSIONS, build_follow_up_context
+from .dependencies import (
+    build_dependency_plan,
+    direct_dependency_requirements,
+    parse_dependency_declarations,
+)
 from .discovery import score_issue
-from .github import GitHubClient, GitHubError, resolve_token
+from .github import GitHubClient, GitHubError, PullRequest, resolve_token
 from .harness import Harness, HarnessRequest, create_harness
 from .issues import (
     attach_proposal_marker,
@@ -119,6 +124,17 @@ class Pipeline:
         if expected_digest and not re.fullmatch(r"[a-f0-9]{64}", expected_digest):
             raise ValueError("expected portfolio digest must be 64 lowercase hex chars")
         pulls = self.github.open_pull_requests(policy.name)
+        return self._portfolio_snapshot_from_pulls(
+            policy, pulls, expected_digest=expected_digest
+        )
+
+    def _portfolio_snapshot_from_pulls(
+        self,
+        policy: RepositoryPolicy,
+        pulls: tuple[PullRequest, ...],
+        *,
+        expected_digest: str = "",
+    ) -> dict[str, Any]:
         snapshots: list[dict[str, Any]] = []
         errors: list[dict[str, Any]] = []
         for pull in pulls:
@@ -181,6 +197,209 @@ class Pipeline:
             "snapshot": snapshot,
             "harness_invoked": False,
             "workspace_modified": False,
+            "public_write": False,
+        }
+
+    def _dependency_target_states(
+        self,
+        repository: str,
+        target_numbers: set[int],
+        *,
+        open_pulls: tuple[PullRequest, ...] = (),
+    ) -> dict[tuple[str, int], dict[str, Any]]:
+        normalized_repository = repository.casefold()
+        result = {
+            (normalized_repository, int(pull.number)): {
+                "state": "open",
+                "merged": False,
+                "head_sha": str(pull.head_sha),
+                "url": str(pull.url),
+            }
+            for pull in open_pulls
+            if int(pull.number) in target_numbers
+        }
+        for target_number in sorted(target_numbers):
+            key = (normalized_repository, target_number)
+            if key in result:
+                continue
+            try:
+                pull = self.github.pull_request(repository, target_number)
+            except GitHubError as exc:
+                state = "missing" if "failed (404)" in str(exc) else "unknown"
+                result[key] = {"state": state, "merged": False, "error": str(exc)[:500]}
+                continue
+            result[key] = {
+                "state": "merged" if pull.merged else pull.state.casefold(),
+                "merged": pull.merged,
+                "head_sha": pull.head_sha,
+                "url": pull.url,
+            }
+        return result
+
+    def portfolio_dependency_plan(
+        self, repository: str, *, expected_digest: str = ""
+    ) -> dict[str, Any]:
+        """Build a deterministic dependency plan without GitHub or workspace writes."""
+        policy = self.policy(repository)
+        if expected_digest and not re.fullmatch(r"[a-f0-9]{64}", expected_digest):
+            raise ValueError(
+                "expected dependency plan digest must be 64 lowercase hex chars"
+            )
+        pulls = self.github.open_pull_requests(policy.name)
+        portfolio = self._portfolio_snapshot_from_pulls(policy, pulls)
+        snapshot = {
+            **portfolio["snapshot"],
+            "snapshot_digest": portfolio["snapshot_digest"],
+        }
+        declarations = [
+            declaration
+            for pull in pulls
+            for declaration in parse_dependency_declarations(
+                policy.name,
+                pull.number,
+                pull.head_sha,
+                pull.body,
+                actor=pull.author,
+            )
+        ]
+        open_pull_numbers = {pull.number for pull in pulls}
+        attestations = [
+            value
+            for value in self.store.latest_portfolio_dependency_events(policy.name)
+            if int(value["pull_number"]) in open_pull_numbers
+        ]
+        targets = {
+            int(value["dependency_number"])
+            for value in declarations
+            if str(value["dependency_repository"]).casefold() == policy.name.casefold()
+        }
+        targets.update(
+            int(value["dependency_number"])
+            for value in attestations
+            if str(value.get("action") or "") == "confirm"
+        )
+        target_states = self._dependency_target_states(
+            policy.name, targets, open_pulls=pulls
+        )
+        plan = build_dependency_plan(
+            snapshot, declarations, attestations, target_states
+        )
+        digest = str(plan.pop("plan_digest"))
+        return {
+            "plan_digest": digest,
+            "expected_digest": expected_digest,
+            "matches_expected_digest": (
+                digest == expected_digest if expected_digest else None
+            ),
+            "plan": plan,
+            "harness_invoked": False,
+            "workspace_modified": False,
+            "local_write": False,
+            "public_write": False,
+        }
+
+    def attest_portfolio_dependency(
+        self,
+        repository: str,
+        *,
+        pull_number: int,
+        dependency_number: int,
+        action: str,
+        reviewed_by: str,
+    ) -> dict[str, Any]:
+        """Append an explicit, identity-checked local dependency attestation."""
+        policy = self.policy(repository)
+        if pull_number < 1 or dependency_number < 1:
+            raise ValueError("dependency pull numbers must be positive")
+        if pull_number == dependency_number:
+            raise ValueError("a pull request cannot depend on itself")
+        if action not in {"confirm", "revoke"}:
+            raise ValueError("dependency action must be confirm or revoke")
+        if os.environ.get("REPOSTEWARD_ENABLE_DEPENDENCY_ATTESTATION") != "1":
+            raise PolicyError(
+                "dependency attestation is disabled; set "
+                "REPOSTEWARD_ENABLE_DEPENDENCY_ATTESTATION=1 for this command"
+            )
+        actor = reviewed_by.strip()
+        if actor.casefold() != self.config.github.login.casefold():
+            raise PolicyError("--reviewed-by must match the configured GitHub login")
+        if (
+            policy.mode != "maintainer"
+            or policy.submission_strategy != "same-repository"
+        ):
+            raise PolicyError("dependency attestation requires maintainer mode")
+        if self.github.authenticated_login().casefold() != actor.casefold():
+            raise PolicyError(
+                "authenticated GitHub login differs from reviewed identity"
+            )
+        if not self.github.repository(policy.name).can_push:
+            raise PolicyError(
+                "authenticated GitHub login cannot maintain this repository"
+            )
+        pull = self.github.pull_request(policy.name, pull_number)
+        if pull.state.casefold() != "open":
+            raise PolicyError("dependency source pull request is not open")
+        if action == "confirm":
+            self.github.pull_request(policy.name, dependency_number)
+        elif action == "revoke":
+            existing = self.store.latest_portfolio_dependency_events(
+                policy.name, pull_number=pull_number
+            )
+            if not any(
+                int(value["dependency_number"]) == dependency_number
+                for value in existing
+            ):
+                raise PolicyError(
+                    "there is no dependency confirmation history to revoke"
+                )
+        audit = self.store.append_portfolio_dependency_event(
+            repository=policy.name,
+            pull_number=pull_number,
+            dependency_number=dependency_number,
+            head_sha=pull.head_sha,
+            action=action,
+            actor=actor,
+        )
+        return {
+            "repository": policy.name.casefold(),
+            "pull_number": pull_number,
+            "dependency_number": dependency_number,
+            "action": action,
+            "audit": audit,
+            "local_write": True,
+            "public_write": False,
+        }
+
+    def portfolio_dependency_events(
+        self, repository: str, *, pull_number: int = 0, limit: int = 100
+    ) -> dict[str, Any]:
+        policy = self.policy(repository)
+        if pull_number < 0:
+            raise ValueError("pull_number must not be negative")
+        events = self.store.portfolio_dependency_events(
+            policy.name, pull_number=pull_number, limit=limit
+        )
+        return {
+            "repository": policy.name.casefold(),
+            "pull_number": pull_number,
+            "events": [
+                {
+                    key: value[key]
+                    for key in (
+                        "sequence",
+                        "id",
+                        "pull_number",
+                        "dependency_number",
+                        "head_sha",
+                        "action",
+                        "actor",
+                        "source",
+                        "event_digest",
+                        "created_at",
+                    )
+                }
+                for value in events
+            ],
             "public_write": False,
         }
 
@@ -1349,6 +1568,7 @@ class Pipeline:
                 "github_event_index",
                 "merge_decision_audit",
                 "merge_execution_audit",
+                "portfolio_dependency_audit",
                 "storage_gc_audit",
             ],
             "public_write": False,
@@ -2108,8 +2328,43 @@ class Pipeline:
         if not isinstance(project, dict):
             raise PolicyError("the verified context pack has no project policy")
         expected_policy_digest = str(project.get("policy_digest") or "")
-        activity = self.github.pull_request_activity(repository, pull_number)
+        activity = self.github.pull_request_activity(
+            repository, pull_number, include_body=True
+        )
         raw = self.github.pull_request_merge_snapshot(repository, pull_number)
+        pull_activity = activity.get("pull_request", {})
+        attestations = self.store.latest_portfolio_dependency_events(
+            repository, pull_number=pull_number
+        )
+        declarations = parse_dependency_declarations(
+            repository,
+            pull_number,
+            str(raw["head_sha"]),
+            str(pull_activity.get("body") or ""),
+            actor=str(pull_activity.get("author") or ""),
+        )
+        dependency_targets = {
+            int(value["dependency_number"])
+            for value in declarations
+            if str(value["dependency_repository"]).casefold() == repository.casefold()
+            and int(value["dependency_number"]) != pull_number
+        }
+        dependency_targets.update(
+            int(value["dependency_number"])
+            for value in attestations
+            if str(value.get("action") or "") == "confirm"
+            and int(value["dependency_number"]) != pull_number
+        )
+        dependency_status = direct_dependency_requirements(
+            repository=repository,
+            pull_number=pull_number,
+            head_sha=str(raw["head_sha"]),
+            body=str(pull_activity.get("body") or ""),
+            attestations=attestations,
+            target_states=self._dependency_target_states(
+                repository, dependency_targets
+            ),
+        )
         snapshot = MergeSnapshot(
             repository=repository,
             pull_number=pull_number,
@@ -2134,6 +2389,11 @@ class Pipeline:
             files_complete=bool(raw["files_complete"]),
             conversations_complete=bool(raw["conversations_complete"]),
             checks_complete=bool(raw["checks_complete"]),
+            dependency_digest=str(dependency_status["dependency_digest"]),
+            dependency_blockers=tuple(
+                str(value) for value in dependency_status["blockers"]
+            ),
+            dependencies_complete=bool(dependency_status["complete"]),
         )
         decision = evaluate_merge(
             snapshot,

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -353,6 +353,34 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         """
         CREATE UNIQUE INDEX IF NOT EXISTS merge_executions_stage_once
         ON merge_executions(attempt_id, stage)
+        """,
+    ),
+    11: (
+        """
+        CREATE TABLE IF NOT EXISTS portfolio_dependency_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            dependency_number INTEGER NOT NULL,
+            head_sha TEXT NOT NULL,
+            action TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            source TEXT NOT NULL,
+            event_digest TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS portfolio_dependency_events_for_pull
+        ON portfolio_dependency_events(
+            repository, pull_number, dependency_number, sequence DESC
+        )
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS portfolio_dependency_events_digest
+        ON portfolio_dependency_events(event_digest)
         """,
     ),
 }
@@ -1450,6 +1478,17 @@ class Store:
                 """,
             ),
             (
+                "portfolio_dependency_audit",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM portfolio_dependency_events
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
                 "storage_gc_audit",
                 """
                 SELECT CASE WHEN repository='' THEN '*' ELSE repository END AS repository,
@@ -2161,6 +2200,192 @@ class Store:
             "decision_digest": decision_digest,
             "created_at": now,
         }
+
+    def append_portfolio_dependency_event(
+        self,
+        *,
+        repository: str,
+        pull_number: int,
+        dependency_number: int,
+        head_sha: str,
+        action: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Append one head-bound maintainer dependency attestation."""
+        normalized_repository = repository.casefold()
+        normalized_action = action.casefold()
+        normalized_actor = actor.strip()
+        if pull_number < 1 or dependency_number < 1:
+            raise ValueError("dependency pull numbers must be positive")
+        if pull_number == dependency_number:
+            raise ValueError("a pull request cannot depend on itself")
+        if normalized_action not in {"confirm", "revoke"}:
+            raise ValueError("dependency action must be confirm or revoke")
+        if not normalized_actor:
+            raise ValueError("dependency actor must not be empty")
+        if len(head_sha) != 40 or any(
+            value not in "0123456789abcdef" for value in head_sha
+        ):
+            raise ValueError("dependency head_sha must be 40 lowercase hex chars")
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            previous = connection.execute(
+                """
+                SELECT id, head_sha, action, actor, source,
+                       event_digest, payload, created_at
+                FROM portfolio_dependency_events
+                WHERE repository=? AND pull_number=? AND dependency_number=?
+                ORDER BY sequence DESC LIMIT 1
+                """,
+                (normalized_repository, pull_number, dependency_number),
+            ).fetchone()
+            if previous is not None and (
+                str(previous["head_sha"]) == head_sha
+                and str(previous["action"]) == normalized_action
+                and str(previous["actor"]) == normalized_actor
+                and str(previous["source"]) == "maintainer_attestation"
+            ):
+                previous_payload = json.loads(str(previous["payload"]))
+                expected_previous = {
+                    "schema_version": 1,
+                    "repository": normalized_repository,
+                    "pull_number": pull_number,
+                    "dependency_number": dependency_number,
+                    "head_sha": head_sha,
+                    "action": normalized_action,
+                    "actor": normalized_actor,
+                    "source": "maintainer_attestation",
+                    "previous_event_id": (
+                        str(previous_payload.get("previous_event_id") or "")
+                        if isinstance(previous_payload, dict)
+                        else ""
+                    ),
+                }
+                if previous_payload != expected_previous or _json_digest(
+                    expected_previous
+                ) != str(previous["event_digest"]):
+                    raise StoreError("portfolio dependency audit was modified")
+                return {
+                    "id": str(previous["id"]),
+                    **previous_payload,
+                    "event_digest": str(previous["event_digest"]),
+                    "created_at": str(previous["created_at"]),
+                    "idempotent": True,
+                }
+            material = {
+                "schema_version": 1,
+                "repository": normalized_repository,
+                "pull_number": pull_number,
+                "dependency_number": dependency_number,
+                "head_sha": head_sha,
+                "action": normalized_action,
+                "actor": normalized_actor,
+                "source": "maintainer_attestation",
+                "previous_event_id": str(previous["id"]) if previous else "",
+            }
+            event_digest = _json_digest(material)
+            payload = _canonical_json(material)
+            event_id = uuid.uuid4().hex
+            now = utc_now()
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO portfolio_dependency_events(
+                    id, repository, pull_number, dependency_number, head_sha,
+                    action, actor, source, event_digest, payload, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    normalized_repository,
+                    pull_number,
+                    dependency_number,
+                    head_sha,
+                    normalized_action,
+                    normalized_actor,
+                    "maintainer_attestation",
+                    event_digest,
+                    payload,
+                    now,
+                ),
+            )
+            stored = connection.execute(
+                """
+                SELECT id, created_at FROM portfolio_dependency_events
+                WHERE event_digest=?
+                """,
+                (event_digest,),
+            ).fetchone()
+            assert stored is not None
+            return {
+                "id": str(stored["id"]),
+                **material,
+                "event_digest": event_digest,
+                "created_at": str(stored["created_at"]),
+                "idempotent": str(stored["id"]) != event_id,
+            }
+
+    def latest_portfolio_dependency_events(
+        self, repository: str, *, pull_number: int = 0
+    ) -> list[dict[str, Any]]:
+        """Return the latest append-only action for every dependency pair."""
+        normalized_repository = repository.casefold()
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                WITH ranked AS (
+                    SELECT *, ROW_NUMBER() OVER (
+                        PARTITION BY repository, pull_number, dependency_number
+                        ORDER BY sequence DESC
+                    ) AS dependency_rank
+                    FROM portfolio_dependency_events
+                    WHERE repository=? AND (?=0 OR pull_number=?)
+                )
+                SELECT * FROM ranked
+                WHERE dependency_rank=1
+                ORDER BY pull_number, dependency_number
+                """,
+                (normalized_repository, pull_number, pull_number),
+            ).fetchall()
+        return [self._portfolio_dependency_event(row) for row in rows]
+
+    @staticmethod
+    def _portfolio_dependency_event(row: sqlite3.Row) -> dict[str, Any]:
+        value = dict(row)
+        value.pop("dependency_rank", None)
+        payload = json.loads(str(value["payload"]))
+        if not isinstance(payload, dict):
+            raise StoreError("portfolio dependency audit was modified")
+        material = {
+            "schema_version": 1,
+            "repository": str(value["repository"]),
+            "pull_number": int(value["pull_number"]),
+            "dependency_number": int(value["dependency_number"]),
+            "head_sha": str(value["head_sha"]),
+            "action": str(value["action"]),
+            "actor": str(value["actor"]),
+            "source": str(value["source"]),
+            "previous_event_id": str(payload.get("previous_event_id") or ""),
+        }
+        if payload != material or _json_digest(material) != str(value["event_digest"]):
+            raise StoreError("portfolio dependency audit was modified")
+        value["payload"] = payload
+        return value
+
+    def portfolio_dependency_events(
+        self, repository: str, *, pull_number: int = 0, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        """Read recent dependency audit events without collapsing their history."""
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM portfolio_dependency_events
+                WHERE repository=? AND (?=0 OR pull_number=?)
+                ORDER BY sequence DESC LIMIT ?
+                """,
+                (repository.casefold(), pull_number, pull_number, limit),
+            ).fetchall()
+        return [self._portfolio_dependency_event(row) for row in rows]
 
     def merge_decisions(
         self, repository: str, pull_number: int, *, limit: int = 30

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,82 @@ class CliSetupTests(unittest.TestCase):
         self.assertIn("Portfolio: owner/repo", text_output.getvalue())
         pipeline.portfolio_snapshot.assert_called_with("owner/repo", expected_digest="")
 
+    def test_portfolio_plan_and_dependency_attestation_are_routed(self) -> None:
+        plan = {
+            "plan_digest": "a" * 64,
+            "expected_digest": "",
+            "matches_expected_digest": None,
+            "plan": {
+                "repository": "owner/repo",
+                "portfolio_snapshot_digest": "b" * 64,
+                "complete": True,
+                "suggested_merge_order": [1],
+                "authoritative_edges": [],
+                "ready_blockers": {},
+                "suggestions": [],
+            },
+        }
+        pipeline = MagicMock()
+        pipeline.portfolio_dependency_plan.return_value = plan
+        pipeline.attest_portfolio_dependency.return_value = {
+            "action": "confirm",
+            "public_write": False,
+        }
+        pipeline.portfolio_dependency_events.return_value = {
+            "events": [],
+            "public_write": False,
+        }
+        plan_output = io.StringIO()
+        dependency_output = io.StringIO()
+        list_output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+        ):
+            with redirect_stdout(plan_output):
+                plan_code = main(
+                    ["portfolio", "plan", "owner/repo", "--format", "text"]
+                )
+            with redirect_stdout(dependency_output):
+                dependency_code = main(
+                    [
+                        "portfolio",
+                        "dependency",
+                        "confirm",
+                        "owner/repo",
+                        "2",
+                        "1",
+                        "--reviewed-by",
+                        "alice",
+                    ]
+                )
+            with redirect_stdout(list_output):
+                list_code = main(
+                    [
+                        "portfolio",
+                        "dependency",
+                        "list",
+                        "owner/repo",
+                        "--pull-number",
+                        "2",
+                    ]
+                )
+
+        self.assertEqual(plan_code, 0)
+        self.assertEqual(dependency_code, 0)
+        self.assertEqual(list_code, 0)
+        self.assertIn("Dependency plan: owner/repo", plan_output.getvalue())
+        pipeline.attest_portfolio_dependency.assert_called_once_with(
+            "owner/repo",
+            pull_number=2,
+            dependency_number=1,
+            action="confirm",
+            reviewed_by="alice",
+        )
+        pipeline.portfolio_dependency_events.assert_called_once_with(
+            "owner/repo", pull_number=2, limit=100
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from reposteward.config import RepositoryPolicy
+from reposteward.dependencies import (
+    build_dependency_plan,
+    direct_dependency_requirements,
+    parse_dependency_declarations,
+    render_dependency_plan_text,
+)
+from reposteward.github import PullRequest
+from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
+from reposteward.store import Store
+
+
+def _snapshot(numbers: list[int]) -> dict:
+    ordered = sorted(numbers)
+    return {
+        "repository": "owner/repo",
+        "snapshot_digest": "f" * 64,
+        "complete": True,
+        "pull_requests": [
+            {"number": number, "head_sha": str(number) * 40} for number in numbers
+        ],
+        "overlaps": [
+            {
+                "left": ordered[0],
+                "right": ordered[-1],
+                "file_count": 1,
+                "files": ["src/shared.py"],
+            }
+        ]
+        if len(numbers) > 1
+        else [],
+    }
+
+
+def _declared(pull_number: int, body: str) -> list[dict]:
+    return parse_dependency_declarations(
+        "owner/repo", pull_number, str(pull_number) * 40, body
+    )
+
+
+class DependencyDeclarationTests(unittest.TestCase):
+    def test_only_standalone_lines_outside_quotes_and_fences_are_authoritative(
+        self,
+    ) -> None:
+        body = """
+Text saying Depends on #9 is not a declaration.
+- Depends on #2
+Depends on owner/repo#3
+Depends on other/project#4
+> Depends on #5
+```text
+Depends on #6
+```
+<!--
+Depends on #7
+-->
+````text
+```
+Depends on #8
+````
+"""
+
+        declarations = _declared(1, body)
+
+        self.assertEqual(
+            [
+                (value["dependency_repository"], value["dependency_number"])
+                for value in declarations
+            ],
+            [("other/project", 4), ("owner/repo", 2), ("owner/repo", 3)],
+        )
+        self.assertTrue(
+            all(value["source"] == "explicit_pr_body" for value in declarations)
+        )
+
+    def test_source_records_the_pull_request_author(self) -> None:
+        declarations = parse_dependency_declarations(
+            "owner/repo", 1, "1" * 40, "Depends on #2", actor="alice"
+        )
+
+        self.assertEqual(declarations[0]["actor"], "alice")
+
+    def test_duplicate_declarations_collapse_deterministically(self) -> None:
+        first = _declared(1, "Depends on #2\n- depends on #2")
+        second = _declared(1, "- depends on #2\nDepends on #2")
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first[0]["source_digest"], second[0]["source_digest"])
+
+
+class DependencyPlanTests(unittest.TestCase):
+    def test_acyclic_dependencies_have_stable_prerequisite_first_order(self) -> None:
+        declarations = [
+            *_declared(3, "Depends on #2"),
+            *_declared(2, "Depends on #1"),
+        ]
+
+        first = build_dependency_plan(_snapshot([3, 1, 2]), declarations, [], {})
+        second = build_dependency_plan(
+            _snapshot([2, 3, 1]), list(reversed(declarations)), [], {}
+        )
+
+        self.assertEqual(first["plan_digest"], second["plan_digest"])
+        self.assertEqual(first["suggested_merge_order"], [1, 2, 3])
+        self.assertEqual(first["dependency_ready_pull_requests"], [1])
+        self.assertEqual(first["ready_blockers"]["2"], ["dependency_open:#1"])
+        self.assertFalse(first["suggestions"][0]["authoritative"])
+
+    def test_cycles_are_exact_and_stable(self) -> None:
+        declarations = [
+            *_declared(1, "Depends on #2"),
+            *_declared(2, "Depends on #1"),
+            *_declared(3, "Depends on #2"),
+        ]
+
+        plan = build_dependency_plan(_snapshot([1, 2, 3]), declarations, [], {})
+
+        self.assertEqual(plan["cycles"], [[1, 2]])
+        self.assertEqual(plan["suggested_merge_order"], [])
+        self.assertEqual(plan["unscheduled_pull_requests"], [1, 2, 3])
+        self.assertIn("dependency_cycle:#1,#2", plan["ready_blockers"]["1"])
+
+    def test_missing_closed_cross_repository_and_merged_targets_are_distinct(
+        self,
+    ) -> None:
+        declarations = [
+            *_declared(1, "Depends on #10"),
+            *_declared(2, "Depends on #11"),
+            *_declared(3, "Depends on other/repo#12"),
+            *_declared(4, "Depends on #13"),
+        ]
+        target_states = {
+            ("owner/repo", 10): {"state": "missing"},
+            ("owner/repo", 11): {"state": "closed", "merged": False},
+            ("owner/repo", 13): {"state": "merged", "merged": True},
+        }
+
+        plan = build_dependency_plan(
+            _snapshot([1, 2, 3, 4]), declarations, [], target_states
+        )
+
+        statuses = {
+            value["pull_number"]: value["status"]
+            for value in plan["authoritative_edges"]
+        }
+        self.assertEqual(
+            statuses,
+            {1: "missing", 2: "closed_unmerged", 3: "cross_repository", 4: "merged"},
+        )
+        self.assertEqual(plan["revalidation_recommended"], {"4": [13]})
+        self.assertNotIn("4", plan["ready_blockers"])
+        self.assertEqual(plan["suggested_merge_order"], [4])
+        self.assertEqual(plan["unscheduled_pull_requests"], [1, 2, 3])
+
+    def test_self_dependency_and_cycle_downstream_are_not_scheduled(self) -> None:
+        declarations = [
+            *_declared(1, "Depends on #1"),
+            *_declared(2, "Depends on #3"),
+            *_declared(3, "Depends on #2"),
+            *_declared(4, "Depends on #3"),
+        ]
+
+        plan = build_dependency_plan(_snapshot([1, 2, 3, 4]), declarations, [], {})
+
+        self.assertEqual(plan["cycles"], [[1], [2, 3]])
+        self.assertEqual(plan["suggested_merge_order"], [])
+        self.assertEqual(plan["unscheduled_pull_requests"], [1, 2, 3, 4])
+        self.assertIn("dependency_prerequisite_blocked:#3", plan["ready_blockers"]["4"])
+
+    def test_long_reverse_chain_propagates_without_recursion_or_rescans(self) -> None:
+        count = 1_000
+        declarations = [
+            *_declared(count, f"Depends on #{count + 1}"),
+            *(
+                declaration
+                for number in range(1, count)
+                for declaration in _declared(number, f"Depends on #{number + 1}")
+            ),
+        ]
+
+        plan = build_dependency_plan(
+            _snapshot(list(range(1, count + 1))),
+            declarations,
+            [],
+            {("owner/repo", count + 1): {"state": "missing"}},
+        )
+
+        self.assertEqual(plan["suggested_merge_order"], [])
+        self.assertEqual(len(plan["unscheduled_pull_requests"]), count)
+        self.assertEqual(
+            plan["ready_blockers"]["1"],
+            ["dependency_open:#2", "dependency_prerequisite_blocked:#2"],
+        )
+
+    def test_head_change_expires_a_maintainer_confirmation(self) -> None:
+        attestation = {
+            "pull_number": 1,
+            "dependency_number": 2,
+            "head_sha": "0" * 40,
+            "action": "confirm",
+            "actor": "alice",
+            "event_digest": "e" * 64,
+        }
+
+        plan = build_dependency_plan(_snapshot([1, 2]), [], [attestation], {})
+
+        self.assertEqual(plan["authoritative_edges"], [])
+        self.assertEqual(len(plan["stale_confirmations"]), 1)
+        self.assertEqual(
+            plan["ready_blockers"]["1"], ["dependency_confirmation_stale:#2"]
+        )
+
+    def test_current_body_declaration_supersedes_stale_confirmation(self) -> None:
+        attestation = {
+            "pull_number": 1,
+            "dependency_number": 2,
+            "head_sha": "0" * 40,
+            "action": "confirm",
+            "actor": "alice",
+            "event_digest": "e" * 64,
+        }
+
+        plan = build_dependency_plan(
+            _snapshot([1, 2]), _declared(1, "Depends on #2"), [attestation], {}
+        )
+
+        self.assertEqual(plan["stale_confirmations"], [])
+        self.assertEqual(plan["ready_blockers"]["1"], ["dependency_open:#2"])
+
+    def test_text_plan_reports_digest_edges_and_blockers(self) -> None:
+        plan = build_dependency_plan(
+            _snapshot([1, 2]), _declared(2, "Depends on #1"), [], {}
+        )
+        digest = str(plan.pop("plan_digest"))
+        text = render_dependency_plan_text(
+            {"plan_digest": digest, "expected_digest": "0" * 64, "plan": plan}
+        )
+
+        self.assertIn("Expected plan: stale", text)
+        self.assertIn("#2 depends on owner/repo#1", text)
+        self.assertIn("Blocked #2: dependency_open:#1", text)
+
+
+class _PlanGitHub:
+    def open_pull_requests(self, _repository: str) -> tuple[PullRequest, ...]:
+        return (
+            PullRequest(
+                number=1,
+                url="https://example.test/pulls/1",
+                state="open",
+                draft=False,
+                body="",
+                head_sha="1" * 40,
+                base_sha="b" * 40,
+                base_branch="main",
+            ),
+            PullRequest(
+                number=2,
+                url="https://example.test/pulls/2",
+                state="open",
+                draft=True,
+                body="Depends on #1",
+                author="alice",
+                head_sha="2" * 40,
+                base_sha="b" * 40,
+                base_branch="main",
+            ),
+        )
+
+    def pull_request_merge_snapshot(
+        self, _repository: str, number: int
+    ) -> dict[str, object]:
+        return {
+            "repository": "owner/repo",
+            "pull_number": number,
+            "title": f"Pull {number}",
+            "url": f"https://example.test/pulls/{number}",
+            "state": "OPEN",
+            "draft": number == 2,
+            "head_branch": f"change-{number}",
+            "head_sha": str(number) * 40,
+            "base_branch": "main",
+            "base_sha": "b" * 40,
+            "files": ["src/shared.py"],
+            "checks": [],
+            "files_complete": True,
+            "conversations_complete": True,
+            "checks_complete": True,
+        }
+
+
+class DependencyPlanPipelineTests(unittest.TestCase):
+    def test_plan_reuses_one_open_pull_listing_and_has_no_side_effects(self) -> None:
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": RepositoryPolicy(name="owner/repo")}
+        )
+        pipeline.github = _PlanGitHub()
+        pipeline.store = SimpleNamespace(
+            latest_portfolio_dependency_events=lambda _repository: [
+                {
+                    "pull_number": 99,
+                    "dependency_number": 98,
+                    "head_sha": "9" * 40,
+                    "action": "confirm",
+                    "actor": "alice",
+                    "event_digest": "e" * 64,
+                }
+            ]
+        )
+
+        result = pipeline.portfolio_dependency_plan("owner/repo")
+
+        self.assertEqual(result["plan"]["suggested_merge_order"], [1, 2])
+        self.assertEqual(result["plan"]["ready_blockers"]["2"], ["dependency_open:#1"])
+        self.assertEqual(
+            result["plan"]["authoritative_edges"][0]["sources"][0]["actor"],
+            "alice",
+        )
+        self.assertFalse(result["harness_invoked"])
+        self.assertFalse(result["workspace_modified"])
+        self.assertFalse(result["local_write"])
+        self.assertFalse(result["public_write"])
+
+
+class DirectDependencyRequirementTests(unittest.TestCase):
+    def test_open_dependency_blocks_merge_but_merged_dependency_does_not(self) -> None:
+        common = {
+            "repository": "owner/repo",
+            "pull_number": 2,
+            "head_sha": "2" * 40,
+            "body": "Depends on #1",
+            "attestations": [],
+        }
+        blocked = direct_dependency_requirements(
+            **common,
+            target_states={("owner/repo", 1): {"state": "open", "merged": False}},
+        )
+        satisfied = direct_dependency_requirements(
+            **common,
+            target_states={("owner/repo", 1): {"state": "merged", "merged": True}},
+        )
+
+        self.assertEqual(blocked["blockers"], ["dependency_open:#1"])
+        self.assertEqual(satisfied["blockers"], [])
+        self.assertTrue(satisfied["complete"])
+
+    def test_unknown_dependency_fails_closed(self) -> None:
+        result = direct_dependency_requirements(
+            repository="owner/repo",
+            pull_number=2,
+            head_sha="2" * 40,
+            body="Depends on #1",
+            attestations=[],
+            target_states={("owner/repo", 1): {"state": "unknown"}},
+        )
+
+        self.assertFalse(result["complete"])
+        self.assertEqual(result["blockers"], ["dependency_unknown:#1"])
+
+
+class _AttestationGitHub:
+    def authenticated_login(self) -> str:
+        return "alice"
+
+    def repository(self, _repository: str) -> SimpleNamespace:
+        return SimpleNamespace(can_push=True)
+
+    def pull_request(self, _repository: str, number: int) -> PullRequest:
+        return PullRequest(
+            number=number,
+            url=f"https://example.test/pulls/{number}",
+            state="open" if number == 2 else "closed",
+            draft=number == 2,
+            merged=number == 1,
+            head_sha=str(number) * 40,
+        )
+
+
+class DependencyAttestationPipelineTests(unittest.TestCase):
+    def test_confirmation_and_revocation_require_explicit_identity_checked_gate(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pipeline = object.__new__(Pipeline)
+            pipeline.config = SimpleNamespace(
+                repositories={
+                    "owner/repo": RepositoryPolicy(
+                        name="owner/repo",
+                        mode="maintainer",
+                        submission_strategy="same-repository",
+                    )
+                },
+                github=SimpleNamespace(login="alice"),
+            )
+            pipeline.github = _AttestationGitHub()
+            pipeline.store = Store(Path(directory) / "state.sqlite3")
+
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                self.assertRaisesRegex(PolicyError, "attestation is disabled"),
+            ):
+                pipeline.attest_portfolio_dependency(
+                    "owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    action="confirm",
+                    reviewed_by="alice",
+                )
+
+            with patch.dict(
+                os.environ, {"REPOSTEWARD_ENABLE_DEPENDENCY_ATTESTATION": "1"}
+            ):
+                confirmed = pipeline.attest_portfolio_dependency(
+                    "owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    action="confirm",
+                    reviewed_by="alice",
+                )
+                repeated = pipeline.attest_portfolio_dependency(
+                    "owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    action="confirm",
+                    reviewed_by="alice",
+                )
+                revoked = pipeline.attest_portfolio_dependency(
+                    "owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    action="revoke",
+                    reviewed_by="alice",
+                )
+                repeated_revoke = pipeline.attest_portfolio_dependency(
+                    "owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    action="revoke",
+                    reviewed_by="alice",
+                )
+                audit_log = pipeline.portfolio_dependency_events(
+                    "owner/repo", pull_number=2
+                )
+
+        self.assertFalse(confirmed["public_write"])
+        self.assertTrue(confirmed["local_write"])
+        self.assertEqual(confirmed["audit"]["id"], repeated["audit"]["id"])
+        self.assertTrue(repeated["audit"]["idempotent"])
+        self.assertEqual(revoked["action"], "revoke")
+        self.assertEqual(revoked["audit"]["id"], repeated_revoke["audit"]["id"])
+        self.assertTrue(repeated_revoke["audit"]["idempotent"])
+        self.assertEqual(
+            [value["action"] for value in audit_log["events"]],
+            ["revoke", "confirm"],
+        )
+
+
+class DependencyAttestationConcurrencyTests(unittest.TestCase):
+    def test_concurrent_identical_confirmations_append_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+
+            def append(_index: int) -> dict:
+                return store.append_portfolio_dependency_event(
+                    repository="owner/repo",
+                    pull_number=2,
+                    dependency_number=1,
+                    head_sha="2" * 40,
+                    action="confirm",
+                    actor="alice",
+                )
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(append, range(2)))
+            history = store.portfolio_dependency_events("owner/repo", pull_number=2)
+
+        self.assertEqual(results[0]["id"], results[1]["id"])
+        self.assertEqual(len(history), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -106,7 +106,10 @@ class GitHubPullRequestPaginationTests(unittest.TestCase):
                 "state": "open",
                 "draft": number == 2,
                 "title": f"Pull {number}",
+                "body": f"Depends on #{number + 1}",
                 "updated_at": "2026-08-22T00:00:00Z",
+                "user": {"login": "alice"},
+                "merged_at": None,
                 "head": {
                     "ref": f"change-{number}",
                     "sha": str(number) * 40,
@@ -128,6 +131,8 @@ class GitHubPullRequestPaginationTests(unittest.TestCase):
 
         self.assertEqual([value.number for value in pulls], [1, 2])
         self.assertEqual(pulls[1].base_sha, "b" * 40)
+        self.assertEqual(pulls[1].body, "Depends on #3")
+        self.assertEqual(pulls[1].author, "alice")
         self.assertEqual(request.call_count, 2)
         self.assertEqual(request.call_args_list[0].kwargs["query"]["state"], "open")
         self.assertEqual(request.call_args_list[0].kwargs["query"]["page"], 1)
@@ -400,6 +405,8 @@ class GitHubPullRequestTests(unittest.TestCase):
             "html_url": "https://example.test/pull/12",
             "state": "open",
             "draft": True,
+            "body": "Depends on #11",
+            "user": {"login": "contributor"},
             "updated_at": "2026-08-20T00:00:00Z",
             "head": {"sha": "a" * 40},
             "base": {"ref": "main"},
@@ -451,6 +458,8 @@ class GitHubPullRequestTests(unittest.TestCase):
             activity = client.pull_request_activity("owner/repo", 12)
 
         self.assertEqual(len(activity["comments"]), 101)
+        self.assertNotIn("body", activity["pull_request"])
+        self.assertNotIn("author", activity["pull_request"])
         self.assertEqual(request.call_args_list[1].kwargs["query"]["page"], 1)
         self.assertEqual(request.call_args_list[2].kwargs["query"]["page"], 2)
 
@@ -461,6 +470,8 @@ class GitHubPullRequestTests(unittest.TestCase):
             "html_url": "https://example.test/pull/12",
             "state": "open",
             "draft": True,
+            "body": "Depends on #11",
+            "user": {"login": "contributor"},
             "updated_at": "2026-08-20T00:00:00Z",
             "head": {"sha": "a" * 40},
             "base": {"ref": "main"},
@@ -526,9 +537,11 @@ class GitHubPullRequestTests(unittest.TestCase):
                 (checks, None),
             ],
         ):
-            activity = client.pull_request_activity("owner/repo", 12)
+            activity = client.pull_request_activity("owner/repo", 12, include_body=True)
 
         self.assertEqual(activity["pull_request"]["head_sha"], "a" * 40)
+        self.assertEqual(activity["pull_request"]["body"], "Depends on #11")
+        self.assertEqual(activity["pull_request"]["author"], "contributor")
         self.assertEqual(activity["comments"][0]["id"], 21)
         self.assertEqual(activity["reviews"][0]["state"], "CHANGES_REQUESTED")
         self.assertEqual(activity["reviews"][0]["association"], "MEMBER")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -101,6 +101,23 @@ class MergeDecisionTests(unittest.TestCase):
             ],
         )
 
+    def test_dependency_blockers_and_incomplete_dependency_facts_block_merge(
+        self,
+    ) -> None:
+        result = self.evaluate(
+            replace(
+                self.snapshot,
+                dependency_digest="e" * 64,
+                dependency_blockers=("dependency_open:#11",),
+                dependencies_complete=False,
+            )
+        )
+
+        self.assertEqual(
+            [reason.code for reason in result.reasons],
+            ["dependencies_incomplete", "dependency_blocked"],
+        )
+
     def test_builtin_high_risk_paths_cannot_be_disabled(self) -> None:
         result = self.evaluate(
             replace(self.snapshot, files=(".github/workflows/quality.yml",))

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from reposteward.config import RepositoryPolicy
 from reposteward.context import repository_policy_digest
-from reposteward.github import GitHubError
+from reposteward.github import GitHubError, PullRequest
 from reposteward.pipeline import Pipeline
 from reposteward.policy import PolicyError
 
@@ -18,6 +18,7 @@ class StubStore:
         self.audits: list[dict] = []
         self.decisions: dict[str, dict] = {}
         self.executions: list[dict] = []
+        self.dependency_events: list[dict] = []
 
     def run(self, run_id: str) -> dict:
         return {
@@ -68,6 +69,15 @@ class StubStore:
             "outcome": kwargs["outcome"],
         }
 
+    def latest_portfolio_dependency_events(
+        self, _repository: str, *, pull_number: int = 0
+    ) -> list[dict]:
+        return [
+            value
+            for value in self.dependency_events
+            if not pull_number or int(value["pull_number"]) == pull_number
+        ]
+
 
 class StubGitHub:
     def __init__(self) -> None:
@@ -80,17 +90,25 @@ class StubGitHub:
         self.activity_calls = 0
         self.mutate_on_activity_call = 0
         self.conversation_marker = "initial"
+        self.body = ""
+        self.dependency_target_merged = False
 
-    def pull_request_activity(self, repository: str, number: int) -> dict:
+    def pull_request_activity(
+        self, repository: str, number: int, *, include_body: bool = False
+    ) -> dict:
         self.activity_calls += 1
         if self.activity_calls == self.mutate_on_activity_call:
             self.activity_marker = "changed-during-execution"
+        pull = {
+            "number": number,
+            "head_sha": "a" * 40,
+            "marker": self.activity_marker,
+        }
+        if include_body:
+            pull["body"] = self.body
+            pull["author"] = "contributor"
         return {
-            "pull_request": {
-                "number": number,
-                "head_sha": "a" * 40,
-                "marker": self.activity_marker,
-            },
+            "pull_request": pull,
             "comments": [],
             "reviews": [],
             "review_comments": [],
@@ -125,6 +143,18 @@ class StubGitHub:
             "checks_complete": True,
             "merge_commit_sha": self.merge_commit_sha,
         }
+
+    def pull_request(self, _repository: str, number: int) -> PullRequest:
+        return PullRequest(
+            number=number,
+            url=f"https://example.test/pulls/{number}",
+            state="closed" if self.dependency_target_merged else "open",
+            draft=False,
+            merged=self.dependency_target_merged,
+            head_sha="e" * 40,
+            base_branch="main",
+            base_sha="b" * 40,
+        )
 
     def authenticated_login(self) -> str:
         return "alice"
@@ -193,6 +223,21 @@ class MergePipelineTests(unittest.TestCase):
             pipeline.store.audits[0]["decision"]["snapshot"]["head_sha"],
             "a" * 40,
         )
+
+    def test_open_declared_dependency_blocks_merge_until_it_is_merged(self) -> None:
+        pipeline = self.pipeline()
+        pipeline.github.body = "Depends on #11"
+
+        blocked = pipeline.merge_decision("run-1")
+        pipeline.github.dependency_target_merged = True
+        satisfied = pipeline.merge_decision("run-1")
+
+        self.assertFalse(blocked["eligible"])
+        self.assertIn(
+            "dependency_blocked", [value["code"] for value in blocked["reasons"]]
+        )
+        self.assertTrue(satisfied["eligible"])
+        self.assertNotEqual(blocked["decision_digest"], satisfied["decision_digest"])
 
     def test_opted_in_fresh_decision_merges_once_and_audits_intent_and_result(
         self,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -137,6 +137,7 @@ class StorageGcTests(unittest.TestCase):
         self.assertEqual(store.audit, [])
         self.assertIn("merge_decision_audit", result["protected_categories"])
         self.assertIn("merge_execution_audit", result["protected_categories"])
+        self.assertIn("portfolio_dependency_audit", result["protected_categories"])
 
     def test_gc_apply_requires_switch_then_audits_and_deletes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -242,6 +242,112 @@ class StoreTests(unittest.TestCase):
             self.assertIsNotNone(table)
             self.assertIsNotNone(unique_stage)
 
+    def test_version_ten_database_receives_portfolio_dependency_audit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE portfolio_dependency_events")
+                connection.execute("PRAGMA user_version=10")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name='portfolio_dependency_events'"
+                ).fetchone()
+                index = connection.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name='portfolio_dependency_events_for_pull'"
+                ).fetchone()
+                digest_index = connection.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name='portfolio_dependency_events_digest'"
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIsNotNone(index)
+            self.assertIsNotNone(digest_index)
+
+    def test_dependency_attestations_are_append_only_idempotent_and_verified(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            store = Store(path)
+            confirmed = store.append_portfolio_dependency_event(
+                repository="Owner/Repo",
+                pull_number=12,
+                dependency_number=11,
+                head_sha="a" * 40,
+                action="confirm",
+                actor="alice",
+            )
+            repeated = store.append_portfolio_dependency_event(
+                repository="owner/repo",
+                pull_number=12,
+                dependency_number=11,
+                head_sha="a" * 40,
+                action="confirm",
+                actor="alice",
+            )
+            revoked = store.append_portfolio_dependency_event(
+                repository="owner/repo",
+                pull_number=12,
+                dependency_number=11,
+                head_sha="b" * 40,
+                action="revoke",
+                actor="alice",
+            )
+            repeated_revoke = store.append_portfolio_dependency_event(
+                repository="owner/repo",
+                pull_number=12,
+                dependency_number=11,
+                head_sha="b" * 40,
+                action="revoke",
+                actor="alice",
+            )
+            reconfirmed = store.append_portfolio_dependency_event(
+                repository="owner/repo",
+                pull_number=12,
+                dependency_number=11,
+                head_sha="a" * 40,
+                action="confirm",
+                actor="alice",
+            )
+            latest = store.latest_portfolio_dependency_events("OWNER/REPO")
+            history = store.portfolio_dependency_events("owner/repo", pull_number=12)
+            statistics = store.storage_statistics(repository="owner/repo")
+
+            self.assertEqual(confirmed["id"], repeated["id"])
+            self.assertTrue(repeated["idempotent"])
+            self.assertNotEqual(confirmed["id"], revoked["id"])
+            self.assertEqual(revoked["id"], repeated_revoke["id"])
+            self.assertTrue(repeated_revoke["idempotent"])
+            self.assertNotEqual(confirmed["id"], reconfirmed["id"])
+            self.assertEqual(latest[0]["action"], "confirm")
+            self.assertEqual(
+                [value["action"] for value in history],
+                ["confirm", "revoke", "confirm"],
+            )
+            self.assertEqual(
+                next(
+                    value["records"]
+                    for value in statistics
+                    if value["category"] == "portfolio_dependency_audit"
+                ),
+                3,
+            )
+
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute(
+                    "UPDATE portfolio_dependency_events SET payload='{}' WHERE id=?",
+                    (reconfirmed["id"],),
+                )
+            with self.assertRaisesRegex(StoreError, "dependency audit was modified"):
+                store.latest_portfolio_dependency_events("owner/repo")
+
     def test_version_six_database_moves_event_payloads_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "state.sqlite3"


### PR DESCRIPTION
Closes #34

## 做了什么

- 严格解析 PR 正文中的独立 `Depends on #N` 声明，并把文件重叠保留为非权威建议。
- 增加 head-bound 的维护者 confirm/revoke 追加审计、循环检测和确定性建议合并顺序。
- 将直接依赖摘要和 blocker 纳入现有 merge freshness 检查；未满足或信息不完整时失败关闭。
- 不自动 rebase、强推、关闭 PR，也不修改外部贡献者分支。

## 性能与安全

- Portfolio 复用一次开放 PR 列表；只查询实际依赖目标，已关闭源 PR 的历史确认不触发额外网络请求。
- SCC、拓扑排序和阻塞传播均使用非递归 O(V+E) 图遍历；1,000 节点反向长链由回归测试覆盖。
- 正文仍是不可信输入；只接受严格独立行，不解析引用、代码块、HTML 注释或普通句子。
- 本地确认要求显式环境开关、配置身份、token 身份和仓库 push 权限一致。

## 验证

- `uv run python -m unittest discover -s tests -v`（204 tests）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build --no-build-isolation`
- 实际 GitHub 只读 `portfolio plan` smoke test

Implementation assistance: an external coding workspace was used to prepare the change and its tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility for this contribution.