### PR TITLE
feat(merge): support owner review attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,24 @@ mode = "maintainer"
 submission_strategy = "same-repository"
 auto_merge = true
 auto_merge_method = "squash"
+# 单维护者自有仓库可显式启用；默认 false
+owner_attestation = true
 ```
+
+GitHub 不允许 PR 作者批准自己的 PR。对单维护者自有仓库，可以在 Maintainer、
+same-repository 模式下显式启用 `owner_attestation`。它不伪造 GitHub Approval，也不使用 admin
+bypass；Contributor、外部作者、非受管分支或要求独立 Reviewer 的 branch protection/ruleset
+仍然拒绝。先等待 CI 完成并人工检查精确 diff，再单独追加声明：
+
+```bash
+REPOSTEWARD_ENABLE_OWNER_ATTESTATION=1 \
+  uv run reposteward merge-attest RUN_ID --reviewed-by your-github-login
+```
+
+声明绑定 repository、PR、run、作者、受管分支、head/base、policy、diff、checks、Review、会话、
+活动、依赖和仓库规则摘要。随后必须重新运行 `merge-decision`；任何绑定事实变化都会使旧声明失效。
+仓库规则接口不可读、受保护分支的 classic protection 不可确认，或当前身份不是 owner/admin 且无
+push 权限时均失败关闭。声明只写本地追加审计，且还需要下方独立的一次性 merge 开关才能执行合并。
 
 执行器只消费一次指定的 eligible 决策，不会自己生成资格。先运行 `merge-decision`，人工检查返回的
 决策和 `audit.id`，再显式执行：
@@ -442,7 +459,7 @@ REPOSTEWARD_ENABLE_MERGE=1 \
 任何评论或 Review 编辑、check、会话、head/base、策略、规模或风险变化都会使旧决策失效；请求还会
 绑定精确 head SHA。网络结果不确定时先回读 GitHub，已在相同 head 合并则作为幂等成功，否则失败
 关闭。每次尝试的意图和结果都追加到本地审计。Contributor mode、高风险路径、超限 PR、后台轮询、
-Reviewer 回复和自动开启 GitHub auto-merge 均不在该执行器范围内。
+Reviewer 回复、伪造 Approval、admin bypass 和自动开启 GitHub auto-merge 均不在该执行器范围内。
 
 本地占用可以按仓库、数据类别和时间范围只读查看：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,8 @@ Merge Execution 或自身审计。
   GitHub 结果；`applying` 没有对应 `completed` 时表示进程可能在外部写入期间中断，重试必须先回读。
 - `portfolio_dependency_events`：按依赖对追加保存维护者 confirm/revoke、当前 head、身份、来源和
   前一事件；事件 digest 唯一，读取时会同时校验物化列与规范化载荷。
+- `owner_review_attestations`：追加保存单维护者对精确 PR 事实的本地审查声明；物化 scope、规范化
+  facts、facts digest 和 attestation digest 在读取时交叉校验，普通 GC 不删除该审计。
 
 Context Pack 与 Harness 绑定在一个事务中写入；Checkpoint 采用追加方式写入。数据库列中的版本、
 摘要、基线和关联 ID 必须与 JSON 内容一致，否则拒绝保存。
@@ -171,6 +173,14 @@ same-repository 和 `auto_merge = true`，进程还必须设置一次性环境�
 不完整事实或权限问题都阻止写入。网络超时或 GitHub 返回不确定结果时先回读；相同 head 已合并视为
 幂等成功，其他状态不会盲目重试。执行器不回复 Reviewer、不服务 Contributor mode，也没有常驻
 调度器。
+
+Owner Attestation 是 Merge Decision Engine 的可选输入，不是 GitHub Review。它只在仓库显式启用、
+当前 token 身份为 owner/admin 且有 push 权限、PR 作者与操作者一致、head 是该 run 持续跟踪的
+same-repository 分支、GitHub branch protection 与 applicable rulesets 均可完整读取且不要求独立
+Reviewer 时创建。创建动作有独立环境开关，并要求除 ReviewDecision 外的全部合并门禁已经通过。
+声明绑定 head/base、policy、diff、checks、Review、会话、活动、依赖和规则摘要；Merge Decision 与
+Merge Executor 每次重新读取事实后才接受完全匹配的最新声明。它不会提交 GitHub Approval，也不会
+调用 admin bypass。
 
 三类协议文档都使用 Draft 2020-12 JSON Schema，schema 随 Python 包发布。持久化和导入边界会
 拒绝未知字段、未来版本、跨 work item/run 的关联错配及不一致摘要。Bundle digest 只能检测意外

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -263,6 +263,12 @@ def _parser() -> argparse.ArgumentParser:
     )
     merge_decision.add_argument("run_id")
 
+    merge_attest = subparsers.add_parser(
+        "merge-attest", help="append an exact owner review attestation"
+    )
+    merge_attest.add_argument("run_id")
+    merge_attest.add_argument("--reviewed-by", required=True)
+
     merge = subparsers.add_parser(
         "merge", help="execute one fresh opt-in maintainer merge decision"
     )
@@ -549,6 +555,11 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "merge-decision":
             _json(pipeline.merge_decision(args.run_id))
+            return 0
+        if args.command == "merge-attest":
+            _json(
+                pipeline.attest_owner_review(args.run_id, reviewed_by=args.reviewed_by)
+            )
             return 0
         if args.command == "merge":
             _json(

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -153,6 +153,7 @@ class RepositoryPolicy:
     max_diff_lines: int | None = None
     merge_risk_paths: tuple[str, ...] = ()
     event_payload_retention_days: int | None = None
+    owner_attestation: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -585,6 +586,7 @@ def load_config(
             auto_merge_method=str(
                 repo_value.get("auto_merge_method", "squash")
             ).strip(),
+            owner_attestation=_boolean(repo_value.get("owner_attestation"), False),
             mode=str(repo_value.get("mode", "contributor")).strip(),
             submission_strategy=str(
                 repo_value.get("submission_strategy", "fork")
@@ -701,6 +703,14 @@ def load_config(
             raise ConfigError(
                 f"{repository.name} may enable auto_merge only in maintainer "
                 "same-repository mode"
+            )
+        if repository.owner_attestation and (
+            repository.mode != "maintainer"
+            or repository.submission_strategy != "same-repository"
+        ):
+            raise ConfigError(
+                f"{repository.name} may enable owner_attestation only in "
+                "maintainer same-repository mode"
             )
         if repository.submission_strategy not in {"fork", "same-repository"}:
             raise ConfigError(

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -44,7 +44,12 @@ def _digest(value: object) -> str:
 
 
 def repository_policy_digest(policy: RepositoryPolicy) -> str:
-    return _digest(asdict(policy))
+    value = asdict(policy)
+    # Preserve outstanding run digests when upgrading to the default-off feature.
+    # Enabling it remains a material policy change and receives a different digest.
+    if not policy.owner_attestation:
+        value.pop("owner_attestation")
+    return _digest(value)
 
 
 def _file_digest(path: Path) -> str:

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -24,6 +24,10 @@ MAX_REST_PAGES = 1_000
 class GitHubError(RuntimeError):
     """A GitHub API request failed."""
 
+    def __init__(self, message: str, *, status_code: int = 0) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
@@ -151,7 +155,8 @@ class GitHubClient:
             except json.JSONDecodeError:
                 pass
             raise GitHubError(
-                f"GitHub {method} {path} failed ({exc.code}): {message}"
+                f"GitHub {method} {path} failed ({exc.code}): {message}",
+                status_code=exc.code,
             ) from exc
         except urllib.error.URLError as exc:
             raise GitHubError(f"GitHub {method} {path} failed: {exc.reason}") from exc
@@ -487,7 +492,116 @@ class GitHubClient:
             is_fork=bool(payload["fork"]),
             license_spdx=(str(license_info["spdx_id"]) if license_info else None),
             can_push=bool((payload.get("permissions") or {}).get("push", False)),
+            can_admin=bool((payload.get("permissions") or {}).get("admin", False)),
+            owner_login=str((payload.get("owner") or {}).get("login") or ""),
         )
+
+    def branch_review_policy(self, full_name: str, branch: str) -> dict[str, Any]:
+        """Read every applicable GitHub review rule and fail closed on ambiguity."""
+        if not branch:
+            raise ValueError("branch must not be empty")
+        encoded = urllib.parse.quote(branch, safe="")
+        branch_payload, _ = self._request(
+            "GET", f"/repos/{full_name}/branches/{encoded}"
+        )
+        if not isinstance(branch_payload, dict) or not isinstance(
+            branch_payload.get("protected"), bool
+        ):
+            raise GitHubError("GitHub branch protection status was malformed")
+        classic: dict[str, Any] = {}
+        try:
+            payload, _ = self._request(
+                "GET", f"/repos/{full_name}/branches/{encoded}/protection"
+            )
+        except GitHubError as exc:
+            if exc.status_code != 404:
+                raise
+            if bool(branch_payload["protected"]):
+                raise GitHubError(
+                    "GitHub reports a protected branch but its classic protection "
+                    "settings are unavailable"
+                ) from exc
+        else:
+            if not isinstance(payload, dict):
+                raise GitHubError("GitHub branch protection was not an object")
+            classic = payload
+
+        requirements: set[str] = set()
+        classic_reviews = classic.get("required_pull_request_reviews")
+        if classic_reviews is not None:
+            if not isinstance(classic_reviews, dict):
+                raise GitHubError("GitHub branch review protection was malformed")
+            self._collect_review_requirements(
+                classic_reviews, requirements, source="classic"
+            )
+        rules = self._paginated_rest_values(
+            f"/repos/{full_name}/rules/branches/{encoded}"
+        )
+        compact_rules: list[dict[str, Any]] = []
+        for rule in rules:
+            rule_type = str(rule.get("type") or "")
+            if not rule_type:
+                raise GitHubError("GitHub applicable branch rule omitted its type")
+            if rule_type != "pull_request":
+                continue
+            parameters = rule.get("parameters")
+            if not isinstance(parameters, dict):
+                raise GitHubError("GitHub pull-request rule omitted its parameters")
+            before = set(requirements)
+            self._collect_review_requirements(
+                parameters, requirements, source="ruleset"
+            )
+            compact_rules.append(
+                {
+                    "type": rule_type,
+                    "source_type": str(rule.get("ruleset_source_type") or ""),
+                    "source": str(rule.get("ruleset_source") or ""),
+                    "requirements": sorted(requirements - before),
+                }
+            )
+        facts = {
+            "repository": full_name.casefold(),
+            "branch": branch,
+            "classic_review_protection": classic_reviews is not None,
+            "rules": sorted(
+                compact_rules,
+                key=lambda value: (
+                    value["source_type"],
+                    value["source"],
+                    value["type"],
+                ),
+            ),
+            "requirements": sorted(requirements),
+            "requires_independent_review": bool(requirements),
+            "complete": True,
+        }
+        return {**facts, "rules_digest": _canonical_digest(facts)}
+
+    @staticmethod
+    def _collect_review_requirements(
+        parameters: dict[str, Any], requirements: set[str], *, source: str
+    ) -> None:
+        count = parameters.get("required_approving_review_count", 0)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise GitHubError("GitHub required review count was malformed")
+        if count:
+            requirements.add(f"{source}:approvals={count}")
+        for key in ("require_code_owner_reviews", "require_code_owner_review"):
+            value = parameters.get(key, False)
+            if not isinstance(value, bool):
+                raise GitHubError(f"GitHub {key} review rule was malformed")
+            if value:
+                requirements.add(f"{source}:code_owner_review")
+        last_push = parameters.get("require_last_push_approval", False)
+        if not isinstance(last_push, bool):
+            raise GitHubError("GitHub last-push review rule was malformed")
+        if last_push:
+            requirements.add(f"{source}:last_push_approval")
+        required_reviewers = parameters.get("required_reviewers", [])
+        if not isinstance(required_reviewers, list):
+            raise GitHubError("GitHub required reviewers rule was malformed")
+        if required_reviewers:
+            requirements.add(f"{source}:required_reviewers")
 
     def issues(
         self, full_name: str, *, per_page: int = 100, max_pages: int = 2
@@ -793,6 +907,14 @@ class GitHubClient:
         if include_body:
             pull_state["body"] = str(pull.get("body") or "")
             pull_state["author"] = str((pull.get("user") or {}).get("login") or "")
+            head = pull.get("head") or {}
+            pull_state["head_owner"] = str(
+                (((head.get("repo") or {}).get("owner") or {}).get("login")) or ""
+            )
+            pull_state["head_repository"] = str(
+                (head.get("repo") or {}).get("full_name") or ""
+            )
+            pull_state["head_branch"] = str(head.get("ref") or "")
         return {
             "pull_request": pull_state,
             "comments": [

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -85,6 +85,9 @@ class MergeSnapshot:
     dependency_digest: str = ""
     dependency_blockers: tuple[str, ...] = ()
     dependencies_complete: bool = True
+    owner_attestation_valid: bool = False
+    owner_attestation_digest: str = ""
+    owner_attestation_status: str = "disabled"
 
 
 @dataclass(frozen=True, slots=True)
@@ -177,8 +180,33 @@ def evaluate_merge(
         block("dependency_blocked", dependency_blocker)
     if not snapshot.activity_digest:
         block("activity_incomplete", "Pull-request activity digest is unavailable.")
-    if snapshot.review_decision.casefold() != "approved":
-        block("review_not_approved", "The current review decision is not approved.")
+    owner_attestation_complete = (
+        snapshot.owner_attestation_valid
+        and snapshot.owner_attestation_status == "valid"
+        and len(snapshot.owner_attestation_digest) == 64
+        and all(
+            value in "0123456789abcdef" for value in snapshot.owner_attestation_digest
+        )
+    )
+    review_decision = snapshot.review_decision.casefold()
+    owner_attestation_can_substitute = (
+        owner_attestation_complete and review_decision in {"", "review_required"}
+    )
+    if snapshot.owner_attestation_valid and not owner_attestation_complete:
+        block(
+            "owner_attestation_incomplete",
+            "Owner attestation validity has no complete audit binding.",
+        )
+    if review_decision != "approved" and not owner_attestation_can_substitute:
+        suffix = (
+            f" Owner attestation is {snapshot.owner_attestation_status}."
+            if snapshot.owner_attestation_status != "disabled"
+            else ""
+        )
+        block(
+            "review_not_approved",
+            "The current review decision is not approved." + suffix,
+        )
     if snapshot.unresolved_conversations:
         block(
             "unresolved_conversations",

--- a/src/reposteward/models.py
+++ b/src/reposteward/models.py
@@ -16,6 +16,8 @@ class RepositoryInfo:
     is_fork: bool
     license_spdx: str | None = None
     can_push: bool = False
+    can_admin: bool = False
+    owner_login: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -7,7 +7,7 @@ import re
 import sqlite3
 import subprocess
 import uuid
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -2687,6 +2687,149 @@ class Pipeline:
                 + "); run follow-up and prepare a new repair"
             )
 
+    @staticmethod
+    def _owner_review_attestation_material(facts: dict[str, Any]) -> tuple[str, str]:
+        facts_digest = _canonical_digest(facts)
+        material = {
+            "schema_version": 1,
+            "source": "owner_attestation",
+            "facts": facts,
+            "review_facts_digest": facts_digest,
+        }
+        return facts_digest, _canonical_digest(material)
+
+    def _owner_review_scope(
+        self,
+        *,
+        repository: str,
+        details: dict[str, Any],
+        policy: RepositoryPolicy,
+        actor: str,
+        pull_activity: dict[str, Any],
+        raw: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Verify that an owner review is allowed for this exact tracked PR."""
+        if not policy.owner_attestation:
+            raise PolicyError("repository owner_attestation is not explicitly enabled")
+        if (
+            policy.mode != "maintainer"
+            or policy.submission_strategy != "same-repository"
+        ):
+            raise PolicyError(
+                "owner attestation requires maintainer same-repository mode"
+            )
+        authenticated = self.github.authenticated_login()
+        repository_info = self.github.repository(repository)
+        configured = self.config.github.login
+        if not actor or actor.casefold() != configured.casefold():
+            raise PolicyError("--reviewed-by must match the configured GitHub login")
+        if authenticated.casefold() != actor.casefold():
+            raise PolicyError(
+                "authenticated GitHub login differs from the reviewed identity"
+            )
+        owner_login = str(repository_info.owner_login or "")
+        if not owner_login:
+            raise PolicyError("GitHub did not return the repository owner identity")
+        if not repository_info.can_push:
+            raise PolicyError(
+                "authenticated GitHub login cannot push to the repository"
+            )
+        if not (
+            repository_info.can_admin or owner_login.casefold() == actor.casefold()
+        ):
+            raise PolicyError(
+                "owner attestation requires repository owner or admin permission"
+            )
+        if str(pull_activity.get("author") or "").casefold() != actor.casefold():
+            raise PolicyError(
+                "owner attestation cannot review a pull request authored externally"
+            )
+        if (
+            str(pull_activity.get("head_owner") or "").casefold()
+            != owner_login.casefold()
+        ):
+            raise PolicyError("owner attestation requires a same-repository branch")
+        if (
+            str(pull_activity.get("head_repository") or "").casefold()
+            != repository.casefold()
+        ):
+            raise PolicyError(
+                "owner attestation rejects fork or cross-repository heads"
+            )
+        expected_branch = str(details.get("branch") or "")
+        if (
+            not expected_branch
+            or str(pull_activity.get("head_branch") or "") != expected_branch
+        ):
+            raise PolicyError(
+                "owner attestation requires the exact RepoSteward-tracked branch"
+            )
+        if str(raw.get("head_branch") or "") != expected_branch:
+            raise PolicyError("GitHub merge facts disagree about the tracked branch")
+        if (
+            int(pull_activity.get("number") or 0) != int(raw.get("pull_number") or 0)
+            or str(pull_activity.get("head_sha") or "")
+            != str(raw.get("head_sha") or "")
+            or str(pull_activity.get("base_sha") or "")
+            != str(raw.get("base_sha") or "")
+        ):
+            raise PolicyError(
+                "GitHub activity and merge facts were read at different revisions"
+            )
+        rules = self.github.branch_review_policy(
+            repository, str(raw.get("base_branch") or "")
+        )
+        if not bool(rules.get("complete")):
+            raise PolicyError("GitHub branch review rules are incomplete")
+        if bool(rules.get("requires_independent_review")):
+            requirements = ", ".join(
+                str(value) for value in rules.get("requirements", ())
+            )
+            raise PolicyError(
+                "GitHub requires an independent review; owner attestation is not "
+                f"allowed ({requirements or 'review rule'})"
+            )
+        return rules
+
+    @staticmethod
+    def _owner_review_facts(
+        *,
+        run_id: str,
+        actor: str,
+        snapshot: MergeSnapshot,
+        pull_activity: dict[str, Any],
+        raw: dict[str, Any],
+        rules: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "repository": snapshot.repository.casefold(),
+            "pull_number": snapshot.pull_number,
+            "run_id": run_id,
+            "actor": actor,
+            "pull_author": str(pull_activity.get("author") or ""),
+            "head_owner": str(pull_activity.get("head_owner") or ""),
+            "head_repository": str(pull_activity.get("head_repository") or ""),
+            "head_branch": str(pull_activity.get("head_branch") or ""),
+            "head_sha": snapshot.head_sha,
+            "base_sha": snapshot.base_sha,
+            "policy_digest": snapshot.policy_digest,
+            "review_decision": snapshot.review_decision,
+            "diff_digest": _canonical_digest(
+                {
+                    "files": snapshot.files,
+                    "additions": snapshot.additions,
+                    "deletions": snapshot.deletions,
+                }
+            ),
+            "checks_digest": _canonical_digest(
+                [asdict(value) for value in snapshot.checks]
+            ),
+            "conversation_digest": str(raw.get("conversation_digest") or ""),
+            "dependency_digest": snapshot.dependency_digest,
+            "activity_digest": snapshot.activity_digest,
+            "rules_digest": str(rules.get("rules_digest") or ""),
+        }
+
     def _current_merge_evaluation(
         self, run_id: str
     ) -> tuple[
@@ -2696,6 +2839,7 @@ class Pipeline:
         int,
         MergeSnapshot,
         MergeDecision,
+        dict[str, Any],
         dict[str, Any],
     ]:
         """Read all current facts and produce one deterministic merge evaluation."""
@@ -2782,7 +2926,49 @@ class Pipeline:
                 str(value) for value in dependency_status["blockers"]
             ),
             dependencies_complete=bool(dependency_status["complete"]),
+            owner_attestation_status=(
+                "missing" if policy.owner_attestation else "disabled"
+            ),
         )
+        if (
+            policy.owner_attestation
+            and snapshot.review_decision.casefold() != "approved"
+        ):
+            attestation = self.store.latest_owner_review_attestation(
+                repository, pull_number
+            )
+            if attestation is not None:
+                actor = str(attestation["actor"])
+                rules = self._owner_review_scope(
+                    repository=repository,
+                    details=details,
+                    policy=policy,
+                    actor=actor,
+                    pull_activity=pull_activity,
+                    raw=raw,
+                )
+                facts = self._owner_review_facts(
+                    run_id=run_id,
+                    actor=actor,
+                    snapshot=snapshot,
+                    pull_activity=pull_activity,
+                    raw=raw,
+                    rules=rules,
+                )
+                facts_digest, attestation_digest = (
+                    self._owner_review_attestation_material(facts)
+                )
+                if facts_digest == str(
+                    attestation["review_facts_digest"]
+                ) and attestation_digest == str(attestation["attestation_digest"]):
+                    snapshot = replace(
+                        snapshot,
+                        owner_attestation_valid=True,
+                        owner_attestation_digest=attestation_digest,
+                        owner_attestation_status="valid",
+                    )
+                else:
+                    snapshot = replace(snapshot, owner_attestation_status="stale")
         decision = evaluate_merge(
             snapshot,
             expected_head_sha=str(details.get("commit_sha") or ""),
@@ -2800,7 +2986,86 @@ class Pipeline:
             ),
             extra_risk_patterns=policy.merge_risk_paths,
         )
-        return run, details, policy, pull_number, snapshot, decision, raw
+        return run, details, policy, pull_number, snapshot, decision, raw, activity
+
+    def attest_owner_review(self, run_id: str, *, reviewed_by: str) -> dict[str, Any]:
+        """Append an exact owner review after every non-review merge gate passes."""
+        if os.environ.get("REPOSTEWARD_ENABLE_OWNER_ATTESTATION") != "1":
+            raise PolicyError(
+                "owner attestation is disabled; set "
+                "REPOSTEWARD_ENABLE_OWNER_ATTESTATION=1 for this command"
+            )
+        (
+            run,
+            details,
+            policy,
+            pull_number,
+            snapshot,
+            decision,
+            raw,
+            activity,
+        ) = self._current_merge_evaluation(run_id)
+        if str(run.get("status")) != "submitted":
+            raise PolicyError("owner attestation requires a submitted run")
+        if snapshot.review_decision.casefold() == "approved":
+            raise PolicyError("GitHub already records an approved review decision")
+        if snapshot.review_decision.casefold() not in {"", "review_required"}:
+            raise PolicyError(
+                "owner attestation cannot override the current GitHub review decision"
+            )
+        actor = str(reviewed_by).strip()
+        pull_activity = activity.get("pull_request", {})
+        rules = self._owner_review_scope(
+            repository=snapshot.repository,
+            details=details,
+            policy=policy,
+            actor=actor,
+            pull_activity=pull_activity,
+            raw=raw,
+        )
+        facts = self._owner_review_facts(
+            run_id=run_id,
+            actor=actor,
+            snapshot=snapshot,
+            pull_activity=pull_activity,
+            raw=raw,
+            rules=rules,
+        )
+        _facts_digest, attestation_digest = self._owner_review_attestation_material(
+            facts
+        )
+        non_review_reasons = tuple(
+            value for value in decision.reasons if value.code != "review_not_approved"
+        )
+        if non_review_reasons:
+            reasons = ", ".join(value.code for value in non_review_reasons)
+            raise PolicyError(
+                "owner attestation requires every non-review merge gate to pass: "
+                + reasons
+            )
+        pending_checks = sorted(
+            value.name
+            for value in snapshot.checks
+            if value.status.casefold() != "completed"
+        )
+        if pending_checks:
+            raise PolicyError(
+                "owner attestation requires CI to finish: " + ", ".join(pending_checks)
+            )
+        audit = self.store.append_owner_review_attestation(facts=facts)
+        if str(audit["attestation_digest"]) != attestation_digest:
+            raise PolicyError("owner attestation audit digest did not match")
+        return {
+            "run_id": run_id,
+            "repository": snapshot.repository,
+            "pull_number": pull_number,
+            "reviewed_by": actor,
+            "head_sha": snapshot.head_sha,
+            "attestation_digest": attestation_digest,
+            "audit": audit,
+            "next_action": "run merge-decision and review its fresh audit",
+            "public_write": False,
+        }
 
     def merge_decision(self, run_id: str) -> dict[str, Any]:
         """Evaluate and audit current merge eligibility without writing to GitHub."""
@@ -2812,6 +3077,7 @@ class Pipeline:
             snapshot,
             decision,
             _raw,
+            _activity,
         ) = self._current_merge_evaluation(run_id)
         repository = snapshot.repository
         payload = decision.to_dict()
@@ -2954,6 +3220,7 @@ class Pipeline:
             int,
             MergeSnapshot,
             MergeDecision,
+            dict[str, Any],
             dict[str, Any],
         ]:
             try:

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -205,6 +205,7 @@ enabled = true
 auto_prepare = false
 auto_merge = false
 auto_merge_method = "squash"
+owner_attestation = false
 mode = {_toml_string(mode)}
 submission_strategy = {_toml_string("same-repository" if mode == "maintainer" else "fork")}
 require_no_competing_work = true

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -13,7 +13,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -383,6 +383,30 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON portfolio_dependency_events(event_digest)
         """,
     ),
+    12: (
+        """
+        CREATE TABLE IF NOT EXISTS owner_review_attestations (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            repository TEXT NOT NULL,
+            pull_number INTEGER NOT NULL,
+            run_id TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            head_sha TEXT NOT NULL,
+            base_sha TEXT NOT NULL,
+            policy_digest TEXT NOT NULL,
+            review_facts_digest TEXT NOT NULL UNIQUE,
+            attestation_digest TEXT NOT NULL UNIQUE,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS owner_review_attestations_for_pull
+        ON owner_review_attestations(repository, pull_number, sequence DESC)
+        """,
+    ),
 }
 
 
@@ -405,6 +429,36 @@ def _canonical_json(value: object) -> str:
 
 def _json_digest(value: object) -> str:
     return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _is_lower_hex(value: str, length: int) -> bool:
+    return len(value) == length and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+OWNER_REVIEW_FACT_KEYS = frozenset(
+    {
+        "repository",
+        "pull_number",
+        "run_id",
+        "actor",
+        "pull_author",
+        "head_owner",
+        "head_repository",
+        "head_branch",
+        "head_sha",
+        "base_sha",
+        "policy_digest",
+        "review_decision",
+        "diff_digest",
+        "checks_digest",
+        "conversation_digest",
+        "dependency_digest",
+        "activity_digest",
+        "rules_digest",
+    }
+)
 
 
 class Store:
@@ -1489,6 +1543,17 @@ class Store:
                 """,
             ),
             (
+                "owner_review_attestation_audit",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM owner_review_attestations
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
                 "storage_gc_audit",
                 """
                 SELECT CASE WHEN repository='' THEN '*' ELSE repository END AS repository,
@@ -2125,6 +2190,165 @@ class Store:
         result = dict(row)
         result["details"] = json.loads(result["details"])
         return result
+
+    def append_owner_review_attestation(
+        self, *, facts: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Append one immutable owner review bound to exact merge facts."""
+        if set(facts) != OWNER_REVIEW_FACT_KEYS:
+            raise StoreError("owner review facts have an unexpected shape")
+        normalized = dict(facts)
+        if isinstance(facts["pull_number"], bool) or not isinstance(
+            facts["pull_number"], int
+        ):
+            raise TypeError("owner review pull_number must be an integer")
+        string_keys = OWNER_REVIEW_FACT_KEYS - {"pull_number"}
+        if any(not isinstance(facts[key], str) for key in string_keys):
+            raise TypeError("owner review fact values must be strings")
+        normalized["repository"] = str(facts["repository"]).casefold()
+        normalized["actor"] = str(facts["actor"]).strip()
+        if int(normalized["pull_number"]) < 1:
+            raise ValueError("owner review pull_number must be positive")
+        if not normalized["run_id"] or not normalized["actor"]:
+            raise ValueError("owner review run and actor must not be empty")
+        for key in ("head_sha", "base_sha"):
+            value = str(normalized[key])
+            if not _is_lower_hex(value, 40):
+                raise ValueError(f"owner review {key} must be 40 lowercase hex chars")
+        for key in (
+            "policy_digest",
+            "diff_digest",
+            "checks_digest",
+            "conversation_digest",
+            "dependency_digest",
+            "activity_digest",
+            "rules_digest",
+        ):
+            value = str(normalized[key])
+            if not _is_lower_hex(value, 64):
+                raise ValueError(f"owner review {key} must be 64 lowercase hex chars")
+        review_facts_digest = _json_digest(normalized)
+        material = {
+            "schema_version": 1,
+            "source": "owner_attestation",
+            "facts": normalized,
+            "review_facts_digest": review_facts_digest,
+        }
+        attestation_digest = _json_digest(material)
+        now = utc_now()
+        attestation_id = uuid.uuid4().hex
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            run = connection.execute(
+                "SELECT repository FROM runs WHERE id=?", (normalized["run_id"],)
+            ).fetchone()
+            if run is None or str(run["repository"]) != normalized["repository"]:
+                raise StoreError("owner review does not match its tracked run")
+            previous = connection.execute(
+                """
+                SELECT * FROM owner_review_attestations
+                WHERE review_facts_digest=?
+                """,
+                (review_facts_digest,),
+            ).fetchone()
+            if previous is not None:
+                value = self._owner_review_attestation(previous)
+                return {**value, "idempotent": True}
+            connection.execute(
+                """
+                INSERT INTO owner_review_attestations(
+                    id, repository, pull_number, run_id, actor, head_sha,
+                    base_sha, policy_digest, review_facts_digest,
+                    attestation_digest, payload, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    attestation_id,
+                    normalized["repository"],
+                    int(normalized["pull_number"]),
+                    normalized["run_id"],
+                    normalized["actor"],
+                    normalized["head_sha"],
+                    normalized["base_sha"],
+                    normalized["policy_digest"],
+                    review_facts_digest,
+                    attestation_digest,
+                    _canonical_json(material),
+                    now,
+                ),
+            )
+        return {
+            "id": attestation_id,
+            **material,
+            "attestation_digest": attestation_digest,
+            "created_at": now,
+            "idempotent": False,
+        }
+
+    @staticmethod
+    def _owner_review_attestation(row: sqlite3.Row) -> dict[str, Any]:
+        value = dict(row)
+        payload = json.loads(str(value["payload"]))
+        if not isinstance(payload, dict):
+            raise StoreError("owner review attestation was modified")
+        facts = payload.get("facts")
+        if not isinstance(facts, dict) or set(facts) != OWNER_REVIEW_FACT_KEYS:
+            raise StoreError("owner review attestation was modified")
+        review_facts_digest = _json_digest(facts)
+        material = {
+            "schema_version": 1,
+            "source": "owner_attestation",
+            "facts": facts,
+            "review_facts_digest": review_facts_digest,
+        }
+        scope = {
+            "repository": str(value["repository"]),
+            "pull_number": int(value["pull_number"]),
+            "run_id": str(value["run_id"]),
+            "actor": str(value["actor"]),
+            "head_sha": str(value["head_sha"]),
+            "base_sha": str(value["base_sha"]),
+            "policy_digest": str(value["policy_digest"]),
+        }
+        if (
+            payload != material
+            or any(facts.get(key) != expected for key, expected in scope.items())
+            or str(value["review_facts_digest"]) != review_facts_digest
+            or str(value["attestation_digest"]) != _json_digest(material)
+        ):
+            raise StoreError("owner review attestation was modified")
+        value["payload"] = payload
+        value["facts"] = facts
+        return value
+
+    def latest_owner_review_attestation(
+        self, repository: str, pull_number: int
+    ) -> dict[str, Any] | None:
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT * FROM owner_review_attestations
+                WHERE repository=? AND pull_number=?
+                ORDER BY sequence DESC LIMIT 1
+                """,
+                (repository.casefold(), pull_number),
+            ).fetchone()
+        return self._owner_review_attestation(row) if row is not None else None
+
+    def owner_review_attestations(
+        self, repository: str, pull_number: int, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM owner_review_attestations
+                WHERE repository=? AND pull_number=?
+                ORDER BY sequence DESC LIMIT ?
+                """,
+                (repository.casefold(), pull_number, limit),
+            ).fetchall()
+        return [self._owner_review_attestation(row) for row in rows]
 
     def append_merge_decision(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -422,6 +422,40 @@ auto_merge_method = "octopus"
             with self.assertRaisesRegex(ConfigError, "auto_merge_method"):
                 load_config(path)
 
+    def test_owner_attestation_requires_explicit_maintainer_same_repo_mode(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+owner_attestation = true
+mode = "contributor"
+submission_strategy = "fork"
+""",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ConfigError, "owner_attestation only"):
+                load_config(path)
+
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+owner_attestation = true
+mode = "maintainer"
+submission_strategy = "same-repository"
+""",
+                encoding="utf-8",
+            )
+            config = load_config(path)
+
+        self.assertTrue(config.repositories["owner/repo"].owner_attestation)
+
     def test_quoted_boolean_is_rejected_instead_of_becoming_true(self) -> None:
         with TemporaryDirectory() as directory:
             path = Path(directory) / "config.toml"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import subprocess
 import tempfile
 import unittest
 from contextlib import closing
-from dataclasses import replace
+from dataclasses import asdict, replace
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -20,6 +21,7 @@ from reposteward.context import (
     build_context_pack,
     build_repair_context_pack,
     portable_bundle,
+    repository_policy_digest,
     review_checkpoint,
 )
 from reposteward.context_budget import (
@@ -43,6 +45,24 @@ from reposteward.protocol import validate_context_pack
 from reposteward.repair_prompt import build_budgeted_repair_context_pack
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+class RepositoryPolicyDigestTests(unittest.TestCase):
+    def test_default_off_owner_attestation_preserves_legacy_policy_digest(self) -> None:
+        policy = RepositoryPolicy(name="owner/repo")
+        legacy = asdict(policy)
+        legacy.pop("owner_attestation")
+        encoded = json.dumps(
+            legacy, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode()
+
+        self.assertEqual(
+            repository_policy_digest(policy), hashlib.sha256(encoded).hexdigest()
+        )
+        self.assertNotEqual(
+            repository_policy_digest(replace(policy, owner_attestation=True)),
+            repository_policy_digest(policy),
+        )
 
 
 def _candidate(body: str = "Reproduce the bug") -> Candidate:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -64,6 +64,129 @@ class GitHubAuthenticationTests(unittest.TestCase):
         run.assert_called_once()
 
 
+class GitHubOwnerReviewPolicyTests(unittest.TestCase):
+    def test_unprotected_branch_has_complete_review_policy(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        not_protected = GitHubError("not protected", status_code=404)
+
+        with patch.object(
+            client,
+            "_request",
+            side_effect=[
+                ({"protected": False}, None),
+                not_protected,
+                ([], SimpleNamespace(headers={})),
+            ],
+        ):
+            result = client.branch_review_policy("Owner/Repo", "main")
+
+        self.assertTrue(result["complete"])
+        self.assertFalse(result["requires_independent_review"])
+        self.assertEqual(result["requirements"], [])
+        self.assertEqual(len(result["rules_digest"]), 64)
+
+    def test_classic_and_ruleset_review_requirements_are_combined(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        classic = {
+            "required_pull_request_reviews": {
+                "required_approving_review_count": 1,
+                "require_code_owner_reviews": True,
+                "require_last_push_approval": False,
+            }
+        }
+        rules = [
+            {
+                "type": "pull_request",
+                "ruleset_source_type": "Repository",
+                "ruleset_source": "owner/repo",
+                "parameters": {
+                    "required_approving_review_count": 0,
+                    "require_code_owner_review": False,
+                    "require_last_push_approval": True,
+                },
+            }
+        ]
+
+        with patch.object(
+            client,
+            "_request",
+            side_effect=[
+                ({"protected": True}, None),
+                (classic, None),
+                (rules, SimpleNamespace(headers={})),
+            ],
+        ):
+            result = client.branch_review_policy("owner/repo", "release/v1")
+
+        self.assertTrue(result["requires_independent_review"])
+        self.assertEqual(
+            result["requirements"],
+            [
+                "classic:approvals=1",
+                "classic:code_owner_review",
+                "ruleset:last_push_approval",
+            ],
+        )
+
+    def test_unreadable_or_malformed_rules_fail_closed(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=GitHubError("forbidden", status_code=403),
+            ),
+            self.assertRaisesRegex(GitHubError, "forbidden"),
+        ):
+            client.branch_review_policy("owner/repo", "main")
+
+        malformed = {
+            "required_pull_request_reviews": {"required_approving_review_count": "1"}
+        }
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[({"protected": True}, None), (malformed, None)],
+            ),
+            self.assertRaisesRegex(GitHubError, "count was malformed"),
+        ):
+            client.branch_review_policy("owner/repo", "main")
+
+        protected_but_hidden = GitHubError("not found", status_code=404)
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[({"protected": True}, None), protected_but_hidden],
+            ),
+            self.assertRaisesRegex(GitHubError, "settings are unavailable"),
+        ):
+            client.branch_review_policy("owner/repo", "main")
+
+    def test_repository_exposes_owner_and_admin_permission(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        payload = {
+            "full_name": "owner/repo",
+            "default_branch": "main",
+            "stargazers_count": 1,
+            "forks_count": 2,
+            "open_issues_count": 3,
+            "pushed_at": "2026-08-22T00:00:00Z",
+            "archived": False,
+            "fork": False,
+            "license": None,
+            "permissions": {"push": True, "admin": True},
+            "owner": {"login": "owner"},
+        }
+        with patch.object(client, "_request", return_value=(payload, None)):
+            repository = client.repository("owner/repo")
+
+        self.assertTrue(repository.can_push)
+        self.assertTrue(repository.can_admin)
+        self.assertEqual(repository.owner_login, "owner")
+
+
 class GitHubCompetingWorkTests(unittest.TestCase):
     def test_claim_comment_and_linked_pull_request_are_blockers(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")
@@ -410,7 +533,14 @@ class GitHubPullRequestTests(unittest.TestCase):
             "body": "Depends on #11",
             "user": {"login": "contributor"},
             "updated_at": "2026-08-20T00:00:00Z",
-            "head": {"sha": "a" * 40},
+            "head": {
+                "sha": "a" * 40,
+                "ref": "contributor/feat/example",
+                "repo": {
+                    "full_name": "owner/repo",
+                    "owner": {"login": "owner"},
+                },
+            },
             "base": {"ref": "main"},
             "mergeable": True,
             "mergeable_state": "clean",
@@ -475,7 +605,14 @@ class GitHubPullRequestTests(unittest.TestCase):
             "body": "Depends on #11",
             "user": {"login": "contributor"},
             "updated_at": "2026-08-20T00:00:00Z",
-            "head": {"sha": "a" * 40},
+            "head": {
+                "sha": "a" * 40,
+                "ref": "contributor/feat/example",
+                "repo": {
+                    "full_name": "owner/repo",
+                    "owner": {"login": "owner"},
+                },
+            },
             "base": {"ref": "main"},
             "mergeable": True,
             "mergeable_state": "clean",
@@ -544,6 +681,11 @@ class GitHubPullRequestTests(unittest.TestCase):
         self.assertEqual(activity["pull_request"]["head_sha"], "a" * 40)
         self.assertEqual(activity["pull_request"]["body"], "Depends on #11")
         self.assertEqual(activity["pull_request"]["author"], "contributor")
+        self.assertEqual(activity["pull_request"]["head_owner"], "owner")
+        self.assertEqual(activity["pull_request"]["head_repository"], "owner/repo")
+        self.assertEqual(
+            activity["pull_request"]["head_branch"], "contributor/feat/example"
+        )
         self.assertEqual(activity["comments"][0]["id"], 21)
         self.assertEqual(activity["reviews"][0]["state"], "CHANGES_REQUESTED")
         self.assertEqual(activity["reviews"][0]["association"], "MEMBER")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -101,6 +101,44 @@ class MergeDecisionTests(unittest.TestCase):
             ],
         )
 
+    def test_exact_owner_attestation_can_satisfy_only_the_review_gate(self) -> None:
+        incomplete = self.evaluate(
+            replace(
+                self.snapshot,
+                review_decision="",
+                owner_attestation_valid=True,
+                owner_attestation_status="valid",
+            )
+        )
+        complete = self.evaluate(
+            replace(
+                self.snapshot,
+                review_decision="",
+                owner_attestation_valid=True,
+                owner_attestation_status="valid",
+                owner_attestation_digest="f" * 64,
+            )
+        )
+
+        self.assertEqual(
+            [reason.code for reason in incomplete.reasons],
+            ["owner_attestation_incomplete", "review_not_approved"],
+        )
+        self.assertTrue(complete.eligible)
+        changes_requested = self.evaluate(
+            replace(
+                self.snapshot,
+                review_decision="CHANGES_REQUESTED",
+                owner_attestation_valid=True,
+                owner_attestation_status="valid",
+                owner_attestation_digest="f" * 64,
+            )
+        )
+        self.assertEqual(
+            [reason.code for reason in changes_requested.reasons],
+            ["review_not_approved"],
+        )
+
     def test_dependency_blockers_and_incomplete_dependency_facts_block_merge(
         self,
     ) -> None:

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -19,6 +19,7 @@ class StubStore:
         self.decisions: dict[str, dict] = {}
         self.executions: list[dict] = []
         self.dependency_events: list[dict] = []
+        self.owner_attestation: dict | None = None
 
     def run(self, run_id: str) -> dict:
         return {
@@ -29,6 +30,7 @@ class StubStore:
                 "pr_url": "https://github.com/owner/repo/pull/12",
                 "commit_sha": "a" * 40,
                 "base_commit": "b" * 40,
+                "branch": "alice/feat/example",
             },
         }
 
@@ -78,6 +80,30 @@ class StubStore:
             if not pull_number or int(value["pull_number"]) == pull_number
         ]
 
+    def append_owner_review_attestation(self, *, facts: dict) -> dict:
+        facts_digest, attestation_digest = Pipeline._owner_review_attestation_material(
+            facts
+        )
+        if (
+            self.owner_attestation is not None
+            and self.owner_attestation["review_facts_digest"] == facts_digest
+        ):
+            return {**self.owner_attestation, "idempotent": True}
+        self.owner_attestation = {
+            "id": "owner-attestation-1",
+            "actor": facts["actor"],
+            "facts": facts,
+            "review_facts_digest": facts_digest,
+            "attestation_digest": attestation_digest,
+            "idempotent": False,
+        }
+        return self.owner_attestation
+
+    def latest_owner_review_attestation(
+        self, _repository: str, _pull_number: int
+    ) -> dict | None:
+        return self.owner_attestation
+
 
 class StubGitHub:
     def __init__(self) -> None:
@@ -92,6 +118,18 @@ class StubGitHub:
         self.conversation_marker = "initial"
         self.body = ""
         self.dependency_target_merged = False
+        self.review_decision = "APPROVED"
+        self.pull_author = "alice"
+        self.head_owner = "owner"
+        self.head_repository = "owner/repo"
+        self.head_branch = "alice/feat/example"
+        self.activity_head_sha = "a" * 40
+        self.rules_require_review = False
+        self.rules_calls = 0
+        self.can_admin = True
+        self.owner_login = "owner"
+        self.files = ["src/example.py"]
+        self.optional_check_pending = False
 
     def pull_request_activity(
         self, repository: str, number: int, *, include_body: bool = False
@@ -101,12 +139,16 @@ class StubGitHub:
             self.activity_marker = "changed-during-execution"
         pull = {
             "number": number,
-            "head_sha": "a" * 40,
+            "head_sha": self.activity_head_sha,
+            "base_sha": "b" * 40,
             "marker": self.activity_marker,
         }
         if include_body:
             pull["body"] = self.body
-            pull["author"] = "contributor"
+            pull["author"] = self.pull_author
+            pull["head_owner"] = self.head_owner
+            pull["head_repository"] = self.head_repository
+            pull["head_branch"] = self.head_branch
         return {
             "pull_request": pull,
             "comments": [],
@@ -121,13 +163,15 @@ class StubGitHub:
             "pull_number": number,
             "head_sha": "a" * 40,
             "base_sha": "b" * 40,
+            "head_branch": self.head_branch,
+            "base_branch": "main",
             "state": self.state,
             "draft": False,
             "mergeable": "MERGEABLE",
-            "review_decision": "APPROVED",
+            "review_decision": self.review_decision,
             "unresolved_conversations": 0,
             "conversation_digest": self.conversation_marker,
-            "files": ["src/example.py"],
+            "files": self.files,
             "additions": 10,
             "deletions": 2,
             "checks": [
@@ -136,7 +180,19 @@ class StubGitHub:
                     "status": "COMPLETED",
                     "conclusion": "SUCCESS",
                     "required": True,
-                }
+                },
+                *(
+                    [
+                        {
+                            "name": "optional",
+                            "status": "IN_PROGRESS",
+                            "conclusion": "",
+                            "required": False,
+                        }
+                    ]
+                    if self.optional_check_pending
+                    else []
+                ),
             ],
             "files_complete": True,
             "conversations_complete": True,
@@ -160,7 +216,24 @@ class StubGitHub:
         return "alice"
 
     def repository(self, _repository: str) -> SimpleNamespace:
-        return SimpleNamespace(can_push=True)
+        return SimpleNamespace(
+            can_push=True,
+            can_admin=self.can_admin,
+            owner_login=self.owner_login,
+        )
+
+    def branch_review_policy(self, repository: str, branch: str) -> dict:
+        self.rules_calls += 1
+        return {
+            "repository": repository,
+            "branch": branch,
+            "complete": True,
+            "requirements": (
+                ["ruleset:approvals=1"] if self.rules_require_review else []
+            ),
+            "requires_independent_review": self.rules_require_review,
+            "rules_digest": "9" * 64,
+        }
 
     def merge_pull_request(
         self, repository: str, number: int, *, head_sha: str, method: str
@@ -184,10 +257,13 @@ class StubGitHub:
 
 class MergePipelineTests(unittest.TestCase):
     @staticmethod
-    def pipeline(*, auto_merge: bool = False) -> Pipeline:
+    def pipeline(
+        *, auto_merge: bool = False, owner_attestation: bool = False
+    ) -> Pipeline:
         policy = RepositoryPolicy(
             name="owner/repo",
             auto_merge=auto_merge,
+            owner_attestation=owner_attestation,
             mode="maintainer",
             submission_strategy="same-repository",
         )
@@ -238,6 +314,152 @@ class MergePipelineTests(unittest.TestCase):
         )
         self.assertTrue(satisfied["eligible"])
         self.assertNotEqual(blocked["decision_digest"], satisfied["decision_digest"])
+
+    def test_owner_attestation_is_opt_in_and_adds_no_default_api_reads(self) -> None:
+        pipeline = self.pipeline()
+        pipeline.github.review_decision = ""
+
+        decision = pipeline.merge_decision("run-1")
+
+        self.assertFalse(decision["eligible"])
+        self.assertEqual(pipeline.github.rules_calls, 0)
+        self.assertEqual(decision["reasons"][0]["code"], "review_not_approved")
+
+    def test_owner_attestation_makes_exact_unapproved_facts_eligible(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}):
+            attestation = pipeline.attest_owner_review("run-1", reviewed_by="alice")
+        decision = pipeline.merge_decision("run-1")
+
+        self.assertFalse(attestation["public_write"])
+        self.assertTrue(decision["eligible"])
+        snapshot = pipeline.store.audits[-1]["decision"]["snapshot"]
+        self.assertTrue(snapshot["owner_attestation_valid"])
+        self.assertEqual(snapshot["owner_attestation_status"], "valid")
+
+    def test_owner_attestation_requires_one_time_environment_gate(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+
+        with self.assertRaisesRegex(PolicyError, "is disabled"):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_changed_activity_invalidates_owner_attestation(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+        pipeline.github.activity_marker = "new-review"
+
+        decision = pipeline.merge_decision("run-1")
+
+        self.assertFalse(decision["eligible"])
+        snapshot = pipeline.store.audits[-1]["decision"]["snapshot"]
+        self.assertFalse(snapshot["owner_attestation_valid"])
+        self.assertEqual(snapshot["owner_attestation_status"], "stale")
+
+    def test_owner_attestation_rejects_external_author_and_review_rules(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        pipeline.github.pull_author = "external"
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "authored externally"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        pipeline.github.pull_author = "alice"
+        pipeline.github.rules_require_review = True
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "independent review"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_owner_attestation_rejects_a_different_repository_head(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        pipeline.github.head_repository = "owner/other-repo"
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "cross-repository"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_owner_attestation_rejects_a_torn_github_read(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        pipeline.github.activity_head_sha = "f" * 40
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "different revisions"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_owner_attestation_does_not_override_changes_requested(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = "CHANGES_REQUESTED"
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "cannot override"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_owner_attestation_cannot_override_high_risk_paths(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        pipeline.github.files = [".github/workflows/quality.yml"]
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "high_risk_change"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_owner_attestation_waits_for_optional_ci_to_finish(self) -> None:
+        pipeline = self.pipeline(owner_attestation=True)
+        pipeline.github.review_decision = ""
+        pipeline.github.optional_check_pending = True
+
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}),
+            self.assertRaisesRegex(PolicyError, "CI to finish: optional"),
+        ):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+
+        self.assertIsNone(pipeline.store.owner_attestation)
+
+    def test_merge_executor_accepts_fresh_owner_attestation(self) -> None:
+        pipeline = self.pipeline(auto_merge=True, owner_attestation=True)
+        pipeline.github.review_decision = ""
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_OWNER_ATTESTATION": "1"}):
+            pipeline.attest_owner_review("run-1", reviewed_by="alice")
+        decision = pipeline.merge_decision("run-1")
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}):
+            result = pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertTrue(result["merged"])
+        self.assertEqual(len(pipeline.github.merge_calls), 1)
 
     def test_opted_in_fresh_decision_merges_once_and_audits_intent_and_result(
         self,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -133,6 +133,7 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(policy.submission_strategy, "same-repository")
         self.assertFalse(policy.auto_merge)
         self.assertEqual(policy.auto_merge_method, "squash")
+        self.assertFalse(policy.owner_attestation)
 
     def test_repo_add_excludes_local_config_without_changing_gitignore(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -105,6 +105,29 @@ def _checkpoint_payload(
     }
 
 
+def _owner_review_facts(run_id: str) -> dict:
+    return {
+        "repository": "owner/repo",
+        "pull_number": 12,
+        "run_id": run_id,
+        "actor": "alice",
+        "pull_author": "alice",
+        "head_owner": "owner",
+        "head_repository": "owner/repo",
+        "head_branch": "alice/feat/example",
+        "head_sha": "a" * 40,
+        "base_sha": "b" * 40,
+        "policy_digest": "c" * 64,
+        "review_decision": "",
+        "diff_digest": "d" * 64,
+        "checks_digest": "e" * 64,
+        "conversation_digest": "f" * 64,
+        "dependency_digest": "1" * 64,
+        "activity_digest": "2" * 64,
+        "rules_digest": "3" * 64,
+    }
+
+
 class StoreTests(unittest.TestCase):
     def test_legacy_unversioned_database_is_migrated_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -269,6 +292,67 @@ class StoreTests(unittest.TestCase):
             self.assertIsNotNone(table)
             self.assertIsNotNone(index)
             self.assertIsNotNone(digest_index)
+
+    def test_version_eleven_database_receives_owner_review_attestation_audit(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE owner_review_attestations")
+                connection.execute("PRAGMA user_version=11")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name='owner_review_attestations'"
+                ).fetchone()
+                index = connection.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE name='owner_review_attestations_for_pull'"
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIsNotNone(index)
+
+    def test_owner_review_attestations_are_idempotent_and_tamper_evident(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            run_id = store.start_run("owner/repo", 7, "merge")
+            facts = _owner_review_facts(run_id)
+
+            first = store.append_owner_review_attestation(facts=facts)
+            repeated = store.append_owner_review_attestation(facts=facts)
+            history = store.owner_review_attestations("OWNER/REPO", 12)
+            latest = store.latest_owner_review_attestation("owner/repo", 12)
+            statistics = store.storage_statistics(repository="owner/repo")
+
+            self.assertEqual(first["id"], repeated["id"])
+            self.assertTrue(repeated["idempotent"])
+            self.assertEqual(len(history), 1)
+            assert latest is not None
+            self.assertEqual(latest["facts"], facts)
+            self.assertEqual(
+                next(
+                    value["records"]
+                    for value in statistics
+                    if value["category"] == "owner_review_attestation_audit"
+                ),
+                1,
+            )
+
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                connection.execute(
+                    "UPDATE owner_review_attestations SET payload='{}' WHERE id=?",
+                    (first["id"],),
+                )
+            with self.assertRaisesRegex(StoreError, "attestation was modified"):
+                store.latest_owner_review_attestation("owner/repo", 12)
 
     def test_dependency_attestations_are_append_only_idempotent_and_verified(
         self,


### PR DESCRIPTION
Closes #38

## 背景

GitHub 不允许 PR 作者批准自己的 PR。单账号维护的自有仓库即使已经完成 CI 和本地审查，`merge-decision` 仍会被 `review_not_approved` 阻塞，只能绕开 RepoSteward 的合并审计链手工合并。

## 本 PR 做了什么

- 新增默认关闭的仓库策略 `owner_attestation`，只允许 Maintainer + same-repository 模式显式启用。
- 新增 `merge-attest RUN_ID --reviewed-by LOGIN`，使用独立的一次性环境开关，在 CI 完成且所有非 Review 合并门禁通过后追加本地审查声明。
- 声明绑定仓库、PR、run、操作者、PR 作者、精确 head 仓库与分支、head/base、policy、diff、checks、Review、会话、活动、依赖和 GitHub 规则摘要。
- 新增不可变 SQLite 审计与 v12 无损迁移；相同事实幂等，读取时交叉校验物化 scope、规范化 payload 和双重 digest。
- Merge Decision/Executor 只接受当前事实完全匹配的声明；任一绑定事实变化都会使声明失效。

## 安全边界

- 不创建或伪造 GitHub Approval，不使用 admin bypass。
- 外部作者、fork/跨仓库 head、非受管分支、`CHANGES_REQUESTED`、高风险路径和未完成 CI 均拒绝。
- 创建和后续使用时都验证 token 身份、owner/admin、push 权限，以及 classic branch protection 和 applicable rulesets；规则不完整或要求独立 Reviewer 时失败关闭。
- 默认关闭路径不增加 GitHub API 请求；启用后也只在存在待使用声明时增加一次带索引的本地查询及身份/规则读取。
- 默认关闭时保留旧 policy digest，升级不会让现有已验证 PR 无故失效。

## 验证

- `uv run python -m unittest discover -s tests -p 'test_*.py'`（240 tests）
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv build --no-build-isolation`
- 使用当前仓库真实 GitHub 身份和 `main` 分支做只读规则 smoke check：owner/admin/push 身份与规则摘要均能完整读取

提交使用 SSH 签名并包含 DCO sign-off。实现由外部 coding workspace 辅助，最终 diff、边界与验证结果由 `tiammomo` 审查并负责。
