### PR TITLE
feat(ci): classify pull request failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,20 @@ UTF-8 字节安全截断，初次 `prepare` 语义不变；若仍超限，会先
 始终保留安全事实及至少一条可执行反馈。最终估算和裁剪数量记录在 `context_budget` 与
 `context_plan.stats.final_prompt_budget` 中，无法容纳最小必要集合时明确失败。
 
+失败 check 可以先用确定性 CI 诊断读取，而不立即把日志发送给 Harness 或盲目重跑：
+
+```bash
+uv run reposteward ci diagnose owner/repository 123
+```
+
+该命令完整分页读取目标 workflow run 的 job/step 元数据，只对当前失败 job 及同 job/platform 的
+有限失败对照下载日志。当前失败日志和对照日志分别最多读取 24 个；下载使用不携带 GitHub
+Authorization 的短期签名 URL 和 256 KiB Range 上限；日志先脱敏，
+再提取最多 12 条错误片段生成稳定指纹，完整原始日志不会进入输出或本地数据库。比较范围固定为
+同一 workflow run 的其他 attempt、同 PR 最近 12 个 run，以及当前 base SHA 最近 12 个 push run。
+结果只在证据充分时标记 `introduced`、`inherited`、`flaky` 或 `infrastructure`；第三方 check、
+日志不可读、比较不完整或矛盾时返回 `unknown`。命令不调用 Harness、不修改 PR，也不触发 rerun。
+
 `merge-decision` 只读获取完整的 changed files、required checks、Review decision 和未解决会话，
 再对照验证时冻结的 head、base、policy digest、规模上限及高风险路径生成确定性结果。每次调用都会
 追加一条本地审计记录，但不会调用 Harness、修改 workspace 或执行 GitHub 写操作。内置 CI、权限、
@@ -466,6 +480,7 @@ apply 前会追加 `applying` 审计，删除后再追加 `completed` 审计；�
 
 - GitHub 凭据不会传给 Agent、测试、仓库 hooks、Git push 或 Docker 容器。
 - Issue、仓库内容、评论和 Review 正文都视为不可信输入。
+- CI 日志先限长和脱敏，只保存或输出可解释的有界片段与摘要。
 - 安全报告、已认领 Issue、竞争 PR 和仓库贡献门禁可以阻断流水线。
 - `.github/workflows`、凭据路径和超出配置限额的 diff 默认不可提交。
 - 依赖安装可以在无凭据容器中联网，实际验证命令在 `--network none` 下运行。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,14 @@ successor 从已提交水位开始，避免重新注入完整 PR 历史。修复
 进入本地 `ready` 状态；每个新 commit 都需要新的 submit 身份确认。准备时冻结 head、base、policy
 digest、事件水位和完整 GitHub 结构化快照，公开 push 前逐项复核，任一变化都使准备失效。
 
+CI Failure Analyzer 是 follow-up 与 Repair 之间的只读证据层。当前失败 check 通过 Actions run/job
+结构化关联定位，job/step 元数据完整分页，日志只从一分钟有效的签名 URL 读取；GitHub Authorization
+不得转发到下载主机。每类最多读取 24 个日志，每个使用 256 KiB Range 上限，随后先脱敏再提取有界
+错误片段，完整日志不持久化。
+指纹由 workflow、job、平台标签、失败 step、测试标识和规范化错误片段组成。分类只使用同 head 的
+其他 attempt、同 PR 历史和当前 base SHA 的 push run；证据不完整、第三方 provider 或结果矛盾时
+返回 unknown。该层不调用 Harness、重跑 job、修改 PR，也不把 inherited 等同于通过。
+
 Merge Decision Engine 位于执行器之前。它完整分页读取 GitHub 结构化状态，并以纯函数检查已验证
 head/base、策略摘要、审批、required checks、未解决会话、规模和不可削弱的高风险路径。结果只表示
 当前快照是否具备资格，不执行 merge，也不以 Harness 推理替代确定性事实。任何不完整快照都失败

--- a/src/reposteward/ci.py
+++ b/src/reposteward/ci.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+FAILED_CONCLUSIONS = frozenset(
+    {"action_required", "cancelled", "failure", "stale", "timed_out"}
+)
+MAX_LOG_BYTES = 256 * 1024
+MAX_EXCERPT_LINES = 12
+MAX_EXCERPT_LINE_CHARS = 300
+MAX_TEST_IDS = 20
+MAX_COMPARISON_RUNS = 12
+MAX_CURRENT_LOGS = 24
+MAX_COMPARISON_LOGS = 24
+
+_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_TIMESTAMP = re.compile(
+    r"^\s*(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z|"
+    r"\d{2}:\d{2}:\d{2})\s*"
+)
+_SECRET_VALUE = re.compile(
+    r"(?i)\b(token|password|passwd|secret|api[_-]?key|authorization)"
+    r"(\s*[:=]\s*)([^\s,;]+)"
+)
+_KNOWN_TOKEN = re.compile(
+    r"(?i)\b(?:github_pat_[A-Za-z0-9_]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|"
+    r"AKIA[0-9A-Z]{16})\b"
+)
+_BEARER = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}")
+_QUERY_SECRET = re.compile(
+    r"(?i)([?&](?:token|sig|signature|key|secret|x-amz-signature)=)[^&\s]+"
+)
+_PRIVATE_KEY = re.compile(
+    r"-----BEGIN [^-\r\n]*PRIVATE KEY-----.*?"
+    r"-----END [^-\r\n]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b")
+_URL_USERINFO = re.compile(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@")
+_SIGNAL = re.compile(
+    r"(?i)\b(error|failed?|failure|exception|traceback|panic|fatal|timeout|"
+    r"timed out|assert(?:ion)?|segmentation fault|no space left)\b"
+)
+_TEST_ID = re.compile(
+    r"(?i)(?:FAILED|FAIL|ERROR)\s+([A-Za-z0-9_./\\:[\]-]+(?:\([^)]*\))?)"
+)
+_INFRASTRUCTURE = re.compile(
+    r"(?i)(runner (?:has )?lost communication with the server|"
+    r"hosted runner (?:is not responding|failed to start)|"
+    r"github actions (?:has )?encountered an internal error|"
+    r"runner was terminated by the operating system)"
+)
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def redact_ci_log(value: str) -> str:
+    """Remove common credentials before a log fragment enters an output object."""
+    value = _PRIVATE_KEY.sub("[REDACTED PRIVATE KEY]", value)
+    value = _KNOWN_TOKEN.sub("[REDACTED]", value)
+    value = _JWT.sub("[REDACTED]", value)
+    value = _BEARER.sub("Bearer [REDACTED]", value)
+    value = _URL_USERINFO.sub(r"\1[REDACTED]@", value)
+    value = _QUERY_SECRET.sub(r"\1[REDACTED]", value)
+    return _SECRET_VALUE.sub(r"\1\2[REDACTED]", value)
+
+
+def _normalize_line(value: str) -> str:
+    value = _ANSI.sub("", value)
+    value = _TIMESTAMP.sub("", value)
+    value = re.sub(r"(?i)[A-Z]:\\a\\[^\\\s]+\\[^\\\s]+", "<workspace>", value)
+    value = re.sub(r"/home/runner/work/[^/\s]+/[^/\s]+", "<workspace>", value)
+    value = re.sub(r"(?i)[A-Z]:\\Users\\[^\\\s]+", "<home>", value)
+    value = re.sub(r"/(?:home|Users)/[^/\s]+", "<home>", value)
+    value = re.sub(r"\b[0-9a-f]{12,64}\b", "<hex>", value, flags=re.IGNORECASE)
+    value = re.sub(r":\d+(?::\d+)?\b", ":<line>", value)
+    value = re.sub(r"\b\d+(?:\.\d+)?\s*(?:ms|s|sec|seconds)\b", "<duration>", value)
+    return " ".join(value.casefold().split())
+
+
+def platform_key(job: dict[str, Any]) -> str:
+    labels = sorted(
+        {
+            _normalize_line(redact_ci_log(str(value).strip()))[:200]
+            for value in (job.get("labels") or ())
+            if str(value).strip() and str(value).strip().casefold() != "self-hosted"
+        }
+    )
+    if labels:
+        return "|".join(labels)
+    group = _normalize_line(
+        redact_ci_log(str(job.get("runner_group_name") or "").strip())
+    )[:200]
+    return group or "unknown"
+
+
+def fingerprint_failure(
+    job: dict[str, Any], *, log: str, log_bytes: int, log_truncated: bool
+) -> dict[str, Any]:
+    """Build a bounded, secret-redacted fingerprint from one failed job log."""
+    redacted = redact_ci_log(log)
+    signal_lines: list[str] = []
+    test_ids: set[str] = set()
+    infrastructure_signals: set[str] = set()
+    for raw_line in redacted.splitlines():
+        line = _ANSI.sub("", raw_line).strip()
+        if not line:
+            continue
+        for match in _TEST_ID.findall(line):
+            if len(test_ids) >= MAX_TEST_IDS:
+                break
+            test_ids.add(_normalize_line(match))
+        infrastructure_signals.update(
+            match.casefold() for match in _INFRASTRUCTURE.findall(line)
+        )
+        if not _SIGNAL.search(line):
+            continue
+        normalized = _normalize_line(line)
+        if (
+            len(signal_lines) < MAX_EXCERPT_LINES
+            and normalized
+            and normalized not in signal_lines
+        ):
+            signal_lines.append(normalized[:MAX_EXCERPT_LINE_CHARS])
+    failed_steps = sorted(
+        {
+            _normalize_line(redact_ci_log(str(value.get("name") or "").strip()))[
+                :MAX_EXCERPT_LINE_CHARS
+            ]
+            for value in (job.get("steps") or ())
+            if str(value.get("conclusion") or "").casefold() in FAILED_CONCLUSIONS
+            and str(value.get("name") or "").strip()
+        }
+    )
+    material = {
+        "workflow": _normalize_line(
+            redact_ci_log(str(job.get("workflow_name") or "").strip())
+        )[:MAX_EXCERPT_LINE_CHARS],
+        "job": _normalize_line(redact_ci_log(str(job.get("name") or "").strip()))[
+            :MAX_EXCERPT_LINE_CHARS
+        ],
+        "platform": platform_key(job),
+        "failed_steps": failed_steps,
+        "test_ids": sorted(test_ids),
+        "error_fragments": signal_lines,
+    }
+    fingerprint = _digest(material) if signal_lines or test_ids else ""
+    return {
+        "fingerprint": fingerprint,
+        "fingerprint_material": material,
+        "log_excerpt": signal_lines,
+        "log_bytes_read": log_bytes,
+        "log_truncated": log_truncated,
+        "infrastructure_signals": sorted(infrastructure_signals),
+    }
+
+
+def compact_job(job: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": int(job.get("run_id") or 0),
+        "run_attempt": int(job.get("run_attempt") or 0),
+        "job_id": int(job.get("id") or 0),
+        "check_run_id": int(job.get("check_run_id") or 0),
+        "head_sha": str(job.get("head_sha") or ""),
+        "workflow_name": redact_ci_log(str(job.get("workflow_name") or ""))[:300],
+        "name": redact_ci_log(str(job.get("name") or ""))[:300],
+        "platform": platform_key(job),
+        "status": str(job.get("status") or ""),
+        "conclusion": str(job.get("conclusion") or ""),
+        "failed_steps": [
+            redact_ci_log(str(value.get("name") or ""))[:300]
+            for value in (job.get("steps") or ())
+            if str(value.get("conclusion") or "").casefold() in FAILED_CONCLUSIONS
+        ],
+        "url": redact_ci_log(str(job.get("url") or ""))[:500],
+    }
+
+
+def compact_check(check: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": int(check.get("id") or 0),
+        "name": redact_ci_log(str(check.get("name") or ""))[:300],
+        "status": str(check.get("status") or "")[:100],
+        "conclusion": str(check.get("conclusion") or "")[:100],
+        "url": redact_ci_log(str(check.get("url") or ""))[:500],
+        "app_slug": redact_ci_log(str(check.get("app_slug") or ""))[:200],
+    }
+
+
+def same_job(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return (
+        str(left.get("workflow_name") or "").casefold(),
+        str(left.get("name") or "").casefold(),
+        platform_key(left),
+    ) == (
+        str(right.get("workflow_name") or "").casefold(),
+        str(right.get("name") or "").casefold(),
+        platform_key(right),
+    )
+
+
+def classify_failure(
+    current: dict[str, Any],
+    *,
+    same_head: list[dict[str, Any]],
+    pull_history: list[dict[str, Any]],
+    baseline: list[dict[str, Any]],
+    evidence_complete: bool,
+) -> dict[str, Any]:
+    """Classify one failure using only deterministic, reproducible evidence."""
+    fingerprint = str(current.get("fingerprint") or "")
+    current_job = current["job"]
+    comparable_same_head = [
+        value for value in same_head if same_job(current_job, value)
+    ]
+    comparable_history = [
+        value for value in pull_history if same_job(current_job, value)
+    ]
+    comparable_baseline = [value for value in baseline if same_job(current_job, value)]
+    same_head_success = [
+        value
+        for value in comparable_same_head
+        if str(value.get("conclusion") or "").casefold() == "success"
+    ]
+    baseline_success = [
+        value
+        for value in comparable_baseline
+        if str(value.get("conclusion") or "").casefold() == "success"
+    ]
+    baseline_failures = [
+        value
+        for value in comparable_baseline
+        if str(value.get("fingerprint") or "") == fingerprint and fingerprint
+    ]
+    baseline_other_failures = [
+        value
+        for value in comparable_baseline
+        if str(value.get("conclusion") or "").casefold() in FAILED_CONCLUSIONS
+        and value not in baseline_failures
+    ]
+    history_matches = [
+        value
+        for value in comparable_history
+        if str(value.get("fingerprint") or "") == fingerprint and fingerprint
+    ]
+
+    if current.get("infrastructure_signals"):
+        classification = "infrastructure"
+        confidence = "high"
+        reason = "current log matched a deterministic infrastructure signature"
+        compared = []
+    elif same_head_success:
+        classification = "flaky"
+        confidence = "high"
+        reason = "the same head, job, and platform also completed successfully"
+        compared = same_head_success
+    elif baseline_failures:
+        classification = "inherited"
+        confidence = "high"
+        reason = "the current base has the same failure fingerprint"
+        compared = baseline_failures
+    elif (
+        fingerprint
+        and baseline_success
+        and not baseline_other_failures
+        and evidence_complete
+    ):
+        classification = "introduced"
+        confidence = "medium"
+        reason = "the current base passed the same job and platform"
+        compared = baseline_success
+    else:
+        classification = "unknown"
+        confidence = "none"
+        reason = "available deterministic evidence is insufficient or contradictory"
+        compared = []
+
+    return {
+        "classification": classification,
+        "confidence": confidence,
+        "reason": reason,
+        "compared_run_ids": sorted(
+            {int(value.get("run_id") or 0) for value in compared if value.get("run_id")}
+        ),
+        "same_pr_history_run_ids": sorted(
+            {
+                int(value.get("run_id") or 0)
+                for value in history_matches
+                if value.get("run_id")
+            }
+        ),
+    }
+
+
+def finalize_ci_analysis(material: dict[str, Any]) -> dict[str, Any]:
+    return {**material, "analysis_digest": _digest(material)}

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -191,6 +191,14 @@ def _parser() -> argparse.ArgumentParser:
     storage_gc.add_argument("--repo", default="", help="limit to owner/name")
     storage_gc.add_argument("--apply", action="store_true")
 
+    ci = subparsers.add_parser("ci", help="inspect CI failures without rerunning jobs")
+    ci_commands = ci.add_subparsers(dest="ci_command", required=True)
+    ci_diagnose = ci_commands.add_parser(
+        "diagnose", help="fingerprint and classify current pull request failures"
+    )
+    ci_diagnose.add_argument("repository")
+    ci_diagnose.add_argument("pull_number", type=int)
+
     portfolio = subparsers.add_parser(
         "portfolio", help="inspect repository-wide pull request state"
     )
@@ -486,6 +494,11 @@ def main(argv: list[str] | None = None) -> int:
                 _json(pipeline.storage_gc(repository=args.repo, apply=args.apply))
                 return 0
             raise AssertionError(f"unhandled storage command: {args.storage_command}")
+        if args.command == "ci":
+            if args.ci_command == "diagnose":
+                _json(pipeline.ci_failure_analysis(args.repository, args.pull_number))
+                return 0
+            raise AssertionError(f"unhandled ci command: {args.ci_command}")
         if args.command == "portfolio":
             if args.portfolio_command == "inspect":
                 result = pipeline.portfolio_snapshot(

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -25,6 +25,11 @@ class GitHubError(RuntimeError):
     """A GitHub API request failed."""
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def _canonical_digest(value: object) -> str:
     encoded = json.dumps(
         value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
@@ -196,6 +201,7 @@ class GitHubClient:
         *,
         container: str = "",
         query: dict[str, str | int] | None = None,
+        max_items: int = 0,
     ) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         page = 1
@@ -216,6 +222,8 @@ class GitHubClient:
                 label = container or "response"
                 raise GitHubError(f"GitHub paginated {label} was not a list")
             result.extend(values)
+            if max_items and len(result) >= max_items:
+                return result[:max_items]
             if not self._response_has_next_page(response):
                 return result
             if page >= MAX_REST_PAGES:
@@ -835,6 +843,162 @@ class GitHubClient:
                 }
                 for value in check_runs
             ],
+        }
+
+    def check_runs(self, upstream: str, ref: str) -> tuple[dict[str, Any], ...]:
+        values = self._paginated_rest_values(
+            f"/repos/{upstream}/commits/{urllib.parse.quote(ref, safe='')}/check-runs",
+            container="check_runs",
+        )
+        return tuple(
+            {
+                "id": int(value["id"]),
+                "name": str(value.get("name") or ""),
+                "status": str(value.get("status") or ""),
+                "conclusion": str(value.get("conclusion") or ""),
+                "url": str(value.get("details_url") or ""),
+                "app_slug": str((value.get("app") or {}).get("slug") or ""),
+            }
+            for value in values
+        )
+
+    def workflow_runs(
+        self,
+        upstream: str,
+        *,
+        head_sha: str = "",
+        branch: str = "",
+        event: str = "",
+        limit: int = 0,
+    ) -> tuple[dict[str, Any], ...]:
+        query: dict[str, str | int] = {"status": "completed"}
+        if head_sha:
+            query["head_sha"] = head_sha
+        if branch:
+            query["branch"] = branch
+        if event:
+            query["event"] = event
+        values = self._paginated_rest_values(
+            f"/repos/{upstream}/actions/runs",
+            container="workflow_runs",
+            query=query,
+            max_items=limit,
+        )
+        return tuple(
+            {
+                "id": int(value["id"]),
+                "name": str(value.get("name") or ""),
+                "event": str(value.get("event") or ""),
+                "status": str(value.get("status") or ""),
+                "conclusion": str(value.get("conclusion") or ""),
+                "head_branch": str(value.get("head_branch") or ""),
+                "head_sha": str(value.get("head_sha") or ""),
+                "run_attempt": int(value.get("run_attempt") or 0),
+                "created_at": str(value.get("created_at") or ""),
+                "updated_at": str(value.get("updated_at") or ""),
+                "url": str(value.get("html_url") or ""),
+                "pull_numbers": sorted(
+                    int(pull["number"])
+                    for pull in (value.get("pull_requests") or ())
+                    if isinstance(pull, dict) and pull.get("number")
+                ),
+            }
+            for value in values
+        )
+
+    def workflow_jobs(self, upstream: str, run_id: int) -> tuple[dict[str, Any], ...]:
+        values = self._paginated_rest_values(
+            f"/repos/{upstream}/actions/runs/{run_id}/jobs",
+            container="jobs",
+            query={"filter": "all"},
+        )
+        result = []
+        for value in values:
+            check_run_match = re.search(
+                r"/check-runs/(\d+)$", str(value.get("check_run_url") or "")
+            )
+            result.append(
+                {
+                    "id": int(value["id"]),
+                    "run_id": int(value.get("run_id") or run_id),
+                    "run_attempt": int(value.get("run_attempt") or 0),
+                    "head_sha": str(value.get("head_sha") or ""),
+                    "workflow_name": str(value.get("workflow_name") or ""),
+                    "name": str(value.get("name") or ""),
+                    "status": str(value.get("status") or ""),
+                    "conclusion": str(value.get("conclusion") or ""),
+                    "started_at": str(value.get("started_at") or ""),
+                    "completed_at": str(value.get("completed_at") or ""),
+                    "url": str(value.get("html_url") or ""),
+                    "labels": [str(label) for label in (value.get("labels") or ())],
+                    "runner_group_name": str(value.get("runner_group_name") or ""),
+                    "check_run_id": (
+                        int(check_run_match.group(1)) if check_run_match else 0
+                    ),
+                    "steps": [
+                        {
+                            "number": int(step.get("number") or 0),
+                            "name": str(step.get("name") or ""),
+                            "status": str(step.get("status") or ""),
+                            "conclusion": str(step.get("conclusion") or ""),
+                        }
+                        for step in (value.get("steps") or ())
+                        if isinstance(step, dict)
+                    ],
+                }
+            )
+        return tuple(result)
+
+    def workflow_job_log(
+        self, upstream: str, job_id: int, *, max_bytes: int
+    ) -> dict[str, Any]:
+        """Download a bounded job log without forwarding auth to its signed URL."""
+        if job_id < 1 or max_bytes < 1:
+            raise ValueError("job_id and max_bytes must be positive")
+        api_url = f"{self.config.api_url}/repos/{upstream}/actions/jobs/{job_id}/logs"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "reposteward/0.1",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(api_url, headers=headers, method="GET")
+        opener = urllib.request.build_opener(_NoRedirectHandler())
+        try:
+            response = opener.open(request, timeout=30)
+        except urllib.error.HTTPError as exc:
+            if exc.code != 302:
+                raise GitHubError(f"GitHub GET job log failed ({exc.code})") from exc
+            location = str(exc.headers.get("Location") or "")
+            exc.close()
+        except urllib.error.URLError as exc:
+            raise GitHubError("GitHub GET job log failed") from exc
+        else:
+            response.close()
+            raise GitHubError("GitHub job log endpoint did not return a redirect")
+        parsed = urllib.parse.urlparse(location)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise GitHubError("GitHub job log returned an unsafe redirect")
+        download = urllib.request.Request(
+            location,
+            headers={
+                "User-Agent": "reposteward/0.1",
+                "Range": f"bytes=-{max_bytes}",
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(download, timeout=30) as response:
+                payload = response.read(max_bytes + 1)
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            raise GitHubError("GitHub signed job log download failed") from exc
+        truncated = len(payload) > max_bytes
+        bounded = payload[:max_bytes]
+        return {
+            "text": bounded.decode("utf-8", errors="replace"),
+            "bytes_read": len(bounded),
+            "truncated": truncated,
         }
 
     def pull_request_merge_snapshot(self, upstream: str, number: int) -> dict[str, Any]:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -12,6 +12,20 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from .ci import (
+    FAILED_CONCLUSIONS,
+    MAX_COMPARISON_LOGS,
+    MAX_COMPARISON_RUNS,
+    MAX_CURRENT_LOGS,
+    MAX_LOG_BYTES,
+    classify_failure,
+    compact_check,
+    compact_job,
+    finalize_ci_analysis,
+    fingerprint_failure,
+    redact_ci_log,
+    same_job,
+)
 from .config import AppConfig, RepositoryPolicy
 from .context import (
     CONTEXT_SCHEMA_VERSION,
@@ -235,6 +249,380 @@ class Pipeline:
                 "url": pull.url,
             }
         return result
+
+    @staticmethod
+    def _recent_ci_runs(
+        runs: tuple[dict[str, Any], ...], *, exclude_sha: str = ""
+    ) -> list[dict[str, Any]]:
+        values = [
+            value
+            for value in runs
+            if not exclude_sha or str(value.get("head_sha") or "") != exclude_sha
+        ]
+        return sorted(
+            values,
+            key=lambda value: (
+                str(value.get("created_at") or ""),
+                int(value.get("id") or 0),
+            ),
+            reverse=True,
+        )[:MAX_COMPARISON_RUNS]
+
+    def _ci_jobs_for_runs(
+        self,
+        repository: str,
+        runs: list[dict[str, Any]],
+        *,
+        source: str,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        jobs: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        for run in runs:
+            try:
+                run_jobs = self.github.workflow_jobs(repository, int(run["id"]))
+            except GitHubError as exc:
+                errors.append(
+                    {
+                        "source": source,
+                        "run_id": int(run["id"]),
+                        "reason": redact_ci_log(str(exc))[:500],
+                    }
+                )
+                continue
+            for job in run_jobs:
+                jobs.append(
+                    {
+                        **job,
+                        "head_sha": str(
+                            job.get("head_sha") or run.get("head_sha") or ""
+                        ),
+                        "workflow_name": str(
+                            job.get("workflow_name") or run.get("name") or ""
+                        ),
+                    }
+                )
+        return jobs, errors
+
+    def ci_failure_analysis(self, repository: str, pull_number: int) -> dict[str, Any]:
+        """Classify current CI failures without writes, reruns, or Harness calls."""
+        policy = self.policy(repository)
+        if pull_number < 1:
+            raise ValueError("pull_number must be positive")
+        pull = self.github.pull_request(policy.name, pull_number)
+        if not re.fullmatch(r"[a-f0-9]{40}", pull.head_sha):
+            raise GitHubError("pull request head SHA is unavailable")
+        checks = self.github.check_runs(policy.name, pull.head_sha)
+        failed_checks = [
+            value
+            for value in checks
+            if str(value.get("conclusion") or "").casefold() in FAILED_CONCLUSIONS
+        ]
+        if not failed_checks:
+            material = {
+                "schema_version": 1,
+                "repository": policy.name.casefold(),
+                "pull_number": pull_number,
+                "head_sha": pull.head_sha,
+                "base_sha": pull.base_sha,
+                "complete": True,
+                "failures": [],
+                "errors": [],
+                "errors_omitted": 0,
+                "comparison": {
+                    "current_head_run_ids": [],
+                    "same_pr_history_run_ids": [],
+                    "base_run_ids": [],
+                },
+            }
+            return {
+                **finalize_ci_analysis(material),
+                "harness_invoked": False,
+                "workflow_rerun": False,
+                "raw_logs_persisted": False,
+                "local_write": False,
+                "public_write": False,
+            }
+
+        analyzable_checks = [
+            value
+            for value in sorted(failed_checks, key=lambda item: int(item["id"]))
+            if str(value.get("app_slug") or "") == "github-actions"
+        ][:MAX_CURRENT_LOGS]
+        analyzable_check_ids = {int(value["id"]) for value in analyzable_checks}
+        current_run_ids = sorted(
+            {
+                int(match.group(1))
+                for check in analyzable_checks
+                if (
+                    match := re.search(
+                        r"/actions/runs/(\d+)(?:/job/\d+)?/?$",
+                        str(check.get("url") or ""),
+                    )
+                )
+            }
+        )
+        current_runs = [
+            {"id": value, "head_sha": pull.head_sha} for value in current_run_ids
+        ]
+        base_runs = (
+            self._recent_ci_runs(
+                self.github.workflow_runs(
+                    policy.name,
+                    head_sha=pull.base_sha,
+                    event="push",
+                    limit=MAX_COMPARISON_RUNS,
+                )
+            )
+            if analyzable_checks and re.fullmatch(r"[a-f0-9]{40}", pull.base_sha)
+            else []
+        )
+        history_runs = (
+            self._recent_ci_runs(
+                tuple(
+                    value
+                    for value in self.github.workflow_runs(
+                        policy.name,
+                        branch=pull.head_branch,
+                        event="pull_request",
+                        limit=MAX_COMPARISON_RUNS * 2,
+                    )
+                    if pull_number in value.get("pull_numbers", ())
+                ),
+                exclude_sha=pull.head_sha,
+            )
+            if analyzable_checks and pull.head_branch
+            else []
+        )
+        current_jobs, current_errors = self._ci_jobs_for_runs(
+            policy.name, current_runs, source="current_head"
+        )
+        history_jobs, history_errors = self._ci_jobs_for_runs(
+            policy.name, history_runs, source="same_pr_history"
+        )
+        base_jobs, base_errors = self._ci_jobs_for_runs(
+            policy.name, base_runs, source="current_base"
+        )
+        errors = [*current_errors, *history_errors, *base_errors]
+        log_cache: dict[int, dict[str, Any]] = {}
+        current_log_count = 0
+        comparison_log_count = 0
+
+        def fingerprint(job: dict[str, Any], *, comparison: bool) -> dict[str, Any]:
+            nonlocal comparison_log_count, current_log_count
+            job_id = int(job.get("id") or 0)
+            cached = log_cache.get(job_id)
+            if cached is not None:
+                return {**job, **cached}
+            if comparison and comparison_log_count >= MAX_COMPARISON_LOGS:
+                result = {"fingerprint": "", "log_error": "comparison_log_limit"}
+                errors.append(
+                    {
+                        "source": "comparison_log",
+                        "job_id": job_id,
+                        "reason": "comparison_log_limit",
+                    }
+                )
+                log_cache[job_id] = result
+                return {**job, **result}
+            if not comparison and current_log_count >= MAX_CURRENT_LOGS:
+                result = {"fingerprint": "", "log_error": "current_log_limit"}
+                errors.append(
+                    {
+                        "source": "current_log",
+                        "job_id": job_id,
+                        "reason": "current_log_limit",
+                    }
+                )
+                log_cache[job_id] = result
+                return {**job, **result}
+            if comparison:
+                comparison_log_count += 1
+            else:
+                current_log_count += 1
+            try:
+                log = self.github.workflow_job_log(
+                    policy.name, job_id, max_bytes=MAX_LOG_BYTES
+                )
+            except GitHubError as exc:
+                result = {
+                    "fingerprint": "",
+                    "log_error": redact_ci_log(str(exc))[:500],
+                }
+                errors.append(
+                    {
+                        "source": "comparison_log" if comparison else "current_log",
+                        "job_id": job_id,
+                        "reason": result["log_error"],
+                    }
+                )
+            else:
+                result = fingerprint_failure(
+                    job,
+                    log=str(log["text"]),
+                    log_bytes=int(log["bytes_read"]),
+                    log_truncated=bool(log["truncated"]),
+                )
+            log_cache[job_id] = result
+            return {**job, **result}
+
+        failures = []
+        for check in sorted(failed_checks, key=lambda value: int(value["id"])):
+            if (
+                str(check.get("app_slug") or "") == "github-actions"
+                and int(check["id"]) not in analyzable_check_ids
+            ):
+                errors.append(
+                    {
+                        "source": "current_log",
+                        "check_run_id": int(check["id"]),
+                        "reason": "current_log_limit",
+                    }
+                )
+                failures.append(
+                    {
+                        "check": compact_check(check),
+                        "classification": "unknown",
+                        "confidence": "none",
+                        "reason": "current failure exceeds the bounded analysis limit",
+                        "compared_run_ids": [],
+                        "same_pr_history_run_ids": [],
+                        "log_error": "current_log_limit",
+                    }
+                )
+                continue
+            candidates = [
+                job
+                for job in current_jobs
+                if int(job.get("check_run_id") or 0) == int(check["id"])
+            ]
+            if not candidates:
+                run_match = re.search(
+                    r"/actions/runs/(\d+)(?:/job/\d+)?/?$",
+                    str(check.get("url") or ""),
+                )
+                expected_run_id = int(run_match.group(1)) if run_match else 0
+                candidates = [
+                    job
+                    for job in current_jobs
+                    if int(job.get("run_id") or 0) == expected_run_id
+                    if str(job.get("name") or "").casefold()
+                    == str(check.get("name") or "").casefold()
+                    and str(job.get("conclusion") or "").casefold()
+                    in FAILED_CONCLUSIONS
+                ]
+            if str(check.get("app_slug") or "") != "github-actions" or not candidates:
+                failures.append(
+                    {
+                        "check": compact_check(check),
+                        "classification": "unknown",
+                        "confidence": "none",
+                        "reason": "no readable GitHub Actions job matched this check",
+                        "compared_run_ids": [],
+                        "same_pr_history_run_ids": [],
+                    }
+                )
+                continue
+            current_job = fingerprint(
+                max(
+                    candidates,
+                    key=lambda value: (
+                        int(value.get("run_attempt") or 0),
+                        int(value.get("id") or 0),
+                    ),
+                ),
+                comparison=False,
+            )
+
+            evidence_complete = not errors and bool(current_job.get("fingerprint"))
+
+            def comparable(
+                values: list[dict[str, Any]], reference: dict[str, Any] = current_job
+            ) -> list[dict[str, Any]]:
+                nonlocal evidence_complete
+                result = []
+                for value in values:
+                    if int(value.get("id") or 0) == int(reference.get("id") or 0):
+                        continue
+                    if not same_job(reference, value):
+                        continue
+                    if (
+                        str(value.get("conclusion") or "").casefold()
+                        in FAILED_CONCLUSIONS
+                    ):
+                        value = fingerprint(value, comparison=True)
+                        if not value.get("fingerprint"):
+                            evidence_complete = False
+                    result.append(value)
+                return result
+
+            same_head = comparable(current_jobs)
+            pull_history = comparable(history_jobs)
+            baseline = comparable(base_jobs)
+            classification = classify_failure(
+                {
+                    "job": current_job,
+                    "fingerprint": current_job.get("fingerprint", ""),
+                    "infrastructure_signals": current_job.get(
+                        "infrastructure_signals", []
+                    ),
+                },
+                same_head=same_head,
+                pull_history=pull_history,
+                baseline=baseline,
+                evidence_complete=evidence_complete,
+            )
+            failures.append(
+                {
+                    "check": compact_check(check),
+                    "job": compact_job(current_job),
+                    "fingerprint": str(current_job.get("fingerprint") or ""),
+                    "fingerprint_material": current_job.get("fingerprint_material", {}),
+                    "log_excerpt": current_job.get("log_excerpt", []),
+                    "log_bytes_read": int(current_job.get("log_bytes_read") or 0),
+                    "log_truncated": bool(current_job.get("log_truncated")),
+                    "log_error": str(current_job.get("log_error") or ""),
+                    "infrastructure_signals": current_job.get(
+                        "infrastructure_signals", []
+                    ),
+                    **classification,
+                }
+            )
+
+        complete = (
+            not errors
+            and all(
+                bool(value.get("fingerprint"))
+                for value in failures
+                if value.get("job") is not None
+            )
+            and all(value.get("job") is not None for value in failures)
+        )
+        material = {
+            "schema_version": 1,
+            "repository": policy.name.casefold(),
+            "pull_number": pull_number,
+            "head_sha": pull.head_sha,
+            "base_sha": pull.base_sha,
+            "complete": complete,
+            "failures": failures,
+            "errors": errors[:50],
+            "errors_omitted": max(0, len(errors) - 50),
+            "comparison": {
+                "current_head_run_ids": current_run_ids,
+                "same_pr_history_run_ids": sorted(
+                    int(value["id"]) for value in history_runs
+                ),
+                "base_run_ids": sorted(int(value["id"]) for value in base_runs),
+            },
+        }
+        return {
+            **finalize_ci_analysis(material),
+            "harness_invoked": False,
+            "workflow_rerun": False,
+            "raw_logs_persisted": False,
+            "local_write": False,
+            "public_write": False,
+        }
 
     def portfolio_dependency_plan(
         self, repository: str, *, expected_digest: str = ""

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import unittest
+
+from reposteward.ci import (
+    classify_failure,
+    fingerprint_failure,
+    redact_ci_log,
+)
+
+
+def _job(
+    *,
+    job_id: int,
+    run_id: int,
+    conclusion: str,
+    fingerprint: str = "",
+) -> dict:
+    return {
+        "id": job_id,
+        "run_id": run_id,
+        "workflow_name": "CI",
+        "name": "quality",
+        "labels": ["ubuntu-latest"],
+        "conclusion": conclusion,
+        "fingerprint": fingerprint,
+        "steps": [],
+    }
+
+
+class CiFingerprintTests(unittest.TestCase):
+    def test_fingerprint_is_stable_and_output_is_redacted_and_bounded(self) -> None:
+        job = {
+            **_job(job_id=1, run_id=10, conclusion="failure"),
+            "steps": [
+                {"name": "Run tests", "conclusion": "failure"},
+            ],
+        }
+        first = fingerprint_failure(
+            job,
+            log=(
+                "2026-08-21T10:11:12Z GITHUB_TOKEN=ghp_abcdefghijklmnop\n"
+                "2026-08-21T10:11:13Z FAILED tests/test_api.py::test_case:42 "
+                "AssertionError after 1.23s\n"
+                "https://example.test/log?sig=private-signature\n"
+            ),
+            log_bytes=200,
+            log_truncated=False,
+        )
+        second = fingerprint_failure(
+            job,
+            log=(
+                "2026-08-22T01:02:03Z GITHUB_TOKEN=github_pat_abcdefghijklmnop\n"
+                "2026-08-22T01:02:04Z FAILED tests/test_api.py::test_case:99 "
+                "AssertionError after 9.87s\n"
+            ),
+            log_bytes=190,
+            log_truncated=True,
+        )
+
+        self.assertEqual(first["fingerprint"], second["fingerprint"])
+        self.assertTrue(first["fingerprint"])
+        rendered = str(first)
+        self.assertNotIn("ghp_", rendered)
+        self.assertNotIn("private-signature", rendered)
+        self.assertLessEqual(len(first["log_excerpt"]), 12)
+
+    def test_redaction_covers_assignments_bearer_tokens_and_signed_queries(
+        self,
+    ) -> None:
+        value = redact_ci_log(
+            "password=hunter2 Authorization: Bearer abcdefghijklmnop "
+            "https://user:pass@example.test/x?token=secret-value&ok=1\n"
+            "-----BEGIN PRIVATE KEY-----\nprivate-material\n"
+            "-----END PRIVATE KEY-----"
+        )
+
+        self.assertNotIn("hunter2", value)
+        self.assertNotIn("abcdefghijklmnop", value)
+        self.assertNotIn("secret-value", value)
+        self.assertNotIn("private-material", value)
+        self.assertNotIn("user:pass", value)
+
+    def test_infrastructure_signature_is_reported_without_model_inference(self) -> None:
+        result = fingerprint_failure(
+            _job(job_id=1, run_id=10, conclusion="failure"),
+            log="Error: The runner has lost communication with the server",
+            log_bytes=56,
+            log_truncated=False,
+        )
+
+        classified = classify_failure(
+            {"job": _job(job_id=1, run_id=10, conclusion="failure"), **result},
+            same_head=[],
+            pull_history=[],
+            baseline=[],
+            evidence_complete=True,
+        )
+
+        self.assertEqual(classified["classification"], "infrastructure")
+        self.assertEqual(classified["confidence"], "high")
+
+
+class CiClassificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.current_job = _job(job_id=1, run_id=10, conclusion="failure")
+        self.current = {
+            "job": self.current_job,
+            "fingerprint": "fingerprint-a",
+            "infrastructure_signals": [],
+        }
+
+    def test_same_head_success_is_flaky(self) -> None:
+        result = classify_failure(
+            self.current,
+            same_head=[_job(job_id=2, run_id=10, conclusion="success")],
+            pull_history=[],
+            baseline=[],
+            evidence_complete=True,
+        )
+
+        self.assertEqual(result["classification"], "flaky")
+        self.assertEqual(result["compared_run_ids"], [10])
+
+    def test_matching_base_failure_is_inherited(self) -> None:
+        result = classify_failure(
+            self.current,
+            same_head=[],
+            pull_history=[],
+            baseline=[
+                _job(
+                    job_id=3,
+                    run_id=20,
+                    conclusion="failure",
+                    fingerprint="fingerprint-a",
+                )
+            ],
+            evidence_complete=True,
+        )
+
+        self.assertEqual(result["classification"], "inherited")
+        self.assertEqual(result["compared_run_ids"], [20])
+
+    def test_successful_base_is_introduced_only_with_complete_evidence(self) -> None:
+        baseline = [_job(job_id=4, run_id=30, conclusion="success")]
+
+        complete = classify_failure(
+            self.current,
+            same_head=[],
+            pull_history=[],
+            baseline=baseline,
+            evidence_complete=True,
+        )
+        incomplete = classify_failure(
+            self.current,
+            same_head=[],
+            pull_history=[],
+            baseline=baseline,
+            evidence_complete=False,
+        )
+
+        self.assertEqual(complete["classification"], "introduced")
+        self.assertEqual(incomplete["classification"], "unknown")
+
+    def test_mixed_base_success_and_different_failure_is_unknown(self) -> None:
+        result = classify_failure(
+            self.current,
+            same_head=[],
+            pull_history=[],
+            baseline=[
+                _job(job_id=4, run_id=30, conclusion="success"),
+                _job(
+                    job_id=5,
+                    run_id=31,
+                    conclusion="failure",
+                    fingerprint="fingerprint-b",
+                ),
+            ],
+            evidence_complete=True,
+        )
+
+        self.assertEqual(result["classification"], "unknown")
+
+    def test_history_is_evidence_but_does_not_replace_a_baseline(self) -> None:
+        result = classify_failure(
+            self.current,
+            same_head=[],
+            pull_history=[
+                _job(
+                    job_id=5,
+                    run_id=40,
+                    conclusion="failure",
+                    fingerprint="fingerprint-a",
+                )
+            ],
+            baseline=[],
+            evidence_complete=True,
+        )
+
+        self.assertEqual(result["classification"], "unknown")
+        self.assertEqual(result["same_pr_history_run_ids"], [40])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_pipeline.py
+++ b/tests/test_ci_pipeline.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from reposteward.config import RepositoryPolicy
+from reposteward.github import PullRequest
+from reposteward.pipeline import Pipeline
+
+
+def _job(
+    job_id: int,
+    run_id: int,
+    conclusion: str,
+    *,
+    check_run_id: int = 0,
+    head_sha: str = "",
+) -> dict:
+    return {
+        "id": job_id,
+        "run_id": run_id,
+        "run_attempt": 1,
+        "head_sha": head_sha,
+        "workflow_name": "CI",
+        "name": "quality",
+        "status": "completed",
+        "conclusion": conclusion,
+        "url": f"https://example.test/jobs/{job_id}",
+        "labels": ["ubuntu-latest"],
+        "runner_group_name": "",
+        "check_run_id": check_run_id,
+        "steps": [
+            {
+                "number": 1,
+                "name": "Run tests",
+                "status": "completed",
+                "conclusion": conclusion,
+            }
+        ],
+    }
+
+
+class _CiGitHub:
+    def __init__(self, *, failed: bool = True) -> None:
+        self.failed = failed
+        self.log_calls: list[int] = []
+        self.workflow_run_calls: list[dict] = []
+
+    def pull_request(self, _repository: str, number: int) -> PullRequest:
+        return PullRequest(
+            number=number,
+            url=f"https://example.test/pulls/{number}",
+            state="open",
+            draft=False,
+            head_branch="feature",
+            head_sha="a" * 40,
+            base_branch="main",
+            base_sha="b" * 40,
+        )
+
+    def check_runs(self, _repository: str, _ref: str) -> tuple[dict, ...]:
+        if not self.failed:
+            return (
+                {
+                    "id": 501,
+                    "name": "quality",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "url": "https://github.test/actions/runs/101/job/1001",
+                    "app_slug": "github-actions",
+                },
+            )
+        return (
+            {
+                "id": 501,
+                "name": "quality",
+                "status": "completed",
+                "conclusion": "failure",
+                "url": "https://github.test/actions/runs/101/job/1001",
+                "app_slug": "github-actions",
+            },
+        )
+
+    def workflow_runs(self, _repository: str, **kwargs) -> tuple[dict, ...]:
+        self.workflow_run_calls.append(kwargs)
+        if kwargs.get("head_sha") == "b" * 40:
+            return (
+                {
+                    "id": 201,
+                    "name": "CI",
+                    "head_sha": "b" * 40,
+                    "created_at": "2026-08-21T10:00:00Z",
+                },
+            )
+        if kwargs.get("branch") == "feature":
+            return (
+                {
+                    "id": 301,
+                    "name": "CI",
+                    "head_sha": "c" * 40,
+                    "created_at": "2026-08-20T10:00:00Z",
+                    "pull_numbers": [12],
+                },
+                {
+                    "id": 101,
+                    "name": "CI",
+                    "head_sha": "a" * 40,
+                    "created_at": "2026-08-21T10:00:00Z",
+                    "pull_numbers": [12],
+                },
+            )
+        raise AssertionError(f"unexpected workflow run query: {kwargs}")
+
+    def workflow_jobs(self, _repository: str, run_id: int) -> tuple[dict, ...]:
+        if run_id == 101:
+            return (
+                _job(
+                    1001,
+                    101,
+                    "failure",
+                    check_run_id=501,
+                    head_sha="a" * 40,
+                ),
+            )
+        if run_id == 201:
+            return (_job(2001, 201, "success", head_sha="b" * 40),)
+        if run_id == 301:
+            return (_job(3001, 301, "failure", head_sha="c" * 40),)
+        raise AssertionError(f"unexpected run: {run_id}")
+
+    def workflow_job_log(
+        self, _repository: str, job_id: int, *, max_bytes: int
+    ) -> dict:
+        self.log_calls.append(job_id)
+        self.assert_log_bound(max_bytes)
+        return {
+            "text": "FAILED tests/test_api.py::test_case AssertionError",
+            "bytes_read": 52,
+            "truncated": False,
+        }
+
+    @staticmethod
+    def assert_log_bound(max_bytes: int) -> None:
+        if max_bytes != 256 * 1024:
+            raise AssertionError(f"unexpected log bound: {max_bytes}")
+
+
+class _ManyFailuresGitHub(_CiGitHub):
+    def check_runs(self, _repository: str, _ref: str) -> tuple[dict, ...]:
+        return tuple(
+            {
+                "id": 500 + value,
+                "name": f"quality-{value}",
+                "status": "completed",
+                "conclusion": "failure",
+                "url": f"https://github.test/actions/runs/{100 + value}/job/{1000 + value}",
+                "app_slug": "github-actions",
+            }
+            for value in range(30)
+        )
+
+    def workflow_runs(self, _repository: str, **kwargs) -> tuple[dict, ...]:
+        self.workflow_run_calls.append(kwargs)
+        return ()
+
+    def workflow_jobs(self, _repository: str, run_id: int) -> tuple[dict, ...]:
+        value = run_id - 100
+        return (
+            {
+                **_job(
+                    1000 + value,
+                    run_id,
+                    "failure",
+                    check_run_id=500 + value,
+                    head_sha="a" * 40,
+                ),
+                "name": f"quality-{value}",
+            },
+        )
+
+
+class _ThirdPartyFailureGitHub(_CiGitHub):
+    def check_runs(self, _repository: str, _ref: str) -> tuple[dict, ...]:
+        return (
+            {
+                "id": 900,
+                "name": "external-quality TOKEN=secret-value",
+                "status": "completed",
+                "conclusion": "failure",
+                "url": "https://ci.example.test/build/900?token=secret-value",
+                "app_slug": "external-ci",
+            },
+        )
+
+
+class CiFailurePipelineTests(unittest.TestCase):
+    def pipeline(self, github: _CiGitHub) -> Pipeline:
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": RepositoryPolicy(name="owner/repo")}
+        )
+        pipeline.github = github
+        return pipeline
+
+    def test_current_failure_is_compared_with_base_and_same_pr_history(self) -> None:
+        github = _CiGitHub()
+        result = self.pipeline(github).ci_failure_analysis("owner/repo", 12)
+
+        self.assertTrue(result["complete"])
+        self.assertEqual(result["failures"][0]["classification"], "introduced")
+        self.assertEqual(result["failures"][0]["same_pr_history_run_ids"], [301])
+        self.assertEqual(github.log_calls, [1001, 3001])
+        self.assertEqual(
+            result["comparison"],
+            {
+                "current_head_run_ids": [101],
+                "same_pr_history_run_ids": [301],
+                "base_run_ids": [201],
+            },
+        )
+        self.assertFalse(result["harness_invoked"])
+        self.assertFalse(result["workflow_rerun"])
+        self.assertFalse(result["raw_logs_persisted"])
+        self.assertFalse(result["local_write"])
+        self.assertFalse(result["public_write"])
+
+    def test_successful_checks_skip_workflow_and_log_queries(self) -> None:
+        github = _CiGitHub(failed=False)
+        result = self.pipeline(github).ci_failure_analysis("owner/repo", 12)
+
+        self.assertEqual(result["failures"], [])
+        self.assertTrue(result["complete"])
+        self.assertEqual(github.workflow_run_calls, [])
+        self.assertEqual(github.log_calls, [])
+
+    def test_current_log_downloads_have_a_global_bound(self) -> None:
+        github = _ManyFailuresGitHub()
+        result = self.pipeline(github).ci_failure_analysis("owner/repo", 12)
+
+        self.assertEqual(len(result["failures"]), 30)
+        self.assertEqual(len(github.log_calls), 24)
+        self.assertFalse(result["complete"])
+        self.assertEqual(result["failures"][-1]["classification"], "unknown")
+        self.assertEqual(result["failures"][-1]["log_error"], "current_log_limit")
+
+    def test_third_party_failure_is_unknown_without_actions_queries(self) -> None:
+        github = _ThirdPartyFailureGitHub()
+        result = self.pipeline(github).ci_failure_analysis("owner/repo", 12)
+
+        self.assertEqual(result["failures"][0]["classification"], "unknown")
+        self.assertNotIn("secret-value", str(result))
+        self.assertFalse(result["complete"])
+        self.assertEqual(github.workflow_run_calls, [])
+        self.assertEqual(github.log_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,26 @@ class CliSetupTests(unittest.TestCase):
             "owner/repo", pull_number=2, limit=100
         )
 
+    def test_ci_diagnose_is_routed_as_a_read_only_command(self) -> None:
+        pipeline = MagicMock()
+        pipeline.ci_failure_analysis.return_value = {
+            "analysis_digest": "a" * 64,
+            "failures": [],
+            "public_write": False,
+        }
+        output = io.StringIO()
+
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+            redirect_stdout(output),
+        ):
+            code = main(["ci", "diagnose", "owner/repo", "12"])
+
+        self.assertEqual(code, 0)
+        pipeline.ci_failure_analysis.assert_called_once_with("owner/repo", 12)
+        self.assertIn('"public_write": false', output.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import io
 import unittest
+import urllib.error
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from reposteward.config import GitHubConfig
 from reposteward.github import GitHubClient, GitHubError, resolve_authentication
@@ -616,6 +618,122 @@ class GitHubPullRequestTests(unittest.TestCase):
                 title="docs: example",
                 body="Closes #1",
             )
+
+
+class GitHubActionsEvidenceTests(unittest.TestCase):
+    def test_check_runs_workflow_runs_and_jobs_are_compact_and_paginated(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        check = {
+            "id": 51,
+            "name": "quality",
+            "status": "completed",
+            "conclusion": "failure",
+            "details_url": "https://github.test/actions/runs/10/job/20",
+            "app": {"slug": "github-actions"},
+        }
+        run = {
+            "id": 10,
+            "name": "CI",
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "failure",
+            "head_branch": "feature",
+            "head_sha": "a" * 40,
+            "run_attempt": 2,
+            "created_at": "2026-08-21T00:00:00Z",
+            "updated_at": "2026-08-21T00:01:00Z",
+            "html_url": "https://github.test/actions/runs/10",
+            "pull_requests": [{"number": 12}],
+        }
+        job = {
+            "id": 20,
+            "run_id": 10,
+            "run_attempt": 2,
+            "head_sha": "a" * 40,
+            "workflow_name": "CI",
+            "name": "quality",
+            "status": "completed",
+            "conclusion": "failure",
+            "html_url": "https://github.test/actions/runs/10/job/20",
+            "labels": ["ubuntu-latest"],
+            "runner_group_name": "GitHub Actions 1",
+            "check_run_url": "https://api.github.test/repos/o/r/check-runs/51",
+            "steps": [
+                {
+                    "number": 1,
+                    "name": "Run tests",
+                    "status": "completed",
+                    "conclusion": "failure",
+                }
+            ],
+        }
+
+        with patch.object(
+            client, "_paginated_rest_values", side_effect=[[check], [run], [job]]
+        ) as paginated:
+            checks = client.check_runs("owner/repo", "a" * 40)
+            runs = client.workflow_runs(
+                "owner/repo", branch="feature", event="pull_request", limit=12
+            )
+            jobs = client.workflow_jobs("owner/repo", 10)
+
+        self.assertEqual(checks[0]["app_slug"], "github-actions")
+        self.assertEqual(runs[0]["pull_numbers"], [12])
+        self.assertEqual(jobs[0]["check_run_id"], 51)
+        self.assertEqual(jobs[0]["steps"][0]["name"], "Run tests")
+        self.assertEqual(paginated.call_args_list[1].kwargs["max_items"], 12)
+        self.assertEqual(paginated.call_args_list[2].kwargs["query"], {"filter": "all"})
+
+    def test_job_log_is_bounded_and_does_not_forward_authorization(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        initial_requests = []
+        location = "https://signed.example.test/job.log?sig=private"
+
+        class RedirectOpener:
+            def open(self, request, timeout):
+                initial_requests.append(request)
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    302,
+                    "Found",
+                    {"Location": location},
+                    io.BytesIO(),
+                )
+
+        download_response = io.BytesIO(b"x" * 20)
+        with (
+            patch("urllib.request.build_opener", return_value=RedirectOpener()),
+            patch("urllib.request.urlopen", return_value=download_response) as download,
+        ):
+            result = client.workflow_job_log("owner/repo", 20, max_bytes=12)
+
+        self.assertEqual(result["text"], "x" * 12)
+        self.assertEqual(result["bytes_read"], 12)
+        self.assertTrue(result["truncated"])
+        self.assertEqual(
+            initial_requests[0].get_header("Authorization"), "Bearer test-token"
+        )
+        signed_request = download.call_args.args[0]
+        self.assertIsNone(signed_request.get_header("Authorization"))
+        self.assertEqual(signed_request.get_header("Range"), "bytes=-12")
+        self.assertEqual(signed_request.full_url, location)
+
+    def test_job_log_rejects_non_https_redirects(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        opener = MagicMock()
+        opener.open.side_effect = urllib.error.HTTPError(
+            "https://api.github.test/logs",
+            302,
+            "Found",
+            {"Location": "http://signed.example.test/job.log"},
+            io.BytesIO(),
+        )
+
+        with (
+            patch("urllib.request.build_opener", return_value=opener),
+            self.assertRaisesRegex(GitHubError, "unsafe redirect"),
+        ):
+            client.workflow_job_log("owner/repo", 20, max_bytes=12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #36

## 做了什么

- 新增只读命令 `reposteward ci diagnose owner/repository PR`，为当前失败 check 生成稳定指纹。
- 对照同 workflow run 的其他 attempt、同 PR 历史和当前 base SHA 的 push run，保守分类为 `introduced`、`inherited`、`flaky`、`infrastructure` 或 `unknown`。
- 第三方 check、日志不可读、比较不完整或证据矛盾均 fail closed 为 `unknown`；不会把 inherited 当作成功。

## 性能与安全

- job/step 元数据复用 REST 分页；最近对照 run 固定为 12，当前和对照日志各最多 24 个。
- 每个日志请求使用 256 KiB Range 上限；短期签名下载 URL 不携带 GitHub Authorization，也不会进入输出。
- 日志、workflow/job/step/label/check URL 均先脱敏和限长；只输出最多 12 条错误片段，不持久化完整原始日志。
- 不调用 Harness、不重跑 workflow/job、不修改 PR 或 workspace，不执行任何 GitHub 写操作。

## 验证

- `uv run python -m unittest discover -s tests -v`（220 tests）
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv build --no-build-isolation`
- 对已合并且 checks 成功的 #35 执行真实 GitHub 只读 smoke test，确认不查询运行历史或下载日志

Implementation assistance: an external coding workspace was used to prepare the change and its tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility for this contribution.