### PR TITLE
feat(workflow): configure pull request capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,32 @@ API 验证当前身份确实拥有 push 权限，并继续禁止直接使用默�
 旧配置显式指定 `state_dir` 时保持原有工作区布局。项目层不能覆盖用户层的运行目录、GitHub 身份、Agent executable 或 Runner
 image；项目安全设置只能收紧用户限额和默认禁止路径，不能静默放宽它们。
 
+### 并发与变更规模
+
+默认情况下，每个仓库最多同时保留 4 个由当前 GitHub 账号创建的 open PR；Draft 和 Ready 都计入，
+其他贡献者、closed 与 merged PR 不计入。容量只阻止创建或重新打开会增加 WIP 的 PR，不阻止向已有
+PR 推送 repair、响应 Review 或重新验证。提交前会重新完整分页读取 GitHub；事实读取失败时不执行
+push 或创建 PR，也不会调用 Harness。
+
+用户可以提高本机容量，项目或单个仓库只能进一步收紧。默认单个变更最多涉及 40 个文件和 2,000 行
+diff；高风险路径、隔离验证、Review 和身份门禁不会因容量提高而放宽：
+
+```toml
+[safety]
+max_active_pull_requests = 8
+max_files_changed = 80
+max_diff_lines = 5000
+
+[repositories."owner/repository"]
+max_active_pull_requests = 6
+max_files_changed = 60
+max_diff_lines = 3000
+```
+
+上述配置的实际仓库上限为 6 个 PR、60 个文件和 3,000 行；仓库值即使高于用户值，也不能突破用户
+上限。所有容量值都必须是正整数。容量门禁用于控制并行负担，不替代“一个 PR 只解决一个清晰问题”
+的范围审查。
+
 ## 准备 Issue 草稿
 
 RepoSteward 可以在本地生成结构化 Markdown，并只读搜索相似 Issue：

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,13 @@ GitHub 当前事实临时构建仓库级快照：先完整分页枚举开放 PR�
 重叠关系按 changed file 建立倒排索引，只为实际共同修改文件的 PR 组合生成边；成本与读取的文件
 引用和最终输出边数相关，不对所有 PR 两两重扫文件列表。规范化后的完整快照生成稳定摘要，调用方
 可以用 expected digest 检测后续读取是否已经陈旧。v1 不把快照写入数据库、不调用 Harness，也不
-修改 workspace 或 GitHub；它是后续依赖排序、WIP 策略和单步协调器的只读事实层。
+修改 workspace 或 GitHub；它是依赖排序、WIP 策略和单步协调器的只读事实层。
+
+WIP 容量门禁位于显式 submit 边界。RepoSteward 先按精确 branch 查询是否已有 open PR：已有 PR 的
+增量 push 不消耗新容量；创建或重新打开 PR 才完整分页读取仓库 open PR，并只统计当前配置身份创建
+的项目。默认每仓库 4 个，用户层可以调高，项目和仓库层只能取更小值。读取失败或达到上限时，在
+创建 fork、push 或写 PR 前失败关闭。该门禁控制在线并发，不调用 Harness，也不改变 Portfolio 的
+依赖、重叠或合并判断。
 
 Dependency Planner 在该快照上叠加两类权威边：PR 正文中严格、独立的 `Depends on #N` 声明，以及
 维护者通过显式本地门禁确认的 head-bound attestation。外部正文仍是不可信输入，解析器只接受仓库和

--- a/examples/tiammomo.toml
+++ b/examples/tiammomo.toml
@@ -34,8 +34,9 @@ blocked_labels = [
 ]
 
 [safety]
-max_files_changed = 18
-max_diff_lines = 700
+max_active_pull_requests = 4
+max_files_changed = 40
+max_diff_lines = 2000
 require_verification = true
 draft_pull_requests = true
 forbidden_paths = [".github/workflows/", ".git/", ".env", "credentials", "secrets"]

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -23,8 +23,9 @@ min_score = 30
 preferred_labels = ["good first issue", "help wanted", "bug", "documentation"]
 
 [safety]
-max_files_changed = 18
-max_diff_lines = 700
+max_active_pull_requests = 4
+max_files_changed = 40
+max_diff_lines = 2000
 require_verification = true
 draft_pull_requests = true
 

--- a/src/reposteward/capacity.py
+++ b/src/reposteward/capacity.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .github import PullRequest
+
+CAPACITY_DETAILS_LIMIT = 20
+
+
+def effective_capacity_limit(global_limit: int, repository_limit: int | None) -> int:
+    """A repository may tighten, but never raise, a user-owned capacity limit."""
+    return (
+        min(global_limit, repository_limit)
+        if repository_limit is not None
+        else global_limit
+    )
+
+
+def pull_request_capacity(
+    pulls: tuple[PullRequest, ...], *, login: str, limit: int
+) -> dict[str, Any]:
+    """Return a bounded, deterministic view of one account's open PR capacity."""
+    if limit < 1:
+        raise ValueError("pull request capacity limit must be positive")
+    active = sorted(
+        (
+            pull
+            for pull in pulls
+            if pull.state.casefold() == "open"
+            and pull.author.casefold() == login.casefold()
+        ),
+        key=lambda pull: pull.number,
+    )
+    details = active[:CAPACITY_DETAILS_LIMIT]
+    return {
+        "limit": limit,
+        "active_count": len(active),
+        "available": max(limit - len(active), 0),
+        "allows_new_pull_request": len(active) < limit,
+        "active_pull_requests": [
+            {
+                "number": pull.number,
+                "draft": pull.draft,
+                "url": pull.url,
+            }
+            for pull in details
+        ],
+        "active_pull_requests_omitted": len(active) - len(details),
+    }

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -73,8 +73,9 @@ class DiscoveryConfig:
 
 @dataclass(frozen=True, slots=True)
 class SafetyConfig:
-    max_files_changed: int = 18
-    max_diff_lines: int = 700
+    max_active_pull_requests: int = 4
+    max_files_changed: int = 40
+    max_diff_lines: int = 2_000
     require_verification: bool = True
     draft_pull_requests: bool = True
     forbidden_paths: tuple[str, ...] = (
@@ -168,6 +169,7 @@ class RepositoryPolicy:
     pull_request_template_sha256: str = ""
     branch_template: str = "{login}/issue-{issue}-{slug}"
     default_scope: str = "repo"
+    max_active_pull_requests: int | None = None
     max_files_changed: int | None = None
     max_diff_lines: int | None = None
     merge_risk_paths: tuple[str, ...] = ()
@@ -388,6 +390,7 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
         merged_safety = _merge(user_safety, project_safety)
         defaults = SafetyConfig()
         for key, default in (
+            ("max_active_pull_requests", defaults.max_active_pull_requests),
             ("max_files_changed", defaults.max_files_changed),
             ("max_diff_lines", defaults.max_diff_lines),
         ):
@@ -568,8 +571,9 @@ def load_config(
     safety_defaults = SafetyConfig()
     configured_forbidden = _tuple(safety_raw.get("forbidden_paths"))
     safety = SafetyConfig(
-        max_files_changed=int(safety_raw.get("max_files_changed", 18)),
-        max_diff_lines=int(safety_raw.get("max_diff_lines", 700)),
+        max_active_pull_requests=int(safety_raw.get("max_active_pull_requests", 4)),
+        max_files_changed=int(safety_raw.get("max_files_changed", 40)),
+        max_diff_lines=int(safety_raw.get("max_diff_lines", 2_000)),
         require_verification=_boolean(safety_raw.get("require_verification"), True),
         draft_pull_requests=_boolean(safety_raw.get("draft_pull_requests"), True),
         forbidden_paths=tuple(
@@ -736,6 +740,11 @@ def load_config(
                 repo_value.get("branch_template", "{login}/issue-{issue}-{slug}")
             ),
             default_scope=str(repo_value.get("default_scope", "repo")),
+            max_active_pull_requests=(
+                int(repo_value["max_active_pull_requests"])
+                if "max_active_pull_requests" in repo_value
+                else None
+            ),
             max_files_changed=(
                 int(repo_value["max_files_changed"])
                 if "max_files_changed" in repo_value
@@ -794,9 +803,27 @@ def load_config(
         raise ConfigError("storage.max_gc_items must be between 1 and 10000")
     if not 512 <= context.follow_up_max_tokens <= 100_000:
         raise ConfigError("context.follow_up_max_tokens must be between 512 and 100000")
+    if any(
+        value < 1
+        for value in (
+            safety.max_active_pull_requests,
+            safety.max_files_changed,
+            safety.max_diff_lines,
+        )
+    ):
+        raise ConfigError("safety capacity limits must be positive")
     if not agent.harness:
         raise ConfigError("agent.harness must not be empty")
     for repository in repositories.values():
+        if any(
+            value is not None and value < 1
+            for value in (
+                repository.max_active_pull_requests,
+                repository.max_files_changed,
+                repository.max_diff_lines,
+            )
+        ):
+            raise ConfigError(f"{repository.name} capacity limits must be positive")
         if repository.mode not in {"contributor", "maintainer"}:
             raise ConfigError(
                 f"unsupported mode for {repository.name}: {repository.mode!r}"

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -45,10 +45,12 @@ def _digest(value: object) -> str:
 
 def repository_policy_digest(policy: RepositoryPolicy) -> str:
     value = asdict(policy)
-    # Preserve outstanding run digests when upgrading to the default-off feature.
-    # Enabling it remains a material policy change and receives a different digest.
+    # Preserve outstanding run digests when adding default-neutral policy fields.
+    # Enabling either field remains material and receives a different digest.
     if not policy.owner_attestation:
         value.pop("owner_attestation")
+    if policy.max_active_pull_requests is None:
+        value.pop("max_active_pull_requests")
     return _digest(value)
 
 

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -12,6 +12,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from .capacity import effective_capacity_limit, pull_request_capacity
 from .ci import (
     FAILED_CONCLUSIONS,
     MAX_COMPARISON_LOGS,
@@ -838,6 +839,31 @@ class Pipeline:
                 "submission strategy or grant repository write access"
             )
         return policy.name, policy.name.split("/", 1)[0]
+
+    def _ensure_new_pull_capacity(
+        self, client: GitHubClient, policy: RepositoryPolicy
+    ) -> dict[str, Any]:
+        limit = effective_capacity_limit(
+            self.config.safety.max_active_pull_requests,
+            policy.max_active_pull_requests,
+        )
+        capacity = pull_request_capacity(
+            client.open_pull_requests(policy.name),
+            login=self.config.github.login,
+            limit=limit,
+        )
+        if not capacity["allows_new_pull_request"]:
+            numbers = ", ".join(
+                f"#{value['number']}" for value in capacity["active_pull_requests"]
+            )
+            omitted = int(capacity["active_pull_requests_omitted"])
+            suffix = f" (+{omitted} more)" if omitted else ""
+            raise PolicyError(
+                "active pull request capacity reached: "
+                f"{capacity['active_count']}/{capacity['limit']} open PRs for "
+                f"{self.config.github.login}; {numbers or 'no details'}{suffix}"
+            )
+        return capacity
 
     def ensure_candidate(self, repository: str, issue_number: int) -> Candidate:
         policy = self.policy(repository)
@@ -3093,15 +3119,11 @@ class Pipeline:
             expected_head_sha=str(details.get("commit_sha") or ""),
             expected_base_sha=str(details.get("base_commit") or ""),
             expected_policy_digest=expected_policy_digest,
-            max_files_changed=(
-                policy.max_files_changed
-                if policy.max_files_changed is not None
-                else self.config.safety.max_files_changed
+            max_files_changed=effective_capacity_limit(
+                self.config.safety.max_files_changed, policy.max_files_changed
             ),
-            max_diff_lines=(
-                policy.max_diff_lines
-                if policy.max_diff_lines is not None
-                else self.config.safety.max_diff_lines
+            max_diff_lines=effective_capacity_limit(
+                self.config.safety.max_diff_lines, policy.max_diff_lines
             ),
             extra_risk_patterns=policy.merge_risk_paths,
         )
@@ -3605,12 +3627,17 @@ class Pipeline:
             raise PolicyError("publication branch must differ from the base branch")
 
         client = GitHubClient(self.config.github, token)
-        destination, head_owner = self._publication_target(client, policy)
         self._validate_contribution_contract(worktree, policy)
         body = self._pull_request_body(
             issue_number, details, reviewed_by, policy=policy
         )
-        closed_pull = None
+        planned_head_owner = (
+            self.config.github.login
+            if policy.submission_strategy == "fork"
+            else policy.name.split("/", 1)[0]
+        )
+        closed_pull: PullRequest | None = None
+        existing_pull: PullRequest | None = None
         if reopen_pull_request:
             if isinstance(details.get("repair_guard"), dict):
                 raise PolicyError(
@@ -3622,7 +3649,7 @@ class Pipeline:
                     f"pull request {policy.name}#{reopen_pull_request} is not closed"
                 )
             expected = (
-                head_owner.casefold(),
+                planned_head_owner.casefold(),
                 details["branch"],
                 details["base_branch"],
             )
@@ -3634,9 +3661,25 @@ class Pipeline:
             if actual != expected:
                 raise PolicyError(
                     f"pull request {policy.name}#{reopen_pull_request} does not match "
-                    f"{head_owner}:{details['branch']} -> "
+                    f"{planned_head_owner}:{details['branch']} -> "
                     f"{details['base_branch']}"
                 )
+            self._ensure_new_pull_capacity(client, policy)
+        else:
+            existing_pull = client.existing_pull_request(
+                policy.name,
+                owner=planned_head_owner,
+                branch=details["branch"],
+            )
+            if existing_pull is None:
+                self._ensure_new_pull_capacity(client, policy)
+
+        destination, head_owner = self._publication_target(client, policy)
+        if head_owner.casefold() != planned_head_owner.casefold():
+            raise PolicyError("publication target identity changed during submission")
+
+        if reopen_pull_request:
+            assert closed_pull is not None
             pull_request = client.reopen_pull_request(
                 policy.name,
                 reopen_pull_request,
@@ -3658,11 +3701,6 @@ class Pipeline:
                 raise
             pull_request = client.pull_request(policy.name, reopen_pull_request)
         else:
-            existing_pull = client.existing_pull_request(
-                policy.name,
-                owner=head_owner,
-                branch=details["branch"],
-            )
             repair_guard = details.get("repair_guard")
             if isinstance(repair_guard, dict):
                 if existing_pull is None or existing_pull.number != int(

--- a/src/reposteward/policy.py
+++ b/src/reposteward/policy.py
@@ -5,6 +5,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from .capacity import effective_capacity_limit
 from .config import AppConfig, RepositoryPolicy
 from .models import VerificationResult
 
@@ -112,8 +113,12 @@ def enforce_change_policy(
     summary = summarize_diff(worktree, base_ref)
     if not summary.files:
         raise PolicyError("agent produced no repository changes")
-    file_limit = repository.max_files_changed or config.safety.max_files_changed
-    line_limit = repository.max_diff_lines or config.safety.max_diff_lines
+    file_limit = effective_capacity_limit(
+        config.safety.max_files_changed, repository.max_files_changed
+    )
+    line_limit = effective_capacity_limit(
+        config.safety.max_diff_lines, repository.max_diff_lines
+    )
     if len(summary.files) > file_limit:
         raise PolicyError(
             f"change touches {len(summary.files)} files; policy limit is {file_limit}"

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -78,6 +78,13 @@ project_number = {issue_project_number}
 project_owner_type = {_toml_string(issue_project_owner_type)}
 require_distinct_reviewer = true
 
+[safety]
+max_active_pull_requests = 4
+max_files_changed = 40
+max_diff_lines = 2000
+require_verification = true
+draft_pull_requests = true
+
 [agent]
 harness = "codex-cli"
 executable = "codex"

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import unittest
+
+from reposteward.capacity import effective_capacity_limit, pull_request_capacity
+from reposteward.github import PullRequest
+
+
+def _pull(
+    number: int,
+    *,
+    author: str = "alice",
+    state: str = "open",
+    draft: bool = False,
+) -> PullRequest:
+    return PullRequest(
+        number=number,
+        url=f"https://github.com/owner/repo/pull/{number}",
+        state=state,
+        draft=draft,
+        author=author,
+    )
+
+
+class PullRequestCapacityTests(unittest.TestCase):
+    def test_default_boundary_counts_draft_and_ready_pulls(self) -> None:
+        capacity = pull_request_capacity(
+            (
+                _pull(1, draft=True),
+                _pull(2),
+                _pull(3),
+                _pull(4),
+                _pull(5, author="bob"),
+                _pull(6, state="closed"),
+            ),
+            login="ALICE",
+            limit=4,
+        )
+
+        self.assertEqual(capacity["active_count"], 4)
+        self.assertEqual(capacity["available"], 0)
+        self.assertFalse(capacity["allows_new_pull_request"])
+        self.assertTrue(capacity["active_pull_requests"][0]["draft"])
+        self.assertEqual(
+            [value["number"] for value in capacity["active_pull_requests"]],
+            [1, 2, 3, 4],
+        )
+
+        over_capacity = pull_request_capacity(
+            tuple(_pull(number) for number in range(1, 6)),
+            login="alice",
+            limit=4,
+        )
+        self.assertEqual(over_capacity["active_count"], 5)
+        self.assertFalse(over_capacity["allows_new_pull_request"])
+
+    def test_user_can_raise_capacity_while_repository_can_only_tighten_it(self) -> None:
+        self.assertEqual(effective_capacity_limit(8, None), 8)
+        self.assertEqual(effective_capacity_limit(8, 5), 5)
+        self.assertEqual(effective_capacity_limit(8, 12), 8)
+
+        capacity = pull_request_capacity(
+            tuple(_pull(number) for number in range(1, 6)),
+            login="alice",
+            limit=8,
+        )
+        self.assertEqual(capacity["active_count"], 5)
+        self.assertTrue(capacity["allows_new_pull_request"])
+
+    def test_capacity_details_are_bounded_without_losing_the_total(self) -> None:
+        capacity = pull_request_capacity(
+            tuple(_pull(number) for number in range(1, 26)),
+            login="alice",
+            limit=30,
+        )
+
+        self.assertEqual(capacity["active_count"], 25)
+        self.assertEqual(len(capacity["active_pull_requests"]), 20)
+        self.assertEqual(capacity["active_pull_requests_omitted"], 5)
+
+    def test_non_positive_limit_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            pull_request_capacity((), login="alice", limit=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,9 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.runner.max_output_chars, 12_000)
         self.assertEqual(config.runner.passed_output_chars, 2_000)
         self.assertEqual(config.runner.max_log_chars, 2_000_000)
+        self.assertEqual(config.safety.max_active_pull_requests, 4)
+        self.assertEqual(config.safety.max_files_changed, 40)
+        self.assertEqual(config.safety.max_diff_lines, 2_000)
         policy = config.repositories["langchain-ai/deepagents"]
         self.assertTrue(policy.enabled)
         self.assertTrue(policy.require_assignment_before_submit)
@@ -217,6 +220,77 @@ event_payload_retention_days = 0
             )
 
             with self.assertRaisesRegex(ConfigError, "must be positive"):
+                load_config(path)
+
+    def test_capacity_defaults_can_be_raised_by_user_and_tightened_by_project(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[safety]
+max_active_pull_requests = 8
+max_files_changed = 80
+max_diff_lines = 5000
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[safety]
+max_active_pull_requests = 6
+max_files_changed = 60
+max_diff_lines = 3000
+[repositories."owner/repo"]
+max_active_pull_requests = 5
+max_files_changed = 50
+max_diff_lines = 2500
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project, user_path=user)
+
+        self.assertEqual(config.safety.max_active_pull_requests, 6)
+        self.assertEqual(config.safety.max_files_changed, 60)
+        self.assertEqual(config.safety.max_diff_lines, 3_000)
+        policy = config.repositories["owner/repo"]
+        self.assertEqual(policy.max_active_pull_requests, 5)
+        self.assertEqual(policy.max_files_changed, 50)
+        self.assertEqual(policy.max_diff_lines, 2_500)
+
+    def test_capacity_limits_must_be_positive(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[safety]
+max_active_pull_requests = 0
+""",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                ConfigError, "capacity limits must be positive"
+            ):
+                load_config(path)
+
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+max_diff_lines = 0
+""",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ConfigError, "owner/repo capacity limits"):
                 load_config(path)
 
     def test_follow_up_token_budget_is_bounded(self) -> None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -48,10 +48,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class RepositoryPolicyDigestTests(unittest.TestCase):
-    def test_default_off_owner_attestation_preserves_legacy_policy_digest(self) -> None:
+    def test_default_capacity_and_attestation_preserve_legacy_policy_digest(
+        self,
+    ) -> None:
         policy = RepositoryPolicy(name="owner/repo")
         legacy = asdict(policy)
         legacy.pop("owner_attestation")
+        legacy.pop("max_active_pull_requests")
         encoded = json.dumps(
             legacy, ensure_ascii=False, sort_keys=True, separators=(",", ":")
         ).encode()
@@ -61,6 +64,10 @@ class RepositoryPolicyDigestTests(unittest.TestCase):
         )
         self.assertNotEqual(
             repository_policy_digest(replace(policy, owner_attestation=True)),
+            repository_policy_digest(policy),
+        )
+        self.assertNotEqual(
+            repository_policy_digest(replace(policy, max_active_pull_requests=3)),
             repository_policy_digest(policy),
         )
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from reposteward.config import load_config
-from reposteward.models import AgentResult
+from reposteward.config import RepositoryPolicy, load_config
+from reposteward.models import AgentResult, VerificationResult
 from reposteward.pipeline import Pipeline
-from reposteward.policy import PolicyError, conventional_scope
+from reposteward.policy import (
+    DiffSummary,
+    PolicyError,
+    conventional_scope,
+    enforce_change_policy,
+)
 from reposteward.verifier import DockerVerifier, VerificationError
 from reposteward.workspace import sanitized_environment, slugify
 
@@ -86,6 +91,39 @@ class PolicyTests(unittest.TestCase):
         slug = slugify("BaseSandbox.grep path globs fail because shell is unsafe")
         self.assertLessEqual(len(slug), 48)
         self.assertNotIn(".", slug)
+
+    def test_repository_change_limits_cannot_raise_user_capacity(self) -> None:
+        repository = RepositoryPolicy(
+            name="owner/repo",
+            max_files_changed=100,
+            max_diff_lines=10_000,
+        )
+        verification = VerificationResult(passed=True, commands=())
+        successful_diff_check = Mock(returncode=0, stdout="")
+
+        with (
+            patch(
+                "reposteward.policy.subprocess.run", return_value=successful_diff_check
+            ),
+            patch(
+                "reposteward.policy.summarize_diff",
+                return_value=DiffSummary(tuple(f"file-{i}" for i in range(41)), 1, 0),
+            ),
+            self.assertRaisesRegex(PolicyError, "policy limit is 40"),
+        ):
+            enforce_change_policy(Path("."), verification, repository, self.config)
+
+        with (
+            patch(
+                "reposteward.policy.subprocess.run", return_value=successful_diff_check
+            ),
+            patch(
+                "reposteward.policy.summarize_diff",
+                return_value=DiffSummary(("file",), 2_001, 0),
+            ),
+            self.assertRaisesRegex(PolicyError, "policy limit is 2000"),
+        ):
+            enforce_change_policy(Path("."), verification, repository, self.config)
 
     def test_pull_request_body_contains_review_attestation(self) -> None:
         body = Pipeline._pull_request_body(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -42,6 +42,9 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(parsed["storage"]["cache_retention_days"], 30)
         self.assertEqual(parsed["storage"]["max_gc_items"], 1000)
         self.assertEqual(parsed["context"]["follow_up_max_tokens"], 24_000)
+        self.assertEqual(parsed["safety"]["max_active_pull_requests"], 4)
+        self.assertEqual(parsed["safety"]["max_files_changed"], 40)
+        self.assertEqual(parsed["safety"]["max_diff_lines"], 2_000)
         self.assertEqual(
             parsed["project"]["state_dir"], str(root / "state" / "reposteward")
         )

--- a/tests/test_submission_capacity.py
+++ b/tests/test_submission_capacity.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from reposteward.config import RepositoryPolicy
+from reposteward.github import GitHubError, PullRequest
+from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
+
+
+def _pull(number: int, *, author: str = "alice", draft: bool = False) -> PullRequest:
+    return PullRequest(
+        number=number,
+        url=f"https://github.com/owner/repo/pull/{number}",
+        state="open",
+        draft=draft,
+        author=author,
+        head_owner="owner",
+        head_branch=f"alice/feat/change-{number}",
+        head_sha=str(number) * 40,
+        base_branch="main",
+    )
+
+
+class _SubmissionStore:
+    def __init__(self, details: dict) -> None:
+        self.details = details
+        self.updated: dict | None = None
+
+    def latest_run(self, _repository: str, _issue_number: int) -> dict:
+        return {"id": "run-1", "status": "ready", "details": self.details}
+
+    def update_run(self, _run_id: str, **values) -> None:
+        self.updated = values
+
+    @staticmethod
+    def set_candidate_status(
+        _repository: str, _issue_number: int, _status: str
+    ) -> None:
+        return None
+
+    @staticmethod
+    def record_submission(_repository: str, _issue_number: int, _url: str) -> None:
+        return None
+
+    @staticmethod
+    def context_bundle(_run_id: str) -> None:
+        return None
+
+
+class _SubmissionGitHub:
+    def __init__(
+        self,
+        *,
+        existing: PullRequest | None = None,
+        closed: PullRequest | None = None,
+        pulls: tuple[PullRequest, ...] = (),
+        open_error: Exception | None = None,
+    ) -> None:
+        self.existing = existing
+        self.closed = closed
+        self.pulls = pulls
+        self.open_error = open_error
+        self.open_calls = 0
+        self.create_calls = 0
+        self.repository_calls = 0
+        self.reopen_calls = 0
+
+    @staticmethod
+    def authenticated_login() -> str:
+        return "alice"
+
+    def existing_pull_request(
+        self, _repository: str, *, owner: str, branch: str
+    ) -> PullRequest | None:
+        self.requested_head = (owner, branch)
+        return self.existing
+
+    def open_pull_requests(self, _repository: str) -> tuple[PullRequest, ...]:
+        self.open_calls += 1
+        if self.open_error is not None:
+            raise self.open_error
+        return self.pulls
+
+    def repository(self, _repository: str) -> SimpleNamespace:
+        self.repository_calls += 1
+        return SimpleNamespace(can_push=True)
+
+    def create_pull_request(self, *_args, **_kwargs) -> PullRequest:
+        self.create_calls += 1
+        return _pull(99)
+
+    def pull_request(self, _repository: str, _number: int) -> PullRequest:
+        pull = self.closed or self.existing
+        assert pull is not None
+        return pull
+
+    def reopen_pull_request(self, *_args, **_kwargs) -> PullRequest:
+        self.reopen_calls += 1
+        assert self.closed is not None
+        return self.closed
+
+
+class SubmissionCapacityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.worktree = Path(self.temporary.name)
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(self.worktree)], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.worktree), "config", "user.name", "Alice"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.worktree),
+                "config",
+                "user.email",
+                "alice@example.com",
+            ],
+            check=True,
+        )
+        (self.worktree / "example.txt").write_text("example\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(self.worktree), "add", "example.txt"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.worktree), "commit", "-qm", "initial"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.worktree),
+                "checkout",
+                "-qb",
+                "alice/feat/example",
+            ],
+            check=True,
+        )
+        self.head = subprocess.run(
+            ["git", "-C", str(self.worktree), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def pipeline(self) -> Pipeline:
+        policy = RepositoryPolicy(
+            name="owner/repo",
+            mode="maintainer",
+            submission_strategy="same-repository",
+        )
+        details = {
+            "worktree": str(self.worktree),
+            "branch": "alice/feat/example",
+            "base_branch": "main",
+            "commit_sha": self.head,
+            "agent_result": {
+                "summary": "Implement the capacity policy.",
+                "pr_title": "feat(workflow): configure capacity",
+                "implementation_notes": "Use fresh GitHub facts.",
+                "verification_commands": ["python -m unittest"],
+                "risks": [],
+            },
+        }
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": policy},
+            github=SimpleNamespace(login="alice"),
+            safety=SimpleNamespace(
+                max_active_pull_requests=4,
+                draft_pull_requests=True,
+            ),
+        )
+        pipeline.store = _SubmissionStore(details)
+        pipeline.workspaces = Mock()
+        pipeline.gate_status = Mock(return_value={"submission_ready": True})
+        return pipeline
+
+    def submit(
+        self, pipeline: Pipeline, client: _SubmissionGitHub, *, reopen: int = 0
+    ) -> dict:
+        with (
+            patch.dict(os.environ, {"REPOSTEWARD_ENABLE_SUBMIT": "1"}),
+            patch("reposteward.pipeline.resolve_token", return_value="token"),
+            patch("reposteward.pipeline.GitHubClient", return_value=client),
+        ):
+            return pipeline.submit(
+                "owner/repo",
+                42,
+                reviewed_by="alice",
+                reopen_pull_request=reopen,
+            )
+
+    def test_new_pull_is_blocked_at_capacity_before_any_public_write(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub(
+            pulls=tuple(_pull(number, draft=number == 1) for number in range(1, 5))
+        )
+
+        with self.assertRaisesRegex(PolicyError, "4/4 open PRs.*#1, #2, #3, #4"):
+            self.submit(pipeline, client)
+
+        self.assertEqual(client.open_calls, 1)
+        self.assertEqual(client.repository_calls, 0)
+        self.assertEqual(client.create_calls, 0)
+        pipeline.workspaces.push.assert_not_called()
+
+    def test_existing_pull_update_bypasses_new_pull_capacity(self) -> None:
+        pipeline = self.pipeline()
+        existing = PullRequest(
+            number=41,
+            url="https://github.com/owner/repo/pull/41",
+            state="open",
+            draft=True,
+            author="alice",
+            head_owner="owner",
+            head_branch="alice/feat/example",
+            head_sha=self.head,
+            base_branch="main",
+        )
+        client = _SubmissionGitHub(
+            existing=existing,
+            pulls=tuple(_pull(number) for number in range(1, 5)),
+        )
+
+        result = self.submit(pipeline, client)
+
+        self.assertEqual(result["pr_number"], 41)
+        self.assertEqual(client.open_calls, 0)
+        self.assertEqual(client.create_calls, 0)
+        pipeline.workspaces.push.assert_called_once()
+
+    def test_capacity_read_failure_is_closed_before_push(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub(open_error=GitHubError("pagination failed"))
+
+        with self.assertRaisesRegex(GitHubError, "pagination failed"):
+            self.submit(pipeline, client)
+
+        self.assertEqual(client.repository_calls, 0)
+        self.assertEqual(client.create_calls, 0)
+        pipeline.workspaces.push.assert_not_called()
+
+    def test_reopening_a_closed_pull_consumes_new_capacity(self) -> None:
+        pipeline = self.pipeline()
+        closed = PullRequest(
+            number=40,
+            url="https://github.com/owner/repo/pull/40",
+            state="closed",
+            draft=True,
+            author="alice",
+            head_owner="owner",
+            head_branch="alice/feat/example",
+            head_sha=self.head,
+            base_branch="main",
+        )
+        client = _SubmissionGitHub(
+            closed=closed,
+            pulls=tuple(_pull(number) for number in range(1, 5)),
+        )
+
+        with self.assertRaisesRegex(PolicyError, "capacity reached"):
+            self.submit(pipeline, client, reopen=40)
+
+        self.assertEqual(client.open_calls, 1)
+        self.assertEqual(client.reopen_calls, 0)
+        pipeline.workspaces.push.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #42

## 做了什么

- 新增 `max_active_pull_requests`，默认每仓库允许当前 GitHub 账号同时维护 4 个 open PR；用户可调高，项目和仓库只能收紧。
- Draft 与 Ready PR 都计入 WIP；其他作者、closed 和 merged PR 不计入。
- 容量只阻止新建或重新打开 PR，达到上限后仍允许向已有 PR push repair、响应 Review 和重新验证。
- 将全局默认变更规模从 18 文件/700 行放宽为 40 文件/2,000 行；仓库级文件和行数设置现在不能突破用户上限。
- 更新 `init` 配置、示例、README 和架构说明，并保持新增默认字段对旧 Context Pack policy digest 的兼容。

## 安全与性能边界

- 新 PR 提交前只执行一次完整分页的 GitHub open PR 读取；读取失败时在创建 fork、push 或创建 PR 之前失败关闭。
- 已有 branch 对应 open PR 时直接走更新路径，不执行 WIP 全量读取，因此 repair 循环没有新增 API 成本。
- 容量门禁不调用 Harness，也不削弱 forbidden paths、隔离验证、Review、CI、身份和 merge freshness 门禁。
- 相关 PR 明细最多返回 20 条，但总数始终准确，避免错误信息随 WIP 数量无限增长。

## 验证

- `uv run python -m unittest discover -s tests -p 'test_*.py'`（262 tests）
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv build --no-build-isolation`
- 已使用新实现实际创建本 PR，容量检查通过后才发生 push/PR 写入。

重点请审查新建/已有/重新打开 PR 三条路径的容量语义、用户与仓库限额取最小值的规则，以及大型仓库完整分页读取的提交时成本。

Implementation assistance: an external coding workspace was used to prepare the change and its tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility for this contribution.
