### PR TITLE
feat(observability): add lifecycle usage ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,43 @@ RepoSteward 会从 Codex CLI JSONL 或 Codex SDK turn result 中提取输入、�
 token，并记录工具调用次数；CLI 适配器还记录事件流大小。资源预算告警会出现在 Review Packet
 中，但不会绕过验证。
 
+## 生命周期用量与成本
+
+每次 `prepare` 和 `repair` 的 Harness 执行完成后，RepoSteward 都会追加一条有摘要保护的紧凑
+用量事件。事件只保存 token、工具调用、持续时间、会话恢复结果和上下文裁剪原因等有界计数，不保存
+原始提示、模型响应、告警文本或日志路径。既有数据库会无损升级；升级前没有采集到的指标显示为
+`unknown`，不会按零计算。
+
+按 Issue、PR、阶段、Harness、模型或日期查看机器可读汇总：
+
+```bash
+uv run reposteward usage report owner/repository
+uv run reposteward usage report owner/repository --issue 40 --group-by stage
+uv run reposteward usage report owner/repository --pull-number 41 --include-runs
+uv run reposteward usage report owner/repository \
+  --since 2026-08-01 --until 2026-08-31 --group-by model
+```
+
+原始用量不依赖价格配置。需要估算成本时，在用户配置中维护带生效日期的每百万 token 单价；这些
+数据不会接受仓库内 `.reposteward.toml` 覆盖：
+
+```toml
+[[observability.prices]]
+harness = "codex-sdk"
+model = "your-model"
+effective_from = "2026-08-01"
+currency = "USD"
+input_per_million = "1.00"
+cached_input_per_million = "0.10"
+output_per_million = "4.00"
+# reasoning_output_per_million = "4.00"
+```
+
+同一 Harness 会优先匹配精确模型，也可用 `model = "*"` 设置兜底价格。新生效日期不会重算旧运行；
+缺少适用价格或必要 token 指标时，该次成本保持 `unknown`。如果配置推理输出单价，它会替代输出
+token 中推理部分的普通输出单价。一次查询超过 10,000 条运行时会要求缩小过滤范围。成功的 merge
+结果也会携带对应 PR 的 `usage_summary`，方便把实际交付与生命周期成本关联起来。
+
 ## 上下文与跨 Harness 交接
 
 每次 `prepare` 或 `adopt` 都会创建一个持久 work item，并保存：

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,13 @@ Reviewer 时创建。创建动作有独立环境开关，并要求除 ReviewDeci
 Merge Executor 每次重新读取事实后才接受完全匹配的最新声明。它不会提交 GitHub Approval，也不会
 调用 admin bypass。
 
+Harness Usage Ledger 是本地追加式观测投影。Pipeline 在 Harness 返回后、进入 Runner 验证前写入
+每个 run 唯一的 prompt-free 事件，因此后续验证失败仍能归因实际消耗。事件绑定 run、work item、
+Issue、阶段、Harness 和模型，只包含规范化资源计数、原生会话恢复结果、可移植上下文兜底和裁剪原因；
+事件摘要用于发现本地记录被意外修改。报告层再关联 run 中的 PR 和 Merge Executor 结果，按用户维护
+的生效日期价格计算成本。历史记录缺失、定价缺失和不一致指标均保持 unknown。报告是确定性只读路径，
+不会调用 Harness，也不会存储或重新加载原始提示。
+
 三类协议文档都使用 Draft 2020-12 JSON Schema，schema 随 Python 包发布。持久化和导入边界会
 拒绝未知字段、未来版本、跨 work item/run 的关联错配及不一致摘要。Bundle digest 只能检测意外
 损坏或内容变化，不是数字签名；导入数据仍保留其原始信任级别。

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -46,6 +46,18 @@ max_gc_items = 1000
 [context]
 follow_up_max_tokens = 24000
 
+# Optional user-owned, dated rates per one million tokens. Repository-local
+# configuration cannot override this section. Replace these example values.
+# [[observability.prices]]
+# harness = "codex-sdk"
+# model = "your-model"
+# effective_from = "2026-08-01"
+# currency = "USD"
+# input_per_million = "1.00"
+# cached_input_per_million = "0.10"
+# output_per_million = "4.00"
+# reasoning_output_per_million = "4.00"
+
 [repositories."owner/repository"]
 enabled = true
 auto_prepare = false

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -191,6 +191,38 @@ def _parser() -> argparse.ArgumentParser:
     storage_gc.add_argument("--repo", default="", help="limit to owner/name")
     storage_gc.add_argument("--apply", action="store_true")
 
+    usage = subparsers.add_parser(
+        "usage", help="report prompt-free Harness usage and configured cost"
+    )
+    usage_commands = usage.add_subparsers(dest="usage_command", required=True)
+    usage_report = usage_commands.add_parser(
+        "report", help="aggregate one repository's Issue/PR lifecycle usage"
+    )
+    usage_report.add_argument("repository")
+    usage_report.add_argument("--issue", type=int, default=0)
+    usage_report.add_argument("--pull-number", type=int, default=0)
+    usage_report.add_argument(
+        "--stage", choices=("prepare", "repair", "adopt"), default=""
+    )
+    usage_report.add_argument("--harness", default="")
+    usage_report.add_argument("--model", default="")
+    usage_report.add_argument("--since", default="", help="inclusive YYYY-MM-DD")
+    usage_report.add_argument("--until", default="", help="inclusive YYYY-MM-DD")
+    usage_report.add_argument(
+        "--group-by",
+        choices=(
+            "none",
+            "work-item",
+            "issue",
+            "pull-request",
+            "stage",
+            "harness",
+            "model",
+        ),
+        default="pull-request",
+    )
+    usage_report.add_argument("--include-runs", action="store_true")
+
     ci = subparsers.add_parser("ci", help="inspect CI failures without rerunning jobs")
     ci_commands = ci.add_subparsers(dest="ci_command", required=True)
     ci_diagnose = ci_commands.add_parser(
@@ -500,6 +532,24 @@ def main(argv: list[str] | None = None) -> int:
                 _json(pipeline.storage_gc(repository=args.repo, apply=args.apply))
                 return 0
             raise AssertionError(f"unhandled storage command: {args.storage_command}")
+        if args.command == "usage":
+            if args.usage_command == "report":
+                _json(
+                    pipeline.usage_report(
+                        args.repository,
+                        issue_number=args.issue,
+                        pull_number=args.pull_number,
+                        run_stage=args.stage,
+                        harness=args.harness,
+                        model=args.model,
+                        since=args.since,
+                        until=args.until,
+                        group_by=args.group_by,
+                        include_runs=args.include_runs,
+                    )
+                )
+                return 0
+            raise AssertionError(f"unhandled usage command: {args.usage_command}")
         if args.command == "ci":
             if args.ci_command == "diagnose":
                 _json(pipeline.ci_failure_analysis(args.repository, args.pull_number))

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -4,6 +4,8 @@ import os
 import re
 import tomllib
 from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -121,6 +123,23 @@ class ContextConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class UsagePrice:
+    harness: str
+    model: str
+    effective_from: str
+    currency: str
+    input_per_million: Decimal
+    cached_input_per_million: Decimal
+    output_per_million: Decimal
+    reasoning_output_per_million: Decimal | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ObservabilityConfig:
+    prices: tuple[UsagePrice, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class RepositoryPolicy:
     name: str
     enabled: bool = True
@@ -171,6 +190,7 @@ class AppConfig:
     runner: RunnerConfig
     storage: StorageConfig
     context: ContextConfig
+    observability: ObservabilityConfig
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
 
 
@@ -188,6 +208,18 @@ def _boolean(value: Any, default: bool) -> bool:
     if not isinstance(value, bool):
         raise ConfigError("expected a boolean")
     return value
+
+
+def _price_rate(value: Any, name: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ConfigError(f"observability price {name} must be numeric")
+    try:
+        rate = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise ConfigError(f"observability price {name} is invalid") from exc
+    if not rate.is_finite() or rate < 0:
+        raise ConfigError(f"observability price {name} must be finite and non-negative")
+    return rate
 
 
 def _section(data: dict[str, Any], name: str) -> dict[str, Any]:
@@ -324,6 +356,12 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
         result["context"] = dict(user_context)
     else:
         result.pop("context", None)
+
+    user_observability = user.get("observability")
+    if isinstance(user_observability, dict):
+        result["observability"] = dict(user_observability)
+    else:
+        result.pop("observability", None)
 
     user_agent = user.get("agent")
     project_agent = project.get("agent")
@@ -571,6 +609,78 @@ def load_config(
         follow_up_max_tokens=int(context_raw.get("follow_up_max_tokens", 24_000))
     )
 
+    observability_raw = _section(raw, "observability")
+    raw_prices = observability_raw.get("prices", [])
+    if not isinstance(raw_prices, list) or not all(
+        isinstance(value, dict) for value in raw_prices
+    ):
+        raise ConfigError("observability.prices must be an array of tables")
+    prices: list[UsagePrice] = []
+    price_keys: set[tuple[str, str, str]] = set()
+    for raw_price in raw_prices:
+        text_fields = {
+            key: raw_price.get(key)
+            for key in ("harness", "model", "effective_from", "currency")
+        }
+        if not all(isinstance(value, str) for value in text_fields.values()):
+            raise ConfigError("observability price identity fields must be strings")
+        harness = str(text_fields["harness"]).strip()
+        model = str(text_fields["model"]).strip()
+        effective_from = str(text_fields["effective_from"]).strip()
+        currency = str(text_fields["currency"]).strip().upper()
+        if not harness or not model:
+            raise ConfigError("observability price harness and model must not be empty")
+        try:
+            parsed_date = date.fromisoformat(effective_from)
+        except ValueError as exc:
+            raise ConfigError(
+                "observability price effective_from must use YYYY-MM-DD"
+            ) from exc
+        if parsed_date.isoformat() != effective_from:
+            raise ConfigError("observability price effective_from must use YYYY-MM-DD")
+        if not re.fullmatch(r"[A-Z]{3}", currency):
+            raise ConfigError("observability price currency must use three letters")
+        key = (harness.casefold(), model.casefold(), effective_from)
+        if key in price_keys:
+            raise ConfigError("observability prices contain a duplicate effective row")
+        price_keys.add(key)
+        reasoning_rate = raw_price.get("reasoning_output_per_million")
+        prices.append(
+            UsagePrice(
+                harness=harness,
+                model=model,
+                effective_from=effective_from,
+                currency=currency,
+                input_per_million=_price_rate(
+                    raw_price.get("input_per_million"), "input_per_million"
+                ),
+                cached_input_per_million=_price_rate(
+                    raw_price.get("cached_input_per_million"),
+                    "cached_input_per_million",
+                ),
+                output_per_million=_price_rate(
+                    raw_price.get("output_per_million"), "output_per_million"
+                ),
+                reasoning_output_per_million=(
+                    _price_rate(reasoning_rate, "reasoning_output_per_million")
+                    if reasoning_rate is not None
+                    else None
+                ),
+            )
+        )
+    observability = ObservabilityConfig(
+        prices=tuple(
+            sorted(
+                prices,
+                key=lambda value: (
+                    value.harness.casefold(),
+                    value.model.casefold(),
+                    value.effective_from,
+                ),
+            )
+        )
+    )
+
     repositories_raw = _section(raw, "repositories")
     repositories: dict[str, RepositoryPolicy] = {}
     for name, repo_value in repositories_raw.items():
@@ -770,5 +880,6 @@ def load_config(
         runner=runner,
         storage=storage,
         context=context,
+        observability=observability,
         repositories=repositories,
     )

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -8,7 +8,7 @@ import sqlite3
 import subprocess
 import uuid
 from dataclasses import asdict, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -57,13 +57,19 @@ from .issues import (
     validate_issue_title,
 )
 from .merge import MergeCheck, MergeDecision, MergeSnapshot, evaluate_merge
-from .models import AgentResult, Candidate
+from .models import AgentExecution, AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
 from .portfolio import build_portfolio_snapshot
 from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
-from .store import Store
+from .store import Store, StoreError
+from .usage import (
+    build_usage_report,
+    compact_usage_budget,
+    compact_usage_metrics,
+    session_resume_outcome,
+)
 from .verifier import DockerVerifier
 from .workspace import WorkspaceManager
 
@@ -129,6 +135,34 @@ class Pipeline:
             return self.config.repositories[repository.casefold()]
         except KeyError as exc:
             raise PolicyError(f"repository is not allowlisted: {repository}") from exc
+
+    def _record_harness_usage(
+        self,
+        *,
+        run_id: str,
+        run_stage: str,
+        requested_session_id: str,
+        context: ContextPack,
+        execution: AgentExecution,
+        budget: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        outcome = session_resume_outcome(
+            requested_session_id,
+            execution.native_session_id,
+            execution.metrics.warnings,
+        )
+        return self.store.record_harness_usage(
+            run_id=run_id,
+            run_stage=run_stage,
+            harness=execution.harness or self.harness.name,
+            model=execution.model,
+            session_resume=outcome,
+            portable_context_fallback=(
+                context.handoff is not None and outcome != "resumed"
+            ),
+            metrics=compact_usage_metrics(execution.metrics),
+            budget=compact_usage_budget(budget),
+        )
 
     def portfolio_snapshot(
         self, repository: str, *, expected_digest: str = ""
@@ -1358,6 +1392,13 @@ class Pipeline:
                 model=agent_execution.model,
                 native_session_id=agent_execution.native_session_id,
             )
+            self._record_harness_usage(
+                run_id=run_id,
+                run_stage="prepare",
+                requested_session_id=native_session_id,
+                context=context,
+                execution=agent_execution,
+            )
             agent_result = agent_execution.result
             failure_details.update(
                 {
@@ -1802,6 +1843,76 @@ class Pipeline:
             "notes": (
                 "Per-repository event payload bytes are referenced bytes; one deduplicated "
                 "blob referenced by multiple repositories appears in each repository row."
+            ),
+            "public_write": False,
+        }
+
+    @staticmethod
+    def _usage_boundary(value: str, *, end: bool) -> str:
+        if not value:
+            return ""
+        try:
+            parsed = date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError("usage dates must use YYYY-MM-DD") from exc
+        if parsed.isoformat() != value:
+            raise ValueError("usage dates must use YYYY-MM-DD")
+        if end:
+            parsed += timedelta(days=1)
+        return datetime.combine(parsed, datetime.min.time(), tzinfo=UTC).isoformat()
+
+    def usage_report(
+        self,
+        repository: str,
+        *,
+        issue_number: int = 0,
+        pull_number: int = 0,
+        run_stage: str = "",
+        harness: str = "",
+        model: str = "",
+        since: str = "",
+        until: str = "",
+        group_by: str = "pull-request",
+        include_runs: bool = False,
+    ) -> dict[str, Any]:
+        """Aggregate prompt-free Harness usage over one repository lifecycle."""
+        policy = self.policy(repository)
+        if issue_number < 0 or pull_number < 0:
+            raise ValueError("usage issue and pull filters must not be negative")
+        if run_stage and run_stage not in {"prepare", "repair", "adopt"}:
+            raise ValueError("usage stage must be prepare, repair, or adopt")
+        since_boundary = self._usage_boundary(since, end=False)
+        until_boundary = self._usage_boundary(until, end=True)
+        if since_boundary and until_boundary and since_boundary >= until_boundary:
+            raise ValueError("usage since date must not be after until date")
+        rows = self.store.harness_usage_rows(
+            policy.name,
+            issue_number=issue_number,
+            pull_number=pull_number,
+            run_stage=run_stage,
+            harness=harness,
+            model=model,
+            since=since_boundary,
+            until=until_boundary,
+        )
+        filters = {
+            "repository": policy.name.casefold(),
+            "issue_number": issue_number or None,
+            "pull_number": pull_number or None,
+            "run_stage": run_stage or None,
+            "harness": harness or None,
+            "model": model or None,
+            "since": since or None,
+            "until": until or None,
+        }
+        return {
+            **build_usage_report(
+                rows,
+                prices=self.config.observability.prices,
+                filters=filters,
+                group_by=group_by,
+                include_runs=include_runs,
+                merge_outcomes=self.store.latest_merge_outcomes(policy.name),
             ),
             "public_write": False,
         }
@@ -2528,6 +2639,14 @@ class Pipeline:
                 model=execution.model,
                 native_session_id=execution.native_session_id,
             )
+            self._record_harness_usage(
+                run_id=run_id,
+                run_stage="repair",
+                requested_session_id=native_session_id,
+                context=context,
+                execution=execution,
+                budget=final_prompt_budget,
+            )
             result = execution.result
             failure_details.update(
                 {
@@ -3158,6 +3277,29 @@ class Pipeline:
             )
             raise PolicyError(reason)
 
+        def successful_usage_summary() -> dict[str, Any]:
+            try:
+                report = self.usage_report(
+                    repository,
+                    pull_number=pull_number,
+                    group_by="none",
+                )
+            except (
+                AttributeError,
+                KeyError,
+                sqlite3.Error,
+                StoreError,
+                TypeError,
+                ValueError,
+            ):
+                # The GitHub merge is already authoritative at these return sites.
+                # A local observability fault must not turn that success into a retry.
+                return {
+                    "status": "unavailable",
+                    "reason": "usage_summary_unavailable",
+                }
+            return {"status": "available", **report["summary"]}
+
         if os.environ.get("REPOSTEWARD_ENABLE_MERGE") != "1":
             block(
                 "merge execution is disabled; set REPOSTEWARD_ENABLE_MERGE=1 "
@@ -3255,6 +3397,7 @@ class Pipeline:
                 "merge_commit_sha": str(raw.get("merge_commit_sha") or ""),
                 "attempt_id": attempt_id,
                 "audit": audits,
+                "usage_summary": successful_usage_summary(),
                 "public_write": False,
             }
         if (
@@ -3303,6 +3446,7 @@ class Pipeline:
                 "merge_commit_sha": str(latest_raw.get("merge_commit_sha") or ""),
                 "attempt_id": attempt_id,
                 "audit": audits,
+                "usage_summary": successful_usage_summary(),
                 "public_write": False,
             }
         if (
@@ -3395,6 +3539,7 @@ class Pipeline:
             "merge_commit_sha": str(result.get("sha") or ""),
             "attempt_id": attempt_id,
             "audit": audits,
+            "usage_summary": successful_usage_summary(),
             "public_write": public_write,
         }
 

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -3285,6 +3285,7 @@ class Pipeline:
                     group_by="none",
                 )
             except (
+                ArithmeticError,
                 AttributeError,
                 KeyError,
                 sqlite3.Error,

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import sqlite3
 import uuid
 from collections.abc import Iterator
@@ -13,7 +14,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -407,6 +408,36 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON owner_review_attestations(repository, pull_number, sequence DESC)
         """,
     ),
+    13: (
+        """
+        CREATE TABLE IF NOT EXISTS harness_usage_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            run_id TEXT NOT NULL UNIQUE,
+            work_item_id TEXT NOT NULL,
+            repository TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            run_stage TEXT NOT NULL,
+            harness TEXT NOT NULL,
+            model TEXT NOT NULL,
+            session_resume TEXT NOT NULL,
+            portable_context_fallback INTEGER NOT NULL,
+            event_digest TEXT NOT NULL UNIQUE,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id),
+            FOREIGN KEY(work_item_id) REFERENCES work_items(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS harness_usage_events_report
+        ON harness_usage_events(repository, created_at, sequence)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS harness_usage_events_for_work_item
+        ON harness_usage_events(work_item_id, sequence)
+        """,
+    ),
 }
 
 
@@ -457,6 +488,21 @@ OWNER_REVIEW_FACT_KEYS = frozenset(
         "dependency_digest",
         "activity_digest",
         "rules_digest",
+    }
+)
+
+USAGE_METRIC_KEYS = frozenset(
+    {
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "prompt_chars",
+        "event_bytes",
+        "stderr_bytes",
+        "event_count",
+        "tool_call_count",
+        "duration_seconds",
     }
 )
 
@@ -935,6 +981,416 @@ class Store:
             )
             if cursor.rowcount != 1:
                 raise KeyError(f"harness run not found: {run_id}")
+
+    def record_harness_usage(
+        self,
+        *,
+        run_id: str,
+        run_stage: str,
+        harness: str,
+        model: str,
+        session_resume: str,
+        portable_context_fallback: bool,
+        metrics: dict[str, Any],
+        budget: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Persist one bounded, prompt-free usage event for a Harness run."""
+        if set(metrics) != USAGE_METRIC_KEYS:
+            raise StoreError("Harness usage metrics have an unexpected shape")
+        integer_metrics = USAGE_METRIC_KEYS - {"duration_seconds"}
+        for key in integer_metrics:
+            value = metrics[key]
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(f"Harness usage metric {key} must be non-negative")
+        duration = metrics["duration_seconds"]
+        if duration is not None and (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not math.isfinite(duration)
+            or duration < 0
+        ):
+            raise ValueError("Harness usage duration_seconds must be non-negative")
+        if run_stage not in {"prepare", "repair"}:
+            raise ValueError("unsupported Harness usage run stage")
+        if not isinstance(portable_context_fallback, bool):
+            raise TypeError("portable_context_fallback must be a boolean")
+        if session_resume not in {
+            "not_requested",
+            "resumed",
+            "fallback_new_session",
+            "unavailable",
+        }:
+            raise ValueError("unsupported Harness session resume outcome")
+        if not harness or not isinstance(budget, dict):
+            raise ValueError("Harness usage harness and budget are required")
+        expected_budget_keys = {
+            "budget_tokens",
+            "estimated_tokens",
+            "trim_reasons",
+        }
+        if set(budget) != expected_budget_keys:
+            raise StoreError("Harness usage budget has an unexpected shape")
+        for key in ("budget_tokens", "estimated_tokens"):
+            value = budget[key]
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(f"Harness usage {key} must be non-negative")
+        trim_reasons = budget["trim_reasons"]
+        if not isinstance(trim_reasons, dict) or any(
+            not isinstance(key, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+            for key, value in trim_reasons.items()
+        ):
+            raise ValueError("Harness usage trim_reasons must be non-negative counts")
+
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            scope = connection.execute(
+                """
+                SELECT h.work_item_id, h.harness, h.model,
+                       r.repository, r.issue_number
+                FROM harness_runs h JOIN runs r ON r.id=h.run_id
+                WHERE h.run_id=?
+                """,
+                (run_id,),
+            ).fetchone()
+            if scope is None:
+                raise StoreError("Harness usage references an unknown run")
+            expected = {
+                "harness": harness,
+                "model": model,
+            }
+            if any(str(scope[key]) != value for key, value in expected.items()):
+                raise StoreError("Harness usage identity differs from its run")
+            material = {
+                "schema_version": 1,
+                "run_id": run_id,
+                "work_item_id": str(scope["work_item_id"]),
+                "repository": str(scope["repository"]),
+                "issue_number": int(scope["issue_number"]),
+                "run_stage": run_stage,
+                "harness": harness,
+                "model": model,
+                "session_resume": session_resume,
+                "portable_context_fallback": portable_context_fallback,
+                "metrics": metrics,
+                "budget": budget,
+            }
+            event_digest = _json_digest(material)
+            previous = connection.execute(
+                "SELECT * FROM harness_usage_events WHERE run_id=?", (run_id,)
+            ).fetchone()
+            if previous is not None:
+                value = self._harness_usage_event(previous)
+                if str(value["event_digest"]) != event_digest:
+                    raise StoreError("Harness usage was already recorded differently")
+                return {**value, "idempotent": True}
+            event_id = uuid.uuid4().hex
+            now = utc_now()
+            connection.execute(
+                """
+                INSERT INTO harness_usage_events(
+                    id, run_id, work_item_id, repository, issue_number,
+                    run_stage, harness, model, session_resume,
+                    portable_context_fallback, event_digest, payload, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    run_id,
+                    material["work_item_id"],
+                    material["repository"],
+                    material["issue_number"],
+                    run_stage,
+                    harness,
+                    model,
+                    session_resume,
+                    int(portable_context_fallback),
+                    event_digest,
+                    _canonical_json(material),
+                    now,
+                ),
+            )
+        return {
+            "id": event_id,
+            **material,
+            "event_digest": event_digest,
+            "created_at": now,
+            "idempotent": False,
+        }
+
+    @staticmethod
+    def _harness_usage_event(row: sqlite3.Row) -> dict[str, Any]:
+        value = dict(row)
+        try:
+            payload = json.loads(str(value["payload"]))
+        except json.JSONDecodeError as exc:
+            raise StoreError("Harness usage ledger was modified") from exc
+        if not isinstance(payload, dict):
+            raise StoreError("Harness usage ledger was modified")
+        scope = {
+            "run_id": str(value["run_id"]),
+            "work_item_id": str(value["work_item_id"]),
+            "repository": str(value["repository"]),
+            "issue_number": int(value["issue_number"]),
+            "run_stage": str(value["run_stage"]),
+            "harness": str(value["harness"]),
+            "model": str(value["model"]),
+            "session_resume": str(value["session_resume"]),
+            "portable_context_fallback": bool(value["portable_context_fallback"]),
+        }
+        if (
+            any(payload.get(key) != expected for key, expected in scope.items())
+            or payload.get("schema_version") != 1
+            or not isinstance(payload.get("metrics"), dict)
+            or set(payload["metrics"]) != USAGE_METRIC_KEYS
+            or not isinstance(payload.get("budget"), dict)
+            or _json_digest(payload) != str(value["event_digest"])
+        ):
+            raise StoreError("Harness usage ledger was modified")
+        return {
+            "id": str(value["id"]),
+            **payload,
+            "event_digest": str(value["event_digest"]),
+            "created_at": str(value["created_at"]),
+        }
+
+    @staticmethod
+    def _legacy_usage_metrics(details: dict[str, Any]) -> dict[str, Any]:
+        raw = details.get("agent_metrics")
+        if not isinstance(raw, dict):
+            raw = {}
+        result: dict[str, Any] = {}
+        for key in USAGE_METRIC_KEYS:
+            value = raw.get(key)
+            if key == "duration_seconds":
+                valid = (
+                    not isinstance(value, bool)
+                    and isinstance(value, (int, float))
+                    and value >= 0
+                )
+            else:
+                valid = (
+                    not isinstance(value, bool)
+                    and isinstance(value, int)
+                    and value >= 0
+                )
+            result[key] = value if valid else None
+        return result
+
+    @staticmethod
+    def _legacy_usage_budget(details: dict[str, Any]) -> dict[str, Any]:
+        raw = details.get("context_budget")
+        if not isinstance(raw, dict):
+            raw = {}
+        trim_reasons: dict[str, int] = {}
+        for key, initial_key, retained_key in (
+            ("events", "initial_events", "retained_events"),
+            ("diff_snippets", "initial_diff_snippets", "retained_diff_snippets"),
+        ):
+            initial = raw.get(initial_key)
+            retained = raw.get(retained_key)
+            if (
+                isinstance(initial, int)
+                and not isinstance(initial, bool)
+                and isinstance(retained, int)
+                and not isinstance(retained, bool)
+                and initial > retained
+            ):
+                trim_reasons[key] = initial - retained
+        omitted = raw.get("issue_description_omitted_chars")
+        if isinstance(omitted, int) and not isinstance(omitted, bool) and omitted > 0:
+            trim_reasons["issue_description_chars"] = omitted
+
+        def non_negative_int(name: str) -> int | None:
+            raw_value = raw.get(name)
+            return (
+                raw_value
+                if isinstance(raw_value, int)
+                and not isinstance(raw_value, bool)
+                and raw_value >= 0
+                else None
+            )
+
+        return {
+            "budget_tokens": non_negative_int("budget_tokens"),
+            "estimated_tokens": non_negative_int("estimated_tokens"),
+            "trim_reasons": trim_reasons,
+        }
+
+    def harness_usage_rows(
+        self,
+        repository: str,
+        *,
+        issue_number: int = 0,
+        pull_number: int = 0,
+        run_stage: str = "",
+        harness: str = "",
+        model: str = "",
+        since: str = "",
+        until: str = "",
+        limit: int = 10_001,
+    ) -> list[dict[str, Any]]:
+        """Read compact lifecycle usage facts, including compatible legacy runs."""
+        limit = min(max(limit, 1), 10_001)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT r.id AS run_id, r.repository, r.issue_number,
+                       r.stage AS current_stage, r.status, r.details,
+                       r.created_at AS run_created_at,
+                       r.updated_at AS run_updated_at,
+                       h.work_item_id, h.harness, h.model,
+                       h.native_session_id, h.created_at AS harness_created_at,
+                       s.pr_url AS submission_pr_url,
+                       e.sequence AS usage_sequence, e.payload AS usage_payload,
+                       e.event_digest AS usage_event_digest,
+                       e.created_at AS usage_created_at
+                FROM harness_runs h
+                JOIN runs r ON r.id=h.run_id
+                LEFT JOIN submissions s
+                  ON s.repository=r.repository AND s.issue_number=r.issue_number
+                LEFT JOIN harness_usage_events e ON e.run_id=h.run_id
+                WHERE r.repository=?
+                  AND (?=0 OR r.issue_number=?)
+                  AND (
+                      ?=0
+                      OR CAST(
+                          json_extract(r.details, '$.repair_guard.pull_number')
+                          AS INTEGER
+                      )=?
+                      OR rtrim(
+                          COALESCE(json_extract(r.details, '$.pr_url'), ''), '/'
+                      ) LIKE ?
+                      OR rtrim(COALESCE(s.pr_url, ''), '/') LIKE ?
+                  )
+                  AND (?='' OR h.harness=?)
+                  AND (?='' OR h.model=?)
+                  AND (?='' OR h.created_at>=?)
+                  AND (?='' OR h.created_at<?)
+                ORDER BY h.created_at, r.id LIMIT ?
+                """,
+                (
+                    repository.casefold(),
+                    issue_number,
+                    issue_number,
+                    pull_number,
+                    pull_number,
+                    f"%/pull/{pull_number}",
+                    f"%/pull/{pull_number}",
+                    harness,
+                    harness,
+                    model,
+                    model,
+                    since,
+                    since,
+                    until,
+                    until,
+                    limit,
+                ),
+            ).fetchall()
+        if len(rows) >= limit:
+            raise StoreError(
+                "Harness usage query exceeded 10000 runs; narrow its filters"
+            )
+        result: list[dict[str, Any]] = []
+        for row in rows:
+            raw = dict(row)
+            try:
+                details = json.loads(str(raw["details"]))
+            except json.JSONDecodeError as exc:
+                raise StoreError("run details were modified") from exc
+            if not isinstance(details, dict):
+                raise StoreError("run details were modified")
+            pr_url = str(details.get("pr_url") or raw["submission_pr_url"] or "")
+            parsed_pull = 0
+            if "/pull/" in pr_url:
+                tail = pr_url.rsplit("/pull/", 1)[1].rstrip("/")
+                parsed_pull = int(tail) if tail.isdigit() else 0
+            repair_guard = details.get("repair_guard")
+            if not parsed_pull and isinstance(repair_guard, dict):
+                guard_pull = repair_guard.get("pull_number")
+                if isinstance(guard_pull, int) and not isinstance(guard_pull, bool):
+                    parsed_pull = guard_pull
+            if pull_number and parsed_pull != pull_number:
+                continue
+            event: dict[str, Any] | None = None
+            if raw["usage_sequence"] is not None:
+                try:
+                    event_payload = json.loads(str(raw["usage_payload"]))
+                except json.JSONDecodeError as exc:
+                    raise StoreError("Harness usage ledger was modified") from exc
+                event_scope = {
+                    "run_id": str(raw["run_id"]),
+                    "work_item_id": str(raw["work_item_id"]),
+                    "repository": str(raw["repository"]),
+                    "issue_number": int(raw["issue_number"]),
+                    "harness": str(raw["harness"]),
+                    "model": str(raw["model"]),
+                }
+                if (
+                    not isinstance(event_payload, dict)
+                    or any(
+                        event_payload.get(key) != expected
+                        for key, expected in event_scope.items()
+                    )
+                    or _json_digest(event_payload) != str(raw["usage_event_digest"])
+                ):
+                    raise StoreError("Harness usage ledger was modified")
+                event = {"payload": event_payload}
+            if event is not None:
+                payload = event["payload"]
+                stage = str(payload["run_stage"])
+                metrics = dict(payload["metrics"])
+                budget = dict(payload["budget"])
+                session_resume = str(payload["session_resume"])
+                portable_fallback: bool | None = bool(
+                    payload["portable_context_fallback"]
+                )
+                source = "ledger"
+            else:
+                stage = (
+                    "repair"
+                    if details.get("source_run_id") or isinstance(repair_guard, dict)
+                    else (
+                        "adopt"
+                        if str(raw["harness"]) == "external-workspace"
+                        else "prepare"
+                    )
+                )
+                metrics = self._legacy_usage_metrics(details)
+                budget = self._legacy_usage_budget(details)
+                session_resume = "unknown"
+                portable_fallback = None
+                source = "legacy"
+            if run_stage and stage != run_stage:
+                continue
+            result.append(
+                {
+                    "run_id": str(raw["run_id"]),
+                    "work_item_id": str(raw["work_item_id"]),
+                    "repository": str(raw["repository"]),
+                    "issue_number": int(raw["issue_number"]),
+                    "pull_number": parsed_pull or None,
+                    "run_stage": stage,
+                    "current_stage": str(raw["current_stage"]),
+                    "status": str(raw["status"]),
+                    "harness": str(raw["harness"]),
+                    "model": str(raw["model"]),
+                    "created_at": str(raw["harness_created_at"]),
+                    "metrics": metrics,
+                    "budget": budget,
+                    "session_resume": session_resume,
+                    "portable_context_fallback": portable_fallback,
+                    "source": source,
+                }
+            )
+        return result
 
     @staticmethod
     def _validate_checkpoint_record(
@@ -1549,6 +2005,17 @@ class Store:
                        COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
                        MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
                 FROM owner_review_attestations
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
+                "harness_usage_ledger",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM harness_usage_events
                 WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
                 GROUP BY repository
                 """,
@@ -2815,6 +3282,25 @@ class Store:
             value["payload"] = json.loads(str(value["payload"]))
             result.append(value)
         return result
+
+    def latest_merge_outcomes(self, repository: str) -> dict[int, str]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                WITH ranked AS (
+                    SELECT pull_number, outcome,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY repository, pull_number
+                               ORDER BY created_at DESC, rowid DESC
+                           ) AS outcome_rank
+                    FROM merge_executions
+                    WHERE repository=? AND stage='completed'
+                )
+                SELECT pull_number, outcome FROM ranked WHERE outcome_rank=1
+                """,
+                (repository.casefold(),),
+            ).fetchall()
+        return {int(row["pull_number"]): str(row["outcome"]) for row in rows}
 
     def record_submission(
         self, repository: str, issue_number: int, pr_url: str

--- a/src/reposteward/usage.py
+++ b/src/reposteward/usage.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections import Counter
+from decimal import Decimal
+from typing import Any
+
+from .config import UsagePrice
+from .models import AgentMetrics
+
+USAGE_SCHEMA_VERSION = 1
+METRIC_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "prompt_chars",
+    "event_bytes",
+    "stderr_bytes",
+    "event_count",
+    "tool_call_count",
+    "duration_seconds",
+)
+GROUP_FIELDS = {
+    "work-item": "work_item_id",
+    "issue": "issue_number",
+    "pull-request": "pull_number",
+    "stage": "run_stage",
+    "harness": "harness",
+    "model": "model",
+}
+
+
+def compact_usage_metrics(metrics: AgentMetrics) -> dict[str, Any]:
+    """Keep bounded counters only; paths, warnings, and prompts never enter the ledger."""
+    return {name: getattr(metrics, name) for name in METRIC_FIELDS}
+
+
+def compact_usage_budget(raw: dict[str, Any] | None) -> dict[str, Any]:
+    raw = raw if isinstance(raw, dict) else {}
+
+    def value(name: str) -> int | None:
+        candidate = raw.get(name)
+        return (
+            candidate
+            if isinstance(candidate, int)
+            and not isinstance(candidate, bool)
+            and candidate >= 0
+            else None
+        )
+
+    trim_reasons: dict[str, int] = {}
+    for key, initial_name, retained_name in (
+        ("events", "initial_events", "retained_events"),
+        ("diff_snippets", "initial_diff_snippets", "retained_diff_snippets"),
+    ):
+        initial = value(initial_name)
+        retained = value(retained_name)
+        if initial is not None and retained is not None and initial > retained:
+            trim_reasons[key] = initial - retained
+    omitted = value("issue_description_omitted_chars")
+    if omitted:
+        trim_reasons["issue_description_chars"] = omitted
+    return {
+        "budget_tokens": value("budget_tokens"),
+        "estimated_tokens": value("estimated_tokens"),
+        "trim_reasons": trim_reasons,
+    }
+
+
+def session_resume_outcome(
+    requested_session_id: str,
+    returned_session_id: str,
+    warnings: tuple[str, ...],
+) -> str:
+    if not requested_session_id:
+        return "not_requested"
+    if any("could not resume" in value.casefold() for value in warnings):
+        return "fallback_new_session"
+    if returned_session_id == requested_session_id:
+        return "resumed"
+    if returned_session_id:
+        return "fallback_new_session"
+    return "unavailable"
+
+
+def _select_price(
+    row: dict[str, Any], prices: tuple[UsagePrice, ...]
+) -> UsagePrice | None:
+    harness = str(row["harness"]).casefold()
+    model = str(row["model"]).casefold()
+    run_date = str(row["created_at"])[:10]
+    exact = [
+        value
+        for value in prices
+        if value.harness.casefold() == harness
+        and value.model.casefold() == model
+        and value.effective_from <= run_date
+    ]
+    candidates = exact or [
+        value
+        for value in prices
+        if value.harness.casefold() == harness
+        and value.model == "*"
+        and value.effective_from <= run_date
+    ]
+    return max(candidates, key=lambda value: value.effective_from, default=None)
+
+
+def _decimal_text(value: Decimal) -> str:
+    rendered = format(value.quantize(Decimal("0.000000000001")), "f")
+    return rendered.rstrip("0").rstrip(".") or "0"
+
+
+def _run_cost(row: dict[str, Any], prices: tuple[UsagePrice, ...]) -> dict[str, Any]:
+    price = _select_price(row, prices)
+    if price is None:
+        return {"status": "unknown", "reason": "price_not_configured"}
+    metrics = row["metrics"]
+    required = ("input_tokens", "cached_input_tokens", "output_tokens")
+    missing = [name for name in required if metrics.get(name) is None]
+    if (
+        price.reasoning_output_per_million is not None
+        and metrics.get("reasoning_output_tokens") is None
+    ):
+        missing.append("reasoning_output_tokens")
+    if missing:
+        return {
+            "status": "unknown",
+            "reason": "metrics_missing",
+            "missing": sorted(missing),
+            "currency": price.currency,
+            "price_effective_from": price.effective_from,
+        }
+    input_tokens = int(metrics["input_tokens"])
+    cached_tokens = int(metrics["cached_input_tokens"])
+    output_tokens = int(metrics["output_tokens"])
+    reasoning_tokens = int(metrics.get("reasoning_output_tokens") or 0)
+    if cached_tokens > input_tokens or reasoning_tokens > output_tokens:
+        return {
+            "status": "unknown",
+            "reason": "inconsistent_metrics",
+            "currency": price.currency,
+            "price_effective_from": price.effective_from,
+        }
+    million = Decimal(1_000_000)
+    cost = (
+        Decimal(input_tokens - cached_tokens) * price.input_per_million
+        + Decimal(cached_tokens) * price.cached_input_per_million
+    ) / million
+    if price.reasoning_output_per_million is None:
+        cost += Decimal(output_tokens) * price.output_per_million / million
+    else:
+        cost += (
+            Decimal(output_tokens - reasoning_tokens) * price.output_per_million
+            + Decimal(reasoning_tokens) * price.reasoning_output_per_million
+        ) / million
+    return {
+        "status": "known",
+        "value": _decimal_text(cost),
+        "currency": price.currency,
+        "price_effective_from": price.effective_from,
+    }
+
+
+def _summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for name in METRIC_FIELDS:
+        values = [row["metrics"].get(name) for row in rows]
+        known = [value for value in values if value is not None]
+        total: int | float | None = sum(known) if known else None
+        if name == "duration_seconds" and total is not None:
+            total = round(float(total), 3)
+        metrics[name] = {
+            "value": total,
+            "known_runs": len(known),
+            "unknown_runs": len(values) - len(known),
+        }
+    costs: dict[str, Decimal] = {}
+    known_cost_runs: Counter[str] = Counter()
+    unknown_costs: Counter[str] = Counter()
+    for row in rows:
+        cost = row["cost"]
+        if cost["status"] == "known":
+            currency = str(cost["currency"])
+            costs[currency] = costs.get(currency, Decimal(0)) + Decimal(
+                str(cost["value"])
+            )
+            known_cost_runs[currency] += 1
+        else:
+            unknown_costs[str(cost["reason"])] += 1
+    trim_reasons: Counter[str] = Counter()
+    for row in rows:
+        trim_reasons.update(row["budget"].get("trim_reasons", {}))
+    return {
+        "runs": len(rows),
+        "ledger_runs": sum(row["source"] == "ledger" for row in rows),
+        "legacy_runs": sum(row["source"] == "legacy" for row in rows),
+        "metrics": metrics,
+        "session_resume": dict(
+            sorted(Counter(row["session_resume"] for row in rows).items())
+        ),
+        "portable_context_fallback": {
+            "used": sum(row["portable_context_fallback"] is True for row in rows),
+            "not_used": sum(row["portable_context_fallback"] is False for row in rows),
+            "unknown": sum(row["portable_context_fallback"] is None for row in rows),
+        },
+        "trim_reasons": dict(sorted(trim_reasons.items())),
+        "costs": {
+            currency: {
+                "value": _decimal_text(value),
+                "known_runs": known_cost_runs[currency],
+            }
+            for currency, value in sorted(costs.items())
+        },
+        "unknown_cost_runs": sum(unknown_costs.values()),
+        "unknown_cost_reasons": dict(sorted(unknown_costs.items())),
+    }
+
+
+def build_usage_report(
+    rows: list[dict[str, Any]],
+    *,
+    prices: tuple[UsagePrice, ...],
+    filters: dict[str, Any],
+    group_by: str,
+    include_runs: bool,
+    merge_outcomes: dict[int, str] | None = None,
+) -> dict[str, Any]:
+    if group_by != "none" and group_by not in GROUP_FIELDS:
+        raise ValueError(f"unsupported usage group: {group_by!r}")
+    enriched = [{**row, "cost": _run_cost(row, prices)} for row in rows]
+    groups: list[dict[str, Any]] = []
+    if group_by != "none":
+        field = GROUP_FIELDS[group_by]
+        values: dict[str, list[dict[str, Any]]] = {}
+        for row in enriched:
+            raw_key = row.get(field)
+            key = str(raw_key) if raw_key not in {None, ""} else "unknown"
+            values.setdefault(key, []).append(row)
+        for key in sorted(values):
+            group = {"key": key, "summary": _summary(values[key])}
+            if group_by == "pull-request" and key.isdigit():
+                group["merge_outcome"] = (merge_outcomes or {}).get(int(key), "unknown")
+            groups.append(group)
+    report = {
+        "schema_version": USAGE_SCHEMA_VERSION,
+        "filters": filters,
+        "group_by": group_by,
+        "summary": _summary(enriched),
+        "groups": groups,
+        "runs_included": include_runs,
+        "raw_prompts_stored": False,
+    }
+    if include_runs:
+        report["runs"] = enriched
+    return report

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -317,6 +318,101 @@ require_distinct_reviewer = false
         self.assertEqual(config.issue_review.project_number, 7)
         self.assertEqual(config.issue_review.project_owner_type, "organization")
         self.assertTrue(config.issue_review.require_distinct_reviewer)
+
+    def test_usage_prices_are_dated_and_owned_by_the_user_layer(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[[observability.prices]]
+harness = "codex-sdk"
+model = "gpt-example"
+effective_from = "2026-01-01"
+currency = "usd"
+input_per_million = "1.25"
+cached_input_per_million = "0.125"
+output_per_million = "5"
+[[observability.prices]]
+harness = "codex-sdk"
+model = "gpt-example"
+effective_from = "2026-08-01"
+currency = "USD"
+input_per_million = 2
+cached_input_per_million = 0.2
+output_per_million = 8
+reasoning_output_per_million = 10
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[[observability.prices]]
+harness = "untrusted"
+model = "*"
+effective_from = "2026-01-01"
+currency = "USD"
+input_per_million = 0
+cached_input_per_million = 0
+output_per_million = 0
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project, user_path=user)
+
+        self.assertEqual(len(config.observability.prices), 2)
+        first, second = config.observability.prices
+        self.assertEqual(first.currency, "USD")
+        self.assertEqual(first.input_per_million, Decimal("1.25"))
+        self.assertEqual(second.effective_from, "2026-08-01")
+        self.assertEqual(second.reasoning_output_per_million, Decimal(10))
+
+    def test_usage_prices_reject_invalid_or_duplicate_rows(self) -> None:
+        cases = (
+            ('effective_from = "2026/01/01"', "YYYY-MM-DD"),
+            ("input_per_million = -1", "non-negative"),
+            ('currency = "US"', "three letters"),
+            ("model = true", "identity fields must be strings"),
+        )
+        base = """config_version = 1
+[github]
+login = "alice"
+[[observability.prices]]
+harness = "codex-sdk"
+model = "model-a"
+effective_from = "2026-01-01"
+currency = "USD"
+input_per_million = 1
+cached_input_per_million = 0.1
+output_per_million = 4
+"""
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            for replacement, message in cases:
+                field = replacement.split(" =", 1)[0]
+                lines = [
+                    replacement if line.startswith(f"{field} =") else line
+                    for line in base.splitlines()
+                ]
+                path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                with (
+                    self.subTest(replacement=replacement),
+                    self.assertRaisesRegex(ConfigError, message),
+                ):
+                    load_config(path)
+
+            duplicate = (
+                base
+                + "\n[[observability.prices]]"
+                + base.split("[[observability.prices]]", 1)[1]
+            )
+            path.write_text(duplicate, encoding="utf-8")
+            with self.assertRaisesRegex(ConfigError, "duplicate effective row"):
+                load_config(path)
 
     def test_unknown_configuration_version_is_rejected(self) -> None:
         with TemporaryDirectory() as directory:

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -10,6 +10,7 @@ from reposteward.context import repository_policy_digest
 from reposteward.github import GitHubError, PullRequest
 from reposteward.pipeline import Pipeline
 from reposteward.policy import PolicyError
+from reposteward.store import StoreError
 
 
 class StubStore:
@@ -20,6 +21,7 @@ class StubStore:
         self.executions: list[dict] = []
         self.dependency_events: list[dict] = []
         self.owner_attestation: dict | None = None
+        self.usage_read_fails = False
 
     def run(self, run_id: str) -> dict:
         return {
@@ -105,6 +107,8 @@ class StubStore:
         return self.owner_attestation
 
     def harness_usage_rows(self, _repository: str, **_filters) -> list[dict]:
+        if self.usage_read_fails:
+            raise StoreError("usage ledger unavailable")
         return []
 
     def latest_merge_outcomes(self, _repository: str) -> dict[int, str]:
@@ -508,6 +512,23 @@ class MergePipelineTests(unittest.TestCase):
 
         self.assertEqual(pipeline.store.executions[-1]["outcome"], "blocked")
         self.assertEqual(pipeline.github.merge_calls, [])
+
+    def test_usage_summary_failure_does_not_change_a_successful_merge(self) -> None:
+        pipeline = self.pipeline(auto_merge=True)
+        pipeline.store.usage_read_fails = True
+        decision = pipeline.merge_decision("run-1")
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_MERGE": "1"}):
+            result = pipeline.execute_merge(
+                "run-1", decision_id=decision["audit"]["id"], reviewed_by="alice"
+            )
+
+        self.assertTrue(result["merged"])
+        self.assertEqual(len(pipeline.github.merge_calls), 1)
+        self.assertEqual(
+            result["usage_summary"],
+            {"status": "unavailable", "reason": "usage_summary_unavailable"},
+        )
 
     def test_activity_change_makes_the_decision_stale_without_public_write(
         self,

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -104,6 +104,15 @@ class StubStore:
     ) -> dict | None:
         return self.owner_attestation
 
+    def harness_usage_rows(self, _repository: str, **_filters) -> list[dict]:
+        return []
+
+    def latest_merge_outcomes(self, _repository: str) -> dict[int, str]:
+        completed = [
+            value for value in self.executions if value["stage"] == "completed"
+        ]
+        return {12: completed[-1]["outcome"]} if completed else {}
+
 
 class StubGitHub:
     def __init__(self) -> None:
@@ -272,6 +281,7 @@ class MergePipelineTests(unittest.TestCase):
             repositories={"owner/repo": policy},
             safety=SimpleNamespace(max_files_changed=18, max_diff_lines=700),
             github=SimpleNamespace(login="alice"),
+            observability=SimpleNamespace(prices=()),
         )
         pipeline.store = StubStore(policy)
         pipeline.github = StubGitHub()
@@ -475,6 +485,8 @@ class MergePipelineTests(unittest.TestCase):
         self.assertTrue(result["merged"])
         self.assertFalse(result["idempotent"])
         self.assertTrue(result["public_write"])
+        self.assertEqual(result["usage_summary"]["status"], "available")
+        self.assertEqual(result["usage_summary"]["runs"], 0)
         self.assertEqual(len(pipeline.github.merge_calls), 1)
         self.assertEqual(
             [value["stage"] for value in pipeline.store.executions],

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -128,6 +128,38 @@ def _owner_review_facts(run_id: str) -> dict:
     }
 
 
+def _usage_run(store: Store, *, details: dict | None = None) -> tuple[str, str]:
+    work_item = store.ensure_work_item(
+        "owner/repo",
+        kind="github_issue",
+        external_id="7",
+        title="Example issue",
+    )
+    run_id = store.start_run("owner/repo", 7, "agent")
+    pack_id = f"pack-{run_id}"
+    payload = _context_payload(
+        pack_id=pack_id,
+        work_item_id=str(work_item["id"]),
+        run_id=run_id,
+        source_digest="d" * 64,
+        base_commit="b" * 40,
+    )
+    store.save_context_run(
+        pack_id=pack_id,
+        work_item_id=str(work_item["id"]),
+        run_id=run_id,
+        schema_version=1,
+        source_digest=str(payload["source_digest"]),
+        base_commit="b" * 40,
+        payload=payload,
+        harness="codex-sdk",
+        model="model-a",
+    )
+    if details is not None:
+        store.update_run(run_id, status="submitted", details=details)
+    return run_id, str(work_item["id"])
+
+
 class StoreTests(unittest.TestCase):
     def test_legacy_unversioned_database_is_migrated_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -317,6 +349,155 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
             self.assertIsNotNone(table)
             self.assertIsNotNone(index)
+
+    def test_version_twelve_database_receives_harness_usage_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE harness_usage_events")
+                connection.execute("PRAGMA user_version=12")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE name='harness_usage_events'"
+                ).fetchone()
+                indexes = {
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type='index' AND tbl_name='harness_usage_events'"
+                    )
+                }
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIn("harness_usage_events_report", indexes)
+            self.assertIn("harness_usage_events_for_work_item", indexes)
+
+    def test_harness_usage_is_idempotent_bounded_and_tamper_evident(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            run_id, work_item_id = _usage_run(
+                store,
+                details={
+                    "pr_url": "https://github.com/owner/repo/pull/12",
+                    "agent_metrics": {"input_tokens": 999},
+                },
+            )
+            metrics = {
+                "input_tokens": 100,
+                "cached_input_tokens": 90,
+                "output_tokens": 10,
+                "reasoning_output_tokens": 4,
+                "prompt_chars": 200,
+                "event_bytes": 300,
+                "stderr_bytes": 0,
+                "event_count": 4,
+                "tool_call_count": 2,
+                "duration_seconds": 1.5,
+            }
+            budget = {
+                "budget_tokens": 24_000,
+                "estimated_tokens": 20_000,
+                "trim_reasons": {"events": 2},
+            }
+
+            first = store.record_harness_usage(
+                run_id=run_id,
+                run_stage="repair",
+                harness="codex-sdk",
+                model="model-a",
+                session_resume="resumed",
+                portable_context_fallback=False,
+                metrics=metrics,
+                budget=budget,
+            )
+            repeated = store.record_harness_usage(
+                run_id=run_id,
+                run_stage="repair",
+                harness="codex-sdk",
+                model="model-a",
+                session_resume="resumed",
+                portable_context_fallback=False,
+                metrics=metrics,
+                budget=budget,
+            )
+            rows = store.harness_usage_rows("OWNER/REPO", pull_number=12)
+            statistics = store.storage_statistics(repository="owner/repo")
+
+            self.assertEqual(first["id"], repeated["id"])
+            self.assertTrue(repeated["idempotent"])
+            self.assertEqual(repeated["work_item_id"], work_item_id)
+            self.assertNotIn("payload", repeated)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["source"], "ledger")
+            self.assertEqual(rows[0]["metrics"], metrics)
+            self.assertNotIn("agent_metrics", rows[0])
+            self.assertEqual(
+                next(
+                    value["records"]
+                    for value in statistics
+                    if value["category"] == "harness_usage_ledger"
+                ),
+                1,
+            )
+
+            with self.assertRaisesRegex(StoreError, "already recorded differently"):
+                store.record_harness_usage(
+                    run_id=run_id,
+                    run_stage="repair",
+                    harness="codex-sdk",
+                    model="model-a",
+                    session_resume="resumed",
+                    portable_context_fallback=False,
+                    metrics={**metrics, "input_tokens": 101},
+                    budget=budget,
+                )
+
+            second_run, _ = _usage_run(store)
+            with self.assertRaisesRegex(ValueError, "duration_seconds"):
+                store.record_harness_usage(
+                    run_id=second_run,
+                    run_stage="prepare",
+                    harness="codex-sdk",
+                    model="model-a",
+                    session_resume="not_requested",
+                    portable_context_fallback=False,
+                    metrics={**metrics, "duration_seconds": float("nan")},
+                    budget=budget,
+                )
+
+            with closing(sqlite3.connect(store.path)) as connection, connection:
+                connection.execute(
+                    "UPDATE harness_usage_events SET payload='{}' WHERE run_id=?",
+                    (run_id,),
+                )
+            with self.assertRaisesRegex(StoreError, "ledger was modified"):
+                store.harness_usage_rows("owner/repo")
+
+    def test_legacy_harness_usage_keeps_missing_metrics_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            _usage_run(
+                store,
+                details={
+                    "pr_url": "https://github.com/owner/repo/pull/12",
+                    "agent_metrics": {
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                    },
+                },
+            )
+
+            rows = store.harness_usage_rows("owner/repo")
+
+        self.assertEqual(rows[0]["source"], "legacy")
+        self.assertEqual(rows[0]["metrics"]["input_tokens"], 100)
+        self.assertIsNone(rows[0]["metrics"]["cached_input_tokens"])
+        self.assertEqual(rows[0]["session_resume"], "unknown")
+        self.assertIsNone(rows[0]["portable_context_fallback"])
 
     def test_owner_review_attestations_are_idempotent_and_tamper_evident(
         self,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import unittest
+from decimal import Decimal
+from types import SimpleNamespace
+
+from reposteward.config import RepositoryPolicy, UsagePrice
+from reposteward.models import AgentMetrics
+from reposteward.pipeline import Pipeline
+from reposteward.usage import (
+    build_usage_report,
+    compact_usage_budget,
+    compact_usage_metrics,
+    session_resume_outcome,
+)
+
+
+def _row(
+    run_id: str,
+    *,
+    created_at: str,
+    model: str = "model-a",
+    metrics: dict | None = None,
+) -> dict:
+    return {
+        "run_id": run_id,
+        "work_item_id": "work-1",
+        "repository": "owner/repo",
+        "issue_number": 7,
+        "pull_number": 12,
+        "run_stage": "repair" if run_id == "run-2" else "prepare",
+        "current_stage": "pull_request",
+        "status": "submitted",
+        "harness": "codex-sdk",
+        "model": model,
+        "created_at": created_at,
+        "metrics": metrics
+        or {
+            "input_tokens": 1_000_000,
+            "cached_input_tokens": 900_000,
+            "output_tokens": 100_000,
+            "reasoning_output_tokens": 20_000,
+            "prompt_chars": 2_000,
+            "event_bytes": 100,
+            "stderr_bytes": 0,
+            "event_count": 3,
+            "tool_call_count": 2,
+            "duration_seconds": 5.5,
+        },
+        "budget": {
+            "budget_tokens": 24_000,
+            "estimated_tokens": 20_000,
+            "trim_reasons": {"events": 1} if run_id == "run-2" else {},
+        },
+        "session_resume": "resumed" if run_id == "run-2" else "not_requested",
+        "portable_context_fallback": False,
+        "source": "ledger",
+    }
+
+
+class UsageLedgerTests(unittest.TestCase):
+    def test_compaction_never_keeps_paths_warnings_or_prompt_text(self) -> None:
+        metrics = AgentMetrics(
+            input_tokens=100,
+            cached_input_tokens=90,
+            output_tokens=10,
+            log_path="/secret/path/log.jsonl",
+            warnings=("contains provider detail",),
+        )
+        compact = compact_usage_metrics(metrics)
+
+        self.assertNotIn("log_path", compact)
+        self.assertNotIn("warnings", compact)
+        self.assertNotIn("prompt", compact)
+
+    def test_resume_and_portable_budget_outcomes_are_deterministic(self) -> None:
+        self.assertEqual(session_resume_outcome("", "new", ()), "not_requested")
+        self.assertEqual(session_resume_outcome("old", "old", ()), "resumed")
+        self.assertEqual(
+            session_resume_outcome("old", "new", ()), "fallback_new_session"
+        )
+        self.assertEqual(
+            session_resume_outcome(
+                "old", "new", ("SDK could not resume the previous thread",)
+            ),
+            "fallback_new_session",
+        )
+        self.assertEqual(session_resume_outcome("old", "", ()), "unavailable")
+        self.assertEqual(
+            compact_usage_budget(
+                {
+                    "budget_tokens": 100,
+                    "estimated_tokens": 90,
+                    "initial_events": 4,
+                    "retained_events": 2,
+                    "initial_diff_snippets": 3,
+                    "retained_diff_snippets": 1,
+                    "issue_description_omitted_chars": 12,
+                    "prompt": "must not be retained",
+                }
+            ),
+            {
+                "budget_tokens": 100,
+                "estimated_tokens": 90,
+                "trim_reasons": {
+                    "events": 2,
+                    "diff_snippets": 2,
+                    "issue_description_chars": 12,
+                },
+            },
+        )
+
+    def test_report_uses_dated_prices_and_preserves_unknown_metrics(self) -> None:
+        prices = (
+            UsagePrice(
+                harness="codex-sdk",
+                model="model-a",
+                effective_from="2026-01-01",
+                currency="USD",
+                input_per_million=Decimal(1),
+                cached_input_per_million=Decimal("0.1"),
+                output_per_million=Decimal(2),
+            ),
+            UsagePrice(
+                harness="codex-sdk",
+                model="model-a",
+                effective_from="2026-08-01",
+                currency="USD",
+                input_per_million=Decimal(2),
+                cached_input_per_million=Decimal("0.2"),
+                output_per_million=Decimal(4),
+            ),
+        )
+        missing = dict(_row("run-3", created_at="2026-08-10T00:00:00+00:00"))
+        missing["metrics"] = {**missing["metrics"], "cached_input_tokens": None}
+        report = build_usage_report(
+            [
+                _row("run-1", created_at="2026-07-01T00:00:00+00:00"),
+                _row("run-2", created_at="2026-08-10T00:00:00+00:00"),
+                missing,
+            ],
+            prices=prices,
+            filters={"repository": "owner/repo"},
+            group_by="stage",
+            include_runs=True,
+            merge_outcomes={12: "merged"},
+        )
+
+        self.assertEqual(report["summary"]["costs"]["USD"]["value"], "1.17")
+        self.assertEqual(report["summary"]["unknown_cost_runs"], 1)
+        self.assertEqual(
+            report["summary"]["metrics"]["cached_input_tokens"],
+            {"value": 1_800_000, "known_runs": 2, "unknown_runs": 1},
+        )
+        self.assertEqual(report["summary"]["trim_reasons"], {"events": 1})
+        self.assertEqual(
+            [value["key"] for value in report["groups"]], ["prepare", "repair"]
+        )
+        self.assertFalse(report["raw_prompts_stored"])
+        self.assertNotIn("log_path", str(report))
+        self.assertNotIn("provider detail", str(report))
+
+    def test_reasoning_price_replaces_the_reasoning_part_of_output_cost(self) -> None:
+        price = UsagePrice(
+            harness="codex-sdk",
+            model="*",
+            effective_from="2026-01-01",
+            currency="USD",
+            input_per_million=Decimal(0),
+            cached_input_per_million=Decimal(0),
+            output_per_million=Decimal(2),
+            reasoning_output_per_million=Decimal(4),
+        )
+        report = build_usage_report(
+            [_row("run-1", created_at="2026-08-01T00:00:00+00:00")],
+            prices=(price,),
+            filters={},
+            group_by="none",
+            include_runs=True,
+        )
+
+        self.assertEqual(report["runs"][0]["cost"]["value"], "0.24")
+
+    def test_pipeline_normalizes_filters_without_calling_a_harness(self) -> None:
+        class UsageStore:
+            def __init__(self) -> None:
+                self.filters: dict = {}
+
+            def harness_usage_rows(self, _repository: str, **filters) -> list[dict]:
+                self.filters = filters
+                return []
+
+            @staticmethod
+            def latest_merge_outcomes(_repository: str) -> dict[int, str]:
+                return {}
+
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": RepositoryPolicy(name="owner/repo")},
+            observability=SimpleNamespace(prices=()),
+        )
+        pipeline.store = UsageStore()
+
+        report = pipeline.usage_report(
+            "OWNER/REPO",
+            issue_number=7,
+            pull_number=12,
+            run_stage="repair",
+            harness="codex-sdk",
+            model="model-a",
+            since="2026-08-01",
+            until="2026-08-02",
+            group_by="none",
+        )
+
+        self.assertEqual(report["summary"]["runs"], 0)
+        self.assertFalse(report["public_write"])
+        self.assertEqual(pipeline.store.filters["since"], "2026-08-01T00:00:00+00:00")
+        self.assertEqual(pipeline.store.filters["until"], "2026-08-03T00:00:00+00:00")
+        with self.assertRaisesRegex(ValueError, "YYYY-MM-DD"):
+            pipeline.usage_report("owner/repo", since="2026/08/01")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #40

## 做了什么

- 在 Harness 返回后、Runner 验证前，按 run 追加一条 prompt-free 用量事件，记录 token、缓存、工具调用、耗时、session resume 和上下文裁剪原因。
- 新增 `reposteward usage report`，可按 work item、Issue、PR、阶段、Harness、模型和日期聚合，并可选择输出逐 run 明细。
- 支持用户维护带生效日期的每百万 token 单价；精确模型优先、`*` 模型兜底，仓库配置不能覆盖用户价格。
- 将旧数据库无损迁移到 schema v13；历史缺失指标和缺失价格均保持 `unknown`，不会按 0 计算。
- 成功 merge 的返回值附带该 PR 的生命周期 `usage_summary`；本地汇总失败不会改变 GitHub 已成功合并的事实。

## 安全与性能边界

- 账本不保存原始 Prompt、模型响应、warning 或日志路径，只保存固定结构的数值指标、裁剪原因和摘要。
- 每个 run 只允许一条不可变事件，重复写入幂等，不同内容会被拒绝；读取时校验摘要以发现意外修改。
- 报告路径不会调用 Harness，也不会读取原始 Prompt；单次查询最多 10,000 个 run，PR/Issue/日期等过滤在读取阶段尽量收窄结果。
- 成本只在报告时根据用户配置计算，没有硬编码供应商价格，也不会因新增价格错误修改历史原始用量。

## 验证

- `uv run python -m unittest discover -s tests -p 'test_*.py'`（251 tests）
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv build --no-build-isolation`
- 使用既有本地状态库完成 v12 → v13 迁移烟测；#38 的历史 run 正确报告为 `unknown`。

重点请审查价格选择/缓存计费语义、v13 迁移、账本的 prompt-free 边界，以及 merge 成功后的容错语义。

Implementation assistance: an external coding workspace was used to prepare the change and its tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility for this contribution.
