### PR TITLE
feat(workspace): manage terminal workspace cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,9 +531,9 @@ uv run reposteward storage stats
 uv run reposteward storage stats --repo owner/repository --since-days 30
 ```
 
-输出分别给出逻辑载荷字节、验证日志缓存和 SQLite/WAL/SHM 的实际文件字节；跨仓库共享的内容
-寻址 Blob 会在各仓库行中显示引用字节，并在说明字段中明确其可能重复计算，避免把逻辑引用误当成
-全局物理占用。
+输出分别给出逻辑载荷字节、验证日志缓存、隔离工作区和 SQLite/WAL/SHM 的实际文件字节。工作区
+统计只读取文件系统元数据，不读取文件正文或跟随符号链接；跨仓库共享的内容寻址 Blob 会在各仓库
+行中显示引用字节，并在说明字段中明确其可能重复计算，避免把逻辑引用误当成全局物理占用。
 
 清理命令默认只生成精确计划，不写数据库或删除文件：
 
@@ -541,10 +541,12 @@ uv run reposteward storage stats --repo owner/repository --since-days 30
 uv run reposteward storage gc --repo owner/repository
 ```
 
-默认候选只有超过用户级 `cache_retention_days` 且已有终态 Checkpoint 的验证日志。原始 GitHub
-事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且每个 run 水位
-都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并始终保护事件
-索引、Checkpoint、Merge Decision、Merge Execution 和 GC 审计。
+验证日志候选必须超过用户级 `cache_retention_days` 且已有终态 Checkpoint。工作区候选必须超过
+`workspace_retention_days`，关联的所有 run 均到达终态 Checkpoint，并且 Git 工作区干净、提交已由
+submitted run 或远端引用证明可恢复；活跃、未知、脏、未推送、路径异常和符号链接工作区都会保留。
+原始 GitHub 事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且
+每个 run 水位都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并
+始终保护事件索引、Checkpoint、Merge Decision、Merge Execution 和 GC 审计。
 
 实际应用需要命令参数和独立环境开关同时存在：
 
@@ -553,8 +555,9 @@ REPOSTEWARD_ENABLE_GC=1 uv run reposteward storage gc \
   --repo owner/repository --apply
 ```
 
-apply 前会追加 `applying` 审计，删除后再追加 `completed` 审计；中断后可从未完成记录识别并安全
-重跑。SQLite Blob 删除释放的是可复用数据库页，不会自动执行 `VACUUM` 或承诺立即缩小数据库文件。
+apply 前会追加 `applying` 审计；每个工作区在删除前会重新扫描并核对目录身份、快照、HEAD 和 run
+状态，删除后再追加 `completed` 审计。中断后可从未完成记录识别并安全重跑。SQLite Blob 删除释放
+的是可复用数据库页，不会自动执行 `VACUUM` 或承诺立即缩小数据库文件。
 
 ## 安全约束
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,10 +122,12 @@ Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重
 事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
 的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
-验证日志是唯一默认可回收类别，期限和单次最大对象数由用户级 `[storage]` 配置拥有，项目层不能
-静默缩短。GC 默认 dry-run；apply 同时要求 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后
-追加审计。普通 GC 永不删除事件索引、Context Checkpoint、Portfolio Dependency、Merge Decision、
-Merge Execution 或自身审计。
+验证日志和可恢复的终态隔离工作区是默认可回收类别，期限和单次最大对象数由用户级 `[storage]`
+配置拥有，项目层不能静默缩短。工作区扫描不跟随符号链接；只有所有关联 run 均到达终态
+Checkpoint、Git 状态干净且 HEAD 可从 submitted run 或远端引用恢复时才会进入计划。apply 会再次
+核对目录身份、元数据快照、HEAD 和 run 状态，变化即跳过。GC 默认 dry-run；apply 同时要求
+`--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后追加审计。普通 GC 永不删除事件索引、
+Context Checkpoint、Portfolio Dependency、Merge Decision、Merge Execution 或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 - `merge_executions`：按 attempt 追加保存执行身份、指定决策、精确 head、方法、写入前意图与最终

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -42,6 +42,7 @@ memory = "8g"
 
 [storage]
 cache_retention_days = 30
+workspace_retention_days = 30
 max_gc_items = 1000
 
 [context]

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -115,6 +115,7 @@ class RunnerConfig:
 @dataclass(frozen=True, slots=True)
 class StorageConfig:
     cache_retention_days: int = 30
+    workspace_retention_days: int = 30
     max_gc_items: int = 1_000
 
 
@@ -605,6 +606,7 @@ def load_config(
     storage_raw = _section(raw, "storage")
     storage = StorageConfig(
         cache_retention_days=int(storage_raw.get("cache_retention_days", 30)),
+        workspace_retention_days=int(storage_raw.get("workspace_retention_days", 30)),
         max_gc_items=int(storage_raw.get("max_gc_items", 1_000)),
     )
 
@@ -799,6 +801,10 @@ def load_config(
         )
     if not 1 <= storage.cache_retention_days <= 36_500:
         raise ConfigError("storage.cache_retention_days must be between 1 and 36500")
+    if not 1 <= storage.workspace_retention_days <= 36_500:
+        raise ConfigError(
+            "storage.workspace_retention_days must be between 1 and 36500"
+        )
     if not 1 <= storage.max_gc_items <= 10_000:
         raise ConfigError("storage.max_gc_items must be between 1 and 10000")
     if not 512 <= context.follow_up_max_tokens <= 100_000:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -73,6 +73,13 @@ from .usage import (
 )
 from .verifier import DockerVerifier
 from .workspace import WorkspaceManager
+from .workspace_storage import (
+    WORKSPACE_KIND,
+    delete_workspace,
+    scan_workspaces,
+    workspace_gc_inventory,
+    workspace_statistics,
+)
 
 
 def _canonical_digest(value: object) -> str:
@@ -1811,7 +1818,10 @@ class Pipeline:
             else ""
         )
         categories = self.store.storage_statistics(repository=normalized, cutoff=cutoff)
-        repositories = self.store.run_repositories()
+        run_safety = self.store.run_gc_safety()
+        repositories = {
+            run_id: str(value["repository"]) for run_id, value in run_safety.items()
+        }
         logs: dict[str, dict[str, Any]] = {}
         runs_root = (self.config.state_dir / "runs").resolve()
         if runs_root.is_dir():
@@ -1852,6 +1862,17 @@ class Pipeline:
                     )
                     group["newest_at"] = max(group["newest_at"], timestamp)
         categories.extend(logs.values())
+        workspace_inventory = scan_workspaces(
+            self.config.workspace_dir,
+            repositories=tuple(
+                policy.name for policy in self.config.repositories.values()
+            ),
+            runs=run_safety,
+        )
+        workspace_categories, workspace_errors = workspace_statistics(
+            workspace_inventory, repository=normalized, cutoff=cutoff
+        )
+        categories.extend(workspace_categories)
         categories.sort(key=lambda value: (value["repository"], value["category"]))
         database_files = []
         for suffix in ("", "-wal", "-shm"):
@@ -1866,6 +1887,8 @@ class Pipeline:
             "reported_logical_bytes": sum(value["bytes"] for value in categories),
             "database_physical_bytes": sum(value["bytes"] for value in database_files),
             "database_files": database_files,
+            "workspace_scan_errors": workspace_errors[:100],
+            "workspace_scan_errors_omitted": max(0, len(workspace_errors) - 100),
             "notes": (
                 "Per-repository event payload bytes are referenced bytes; one deduplicated "
                 "blob referenced by multiple repositories appears in each repository row."
@@ -2030,6 +2053,9 @@ class Pipeline:
         cache_cutoff = (
             now - timedelta(days=self.config.storage.cache_retention_days)
         ).isoformat()
+        workspace_cutoff = (
+            now - timedelta(days=self.config.storage.workspace_retention_days)
+        ).isoformat()
         retention_cutoffs = {
             policy.name.casefold(): (
                 now - timedelta(days=policy.event_payload_retention_days)
@@ -2041,6 +2067,15 @@ class Pipeline:
             repository=normalized, cutoff=cache_cutoff
         )
         payloads = self.store.event_payload_gc_inventory(retention_cutoffs)
+        workspaces = workspace_gc_inventory(
+            self.config.workspace_dir,
+            repositories=tuple(
+                policy.name for policy in self.config.repositories.values()
+            ),
+            runs=self.store.run_gc_safety(),
+            repository=normalized,
+            cutoff=workspace_cutoff,
+        )
 
         def in_scope(value: dict[str, Any]) -> bool:
             repositories = value.get("repositories", ())
@@ -2050,7 +2085,11 @@ class Pipeline:
             value for value in payloads["candidates"] if in_scope(value)
         ]
         payload_retained = [value for value in payloads["retained"] if in_scope(value)]
-        candidates = [*logs["candidates"], *payload_candidates]
+        candidates = [
+            *logs["candidates"],
+            *payload_candidates,
+            *workspaces["candidates"],
+        ]
         candidates.sort(
             key=lambda value: (
                 value["created_at"],
@@ -2058,7 +2097,11 @@ class Pipeline:
                 str(value.get("path") or value.get("digest")),
             )
         )
-        retained = [*logs["retained"], *payload_retained]
+        retained = [
+            *logs["retained"],
+            *payload_retained,
+            *workspaces["retained"],
+        ]
         if len(candidates) > self.config.storage.max_gc_items:
             for value in candidates[self.config.storage.max_gc_items :]:
                 retained.append({**value, "reasons": ["gc_item_limit"]})
@@ -2068,6 +2111,7 @@ class Pipeline:
             "repository": normalized,
             "generated_at": generated_at,
             "cache_cutoff": cache_cutoff,
+            "workspace_cutoff": workspace_cutoff,
             "retention_cutoffs": retention_cutoffs,
             "candidates": candidates,
         }
@@ -2113,6 +2157,8 @@ class Pipeline:
         )
         deleted_logs = []
         skipped_logs = []
+        deleted_workspaces = []
+        skipped_workspaces = []
         fresh_safety = self.store.run_gc_safety()
         state_root = self.config.state_dir.resolve()
         runs_root = state_root / "runs"
@@ -2137,6 +2183,55 @@ class Pipeline:
                 deleted_logs.append(value)
             except OSError as exc:
                 skipped_logs.append({"path": value["path"], "reason": str(exc)})
+        planned_workspace_paths = frozenset(
+            str(value["path"])
+            for value in candidates
+            if value["kind"] == WORKSPACE_KIND
+        )
+        fresh_workspaces = (
+            workspace_gc_inventory(
+                self.config.workspace_dir,
+                repositories=tuple(
+                    policy.name for policy in self.config.repositories.values()
+                ),
+                runs=fresh_safety,
+                repository=normalized,
+                cutoff=workspace_cutoff,
+                paths=planned_workspace_paths,
+            )
+            if planned_workspace_paths
+            else {"candidates": [], "retained": []}
+        )
+        fresh_by_path = {
+            str(value["path"]): value for value in fresh_workspaces["candidates"]
+        }
+        stable_fields = (
+            "repository",
+            "run_ids",
+            "device",
+            "inode",
+            "snapshot_digest",
+            "head_commit",
+        )
+        for value in candidates:
+            if value["kind"] != WORKSPACE_KIND:
+                continue
+            current = fresh_by_path.get(str(value["path"]))
+            if current is None or any(
+                current.get(field) != value.get(field) for field in stable_fields
+            ):
+                skipped_workspaces.append(
+                    {
+                        "path": value["path"],
+                        "reason": "workspace no longer satisfies the reviewed plan",
+                    }
+                )
+                continue
+            try:
+                delete_workspace(self.config.workspace_dir, current)
+                deleted_workspaces.append(current)
+            except OSError as exc:
+                skipped_workspaces.append({"path": value["path"], "reason": str(exc)})
         payload_result = self.store.delete_event_payloads(
             tuple(
                 str(value["digest"])
@@ -2148,6 +2243,8 @@ class Pipeline:
         applied = {
             "deleted_logs": deleted_logs,
             "skipped_logs": skipped_logs,
+            "deleted_workspaces": deleted_workspaces,
+            "skipped_workspaces": skipped_workspaces,
             "deleted_event_payloads": payload_result["deleted"],
             "skipped_event_payloads": payload_result["skipped"],
         }

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -104,6 +104,7 @@ max_log_chars = 2000000
 
 [storage]
 cache_retention_days = 30
+workspace_retention_days = 30
 max_gc_items = 1000
 
 [context]

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -2061,7 +2061,8 @@ class Store:
         with self._connection() as connection:
             rows = connection.execute(
                 """
-                SELECT r.id, r.repository,
+                SELECT r.id, r.repository, r.status, r.worktree, r.details,
+                       r.updated_at,
                        EXISTS(
                            SELECT 1 FROM checkpoints c
                            WHERE c.run_id=r.id
@@ -2070,13 +2071,23 @@ class Store:
                 FROM runs r
                 """
             ).fetchall()
-        return {
-            str(row["id"]): {
+        result = {}
+        for row in rows:
+            try:
+                details = json.loads(str(row["details"]))
+            except json.JSONDecodeError as exc:
+                raise StoreError("run details were modified") from exc
+            if not isinstance(details, dict):
+                raise StoreError("run details were modified")
+            result[str(row["id"])] = {
                 "repository": str(row["repository"]),
+                "status": str(row["status"]),
+                "worktree": str(row["worktree"]),
+                "updated_at": str(row["updated_at"]),
+                "head_commit": str(details.get("commit_sha") or ""),
                 "terminal_checkpoint": bool(row["terminal_checkpoint"]),
             }
-            for row in rows
-        }
+        return result
 
     def record_storage_gc(
         self,

--- a/src/reposteward/workspace_storage.py
+++ b/src/reposteward/workspace_storage.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat as stat_module
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .workspace import sanitized_environment
+
+WORKSPACE_KIND = "workspace_cache"
+MANAGED_WORKSPACE = re.compile(r"issue-[1-9][0-9]*-\d{8}T\d{6}Z\Z")
+TERMINAL_RUN_STATUSES = {"ready", "submitted", "failed"}
+
+
+def _absolute(path: Path) -> Path:
+    """Normalize lexical components without following a symlink."""
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def _iso_from_ns(value: int) -> str:
+    return datetime.fromtimestamp(value / 1_000_000_000, UTC).isoformat()
+
+
+def _later_timestamp(left: str, right: str) -> str:
+    return max((value for value in (left, right) if value), default="")
+
+
+def _tree_snapshot(path: Path) -> dict[str, Any]:
+    """Return bounded metadata for one tree without following symlinks."""
+    digest_total = 0
+    try:
+        root_stat = path.lstat()
+    except OSError as exc:
+        return {"error": str(exc)}
+    total_bytes = root_stat.st_size
+    records = 1
+    root_timestamp = _iso_from_ns(root_stat.st_mtime_ns)
+    oldest_at = root_timestamp
+    newest_at = root_timestamp
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as iterator:
+                for entry in iterator:
+                    stat = entry.stat(follow_symlinks=False)
+                    entry_path = Path(entry.path)
+                    relative = entry_path.relative_to(path).as_posix()
+                    if stat_module.S_ISLNK(stat.st_mode):
+                        kind = "symlink"
+                    elif stat_module.S_ISDIR(stat.st_mode):
+                        kind = "directory"
+                        stack.append(entry_path)
+                    elif stat_module.S_ISREG(stat.st_mode):
+                        kind = "file"
+                    else:
+                        kind = "other"
+                    material = {
+                        "path": relative,
+                        "kind": kind,
+                        "size": stat.st_size,
+                        "mtime_ns": stat.st_mtime_ns,
+                        "device": stat.st_dev,
+                        "inode": stat.st_ino,
+                    }
+                    encoded = json.dumps(
+                        material,
+                        ensure_ascii=False,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    digest_total = (
+                        digest_total
+                        + int.from_bytes(
+                            hashlib.sha256(encoded).digest(), byteorder="big"
+                        )
+                    ) % (1 << 256)
+                    total_bytes += stat.st_size
+                    records += 1
+                    timestamp = _iso_from_ns(stat.st_mtime_ns)
+                    oldest_at = min(value for value in (oldest_at, timestamp) if value)
+                    newest_at = _later_timestamp(newest_at, timestamp)
+        except OSError as exc:
+            return {"error": str(exc)}
+    return {
+        "bytes": total_bytes,
+        "records": records,
+        "oldest_at": oldest_at,
+        "newest_at": newest_at,
+        "snapshot_digest": f"{digest_total:064x}",
+    }
+
+
+def _repository_containers(repositories: tuple[str, ...]) -> dict[str, str]:
+    result = {}
+    for repository in repositories:
+        owner, name = repository.casefold().split("/", 1)
+        result[f"{owner}__{name}"] = repository.casefold()
+    return result
+
+
+def scan_workspaces(
+    workspace_root: Path,
+    *,
+    repositories: tuple[str, ...],
+    runs: dict[str, dict[str, Any]],
+    paths: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Inventory managed workspace directories in O(total directory entries)."""
+    root = _absolute(workspace_root)
+    if not root.exists():
+        return {"items": [], "errors": []}
+    if root.is_symlink() or not root.is_dir():
+        return {
+            "items": [],
+            "errors": [{"path": ".", "reason": "workspace_root_not_safe"}],
+        }
+
+    run_paths: dict[Path, list[dict[str, Any]]] = {}
+    for run_id, raw in runs.items():
+        worktree = str(raw.get("worktree") or "").strip()
+        if not worktree:
+            continue
+        path = _absolute(Path(worktree))
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        run_paths.setdefault(path, []).append({"id": str(run_id), **raw})
+
+    containers = _repository_containers(repositories)
+    selected_containers = (
+        {PurePosixPath(value).parts[0] for value in paths if PurePosixPath(value).parts}
+        if paths is not None
+        else None
+    )
+    items: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    try:
+        with os.scandir(root) as iterator:
+            repository_entries = sorted(iterator, key=lambda entry: entry.name)
+    except OSError as exc:
+        return {"items": [], "errors": [{"path": ".", "reason": str(exc)}]}
+
+    for repository_entry in repository_entries:
+        if (
+            selected_containers is not None
+            and repository_entry.name not in selected_containers
+        ):
+            continue
+        if repository_entry.is_symlink() or not repository_entry.is_dir(
+            follow_symlinks=False
+        ):
+            continue
+        repository_path = Path(repository_entry.path)
+        try:
+            with os.scandir(repository_path) as iterator:
+                workspace_entries = sorted(iterator, key=lambda entry: entry.name)
+        except OSError as exc:
+            errors.append(
+                {
+                    "path": repository_path.relative_to(root).as_posix(),
+                    "reason": str(exc),
+                }
+            )
+            continue
+        for workspace_entry in workspace_entries:
+            if not MANAGED_WORKSPACE.fullmatch(workspace_entry.name):
+                continue
+            path = Path(workspace_entry.path)
+            relative = path.relative_to(root).as_posix()
+            if paths is not None and relative not in paths:
+                continue
+            states = sorted(
+                run_paths.get(_absolute(path), []), key=lambda value: value["id"]
+            )
+            run_repositories = {
+                str(value.get("repository") or "").casefold()
+                for value in states
+                if value.get("repository")
+            }
+            repository = containers.get(repository_entry.name.casefold(), "")
+            if not repository and len(run_repositories) == 1:
+                repository = next(iter(run_repositories))
+            repository = repository or "*"
+            if workspace_entry.is_symlink():
+                items.append(
+                    {
+                        "kind": WORKSPACE_KIND,
+                        "path": relative,
+                        "repository": repository,
+                        "run_states": states,
+                        "scan_error": "workspace_symlink",
+                    }
+                )
+                continue
+            if not workspace_entry.is_dir(follow_symlinks=False):
+                continue
+            try:
+                root_stat = path.lstat()
+            except OSError as exc:
+                errors.append({"path": relative, "reason": str(exc)})
+                continue
+            snapshot = _tree_snapshot(path)
+            if snapshot.get("error"):
+                items.append(
+                    {
+                        "kind": WORKSPACE_KIND,
+                        "path": relative,
+                        "repository": repository,
+                        "run_states": states,
+                        "scan_error": str(snapshot["error"]),
+                    }
+                )
+                continue
+            created_at = _iso_from_ns(root_stat.st_mtime_ns)
+            run_updated_at = max(
+                (str(value.get("updated_at") or "") for value in states), default=""
+            )
+            items.append(
+                {
+                    "kind": WORKSPACE_KIND,
+                    "path": relative,
+                    "repository": repository,
+                    "run_states": states,
+                    "run_ids": [value["id"] for value in states],
+                    "bytes": int(snapshot["bytes"]),
+                    "records": int(snapshot["records"]),
+                    "created_at": created_at,
+                    "last_activity_at": _later_timestamp(
+                        str(snapshot["newest_at"]), run_updated_at
+                    ),
+                    "oldest_at": str(snapshot["oldest_at"]),
+                    "newest_at": str(snapshot["newest_at"]),
+                    "mtime_ns": root_stat.st_mtime_ns,
+                    "device": root_stat.st_dev,
+                    "inode": root_stat.st_ino,
+                    "snapshot_digest": str(snapshot["snapshot_digest"]),
+                }
+            )
+    return {"items": items, "errors": errors}
+
+
+def workspace_statistics(
+    inventory: dict[str, Any], *, repository: str, cutoff: str
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    groups: dict[str, dict[str, Any]] = {}
+    errors = list(inventory.get("errors", ()))
+    for item in inventory.get("items", ()):
+        item_repository = str(item.get("repository") or "*")
+        if repository and item_repository != repository:
+            continue
+        if item.get("scan_error"):
+            errors.append(
+                {"path": str(item["path"]), "reason": str(item["scan_error"])}
+            )
+            continue
+        last_activity = str(item["last_activity_at"])
+        if cutoff and last_activity < cutoff:
+            continue
+        group = groups.setdefault(
+            item_repository,
+            {
+                "repository": item_repository,
+                "category": WORKSPACE_KIND,
+                "records": 0,
+                "bytes": 0,
+                "oldest_at": "",
+                "newest_at": "",
+            },
+        )
+        group["records"] += 1
+        group["bytes"] += int(item["bytes"])
+        group["oldest_at"] = min(
+            value for value in (group["oldest_at"], item["created_at"]) if value
+        )
+        group["newest_at"] = _later_timestamp(str(group["newest_at"]), last_activity)
+    return list(groups.values()), errors
+
+
+def _git(workspace: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-c", "core.fsmonitor=false", *arguments],
+        cwd=workspace,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **sanitized_environment(keep_codex_credentials=False),
+            "GIT_OPTIONAL_LOCKS": "0",
+        },
+    )
+
+
+def _git_recovery_state(
+    workspace: Path, run_states: list[dict[str, Any]]
+) -> dict[str, Any]:
+    status = _git(
+        workspace,
+        "status",
+        "--porcelain=v2",
+        "--branch",
+        "--untracked-files=all",
+    )
+    if status.returncode:
+        return {"reason": "git_status_unavailable", "head_commit": ""}
+    lines = status.stdout.splitlines()
+    head_commit = next(
+        (
+            line.removeprefix("# branch.oid ").strip()
+            for line in lines
+            if line.startswith("# branch.oid ")
+        ),
+        "",
+    )
+    if not re.fullmatch(r"[a-f0-9]{40,64}", head_commit):
+        return {"reason": "not_git_workspace", "head_commit": ""}
+    if any(line and not line.startswith("# ") for line in lines):
+        return {"reason": "dirty_workspace", "head_commit": head_commit}
+    submitted = any(
+        str(value.get("status") or "") == "submitted"
+        and str(value.get("head_commit") or "") == head_commit
+        for value in run_states
+    )
+    if not submitted:
+        remote_refs = _git(
+            workspace,
+            "for-each-ref",
+            "--contains",
+            head_commit,
+            "--format=%(refname)",
+            "refs/remotes",
+        )
+        submitted = remote_refs.returncode == 0 and bool(remote_refs.stdout.strip())
+    return {
+        "reason": "" if submitted else "unpushed_commits",
+        "head_commit": head_commit,
+    }
+
+
+def workspace_gc_inventory(
+    workspace_root: Path,
+    *,
+    repositories: tuple[str, ...],
+    runs: dict[str, dict[str, Any]],
+    repository: str,
+    cutoff: str,
+    paths: frozenset[str] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    inventory = scan_workspaces(
+        workspace_root,
+        repositories=repositories,
+        runs=runs,
+        paths=paths,
+    )
+    candidates = []
+    retained = []
+    for raw in inventory["items"]:
+        item = dict(raw)
+        item.setdefault("bytes", 0)
+        item.setdefault("created_at", "")
+        item.setdefault("last_activity_at", "")
+        item.setdefault("run_ids", [])
+        item_repository = str(item.get("repository") or "*")
+        if repository and item_repository != repository:
+            continue
+        run_states = list(item.pop("run_states", ()))
+        reasons: set[str] = set()
+        if item.pop("scan_error", ""):
+            reasons.add("workspace_scan_unsafe")
+        if not run_states:
+            reasons.add("unknown_run")
+        run_repositories = {
+            str(value.get("repository") or "").casefold() for value in run_states
+        }
+        if run_repositories and run_repositories != {item_repository}:
+            reasons.add("repository_mismatch")
+        if any(str(value.get("status") or "") == "running" for value in run_states):
+            reasons.add("active_run")
+        if any(
+            str(value.get("status") or "") not in TERMINAL_RUN_STATUSES
+            or not bool(value.get("terminal_checkpoint"))
+            for value in run_states
+        ):
+            reasons.add("no_terminal_checkpoint")
+        last_activity = str(item.get("last_activity_at") or "")
+        if not last_activity or last_activity >= cutoff:
+            reasons.add("within_workspace_retention")
+        if not reasons:
+            git_state = _git_recovery_state(
+                _absolute(workspace_root) / str(item["path"]), run_states
+            )
+            item["head_commit"] = git_state["head_commit"]
+            if git_state["reason"]:
+                reasons.add(str(git_state["reason"]))
+        if reasons:
+            item["reasons"] = sorted(reasons)
+            retained.append(item)
+        else:
+            item["reason"] = "expired_recoverable_terminal_workspace"
+            candidates.append(item)
+    for error in inventory["errors"]:
+        retained.append(
+            {
+                "kind": WORKSPACE_KIND,
+                "path": str(error["path"]),
+                "repository": "*",
+                "bytes": 0,
+                "created_at": "",
+                "reasons": ["workspace_scan_unsafe"],
+            }
+        )
+    key = lambda value: (str(value.get("created_at") or ""), str(value["path"]))
+    return {
+        "candidates": sorted(candidates, key=key),
+        "retained": sorted(retained, key=key),
+    }
+
+
+def delete_workspace(workspace_root: Path, candidate: dict[str, Any]) -> None:
+    relative = PurePosixPath(str(candidate["path"]))
+    if (
+        relative.is_absolute()
+        or len(relative.parts) != 2
+        or any(part in {"", ".", ".."} for part in relative.parts)
+        or not MANAGED_WORKSPACE.fullmatch(relative.parts[1])
+    ):
+        raise OSError("workspace path no longer satisfies the managed layout")
+    root = _absolute(workspace_root)
+    parent = root / relative.parts[0]
+    target = parent / relative.parts[1]
+    if root.is_symlink() or parent.is_symlink() or target.is_symlink():
+        raise OSError("workspace path became a symlink")
+    try:
+        stat = target.lstat()
+    except OSError as exc:
+        raise OSError("workspace no longer exists") from exc
+    if not target.is_dir():
+        raise OSError("workspace is no longer a directory")
+    if stat.st_dev != int(candidate["device"]) or stat.st_ino != int(
+        candidate["inode"]
+    ):
+        raise OSError("workspace identity changed after planning")
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise OSError("workspace escaped the configured root") from exc
+    shutil.rmtree(target)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,7 @@ cpus = 2
 image = "trusted-runner:latest"
 [storage]
 cache_retention_days = 45
+workspace_retention_days = 60
 max_gc_items = 500
 [context]
 follow_up_max_tokens = 9000
@@ -143,6 +144,7 @@ project_owner_type = "organization"
 require_distinct_reviewer = false
 [storage]
 cache_retention_days = 1
+workspace_retention_days = 1
 max_gc_items = 10000
 [context]
 follow_up_max_tokens = 100000
@@ -175,6 +177,7 @@ event_payload_retention_days = 45
         self.assertEqual(config.agent.harness, "codex-cli")
         self.assertEqual(config.agent.executable, "codex")
         self.assertEqual(config.storage.cache_retention_days, 45)
+        self.assertEqual(config.storage.workspace_retention_days, 60)
         self.assertEqual(config.storage.max_gc_items, 500)
         self.assertEqual(config.context.follow_up_max_tokens, 9_000)
         self.assertEqual(config.issue_review.project_owner, "")
@@ -220,6 +223,22 @@ event_payload_retention_days = 0
             )
 
             with self.assertRaisesRegex(ConfigError, "must be positive"):
+                load_config(path)
+
+    def test_workspace_retention_must_be_positive(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[storage]
+workspace_retention_days = 0
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "workspace_retention_days"):
                 load_config(path)
 
     def test_capacity_defaults_can_be_raised_by_user_and_tightened_by_project(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -40,6 +40,7 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(parsed["issue_review"]["project_number"], 0)
         self.assertTrue(parsed["issue_review"]["require_distinct_reviewer"])
         self.assertEqual(parsed["storage"]["cache_retention_days"], 30)
+        self.assertEqual(parsed["storage"]["workspace_retention_days"], 30)
         self.assertEqual(parsed["storage"]["max_gc_items"], 1000)
         self.assertEqual(parsed["context"]["follow_up_max_tokens"], 24_000)
         self.assertEqual(parsed["safety"]["max_active_pull_requests"], 4)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -32,6 +32,18 @@ class StubStore:
     def run_repositories(self) -> dict[str, str]:
         return {"run-1": "owner/repo"}
 
+    def run_gc_safety(self) -> dict[str, dict]:
+        return {
+            "run-1": {
+                "repository": "owner/repo",
+                "status": "submitted",
+                "worktree": "",
+                "updated_at": "2026-08-21T00:00:00+00:00",
+                "head_commit": "",
+                "terminal_checkpoint": True,
+            }
+        }
+
 
 class StorageStatisticsTests(unittest.TestCase):
     def test_statistics_include_safe_log_and_database_sizes(self) -> None:
@@ -47,6 +59,7 @@ class StorageStatisticsTests(unittest.TestCase):
             pipeline = object.__new__(Pipeline)
             pipeline.config = SimpleNamespace(
                 state_dir=root,
+                workspace_dir=root / "workspaces",
                 repositories={"owner/repo": policy},
             )
             pipeline.store = StubStore(root / "state.sqlite3")
@@ -116,6 +129,7 @@ class StorageGcTests(unittest.TestCase):
         pipeline = object.__new__(Pipeline)
         pipeline.config = SimpleNamespace(
             state_dir=root,
+            workspace_dir=root / "workspaces",
             storage=StorageConfig(cache_retention_days=30, max_gc_items=10),
             repositories={"owner/repo": policy},
             github=SimpleNamespace(login="operator"),

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -744,6 +744,59 @@ class StoreTests(unittest.TestCase):
             [value["stage"] for value in records], ["completed", "applying"]
         )
 
+    def test_run_gc_safety_includes_workspace_recovery_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            work_item = store.ensure_work_item(
+                "owner/repo",
+                kind="github_issue",
+                external_id="7",
+                title="Workspace lifecycle",
+            )
+            run_id = store.start_run("owner/repo", 7, "agent")
+            context = _context_payload(
+                pack_id="pack-workspace",
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                source_digest="a" * 64,
+                base_commit="b" * 40,
+            )
+            store.save_context_pack(
+                pack_id="pack-workspace",
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                schema_version=1,
+                source_digest=_context_source_digest("a" * 64),
+                base_commit="b" * 40,
+                payload=context,
+            )
+            store.update_run(
+                run_id,
+                status="submitted",
+                worktree="/tmp/reposteward-workspace",
+                details={"commit_sha": "c" * 40},
+            )
+            store.save_checkpoint(
+                work_item_id=work_item["id"],
+                run_id=run_id,
+                context_pack_id="pack-workspace",
+                status="submitted",
+                payload=_checkpoint_payload(
+                    work_item_id=work_item["id"],
+                    run_id=run_id,
+                    pack_id="pack-workspace",
+                    status="submitted",
+                ),
+            )
+
+            safety = store.run_gc_safety()[run_id]
+
+        self.assertEqual(safety["repository"], "owner/repo")
+        self.assertEqual(safety["status"], "submitted")
+        self.assertEqual(safety["worktree"], "/tmp/reposteward-workspace")
+        self.assertEqual(safety["head_commit"], "c" * 40)
+        self.assertTrue(safety["terminal_checkpoint"])
+
     def test_event_payload_gc_requires_retention_and_every_run_watermark(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             store = Store(Path(directory) / "state.sqlite3")

--- a/tests/test_workspace_storage.py
+++ b/tests/test_workspace_storage.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from reposteward import workspace_storage
+from reposteward.config import RepositoryPolicy, StorageConfig
+from reposteward.pipeline import Pipeline
+from reposteward.workspace_storage import (
+    delete_workspace,
+    scan_workspaces,
+    workspace_gc_inventory,
+    workspace_statistics,
+)
+
+OLD_TIMESTAMP = 1_577_836_800
+OLD_ISO = "2020-01-01T00:00:00+00:00"
+CUTOFF = "2026-01-01T00:00:00+00:00"
+
+
+def git(workspace: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=workspace,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def age_tree(path: Path) -> None:
+    for current, directories, files in os.walk(path, followlinks=False):
+        for name in [*directories, *files]:
+            os.utime(
+                Path(current) / name,
+                (OLD_TIMESTAMP, OLD_TIMESTAMP),
+                follow_symlinks=False,
+            )
+    os.utime(path, (OLD_TIMESTAMP, OLD_TIMESTAMP))
+
+
+def create_workspace(
+    root: Path, name: str = "issue-44-20200101T000000Z"
+) -> tuple[Path, str]:
+    workspace = root / "owner__repo" / name
+    workspace.mkdir(parents=True)
+    git(workspace, "init", "--quiet")
+    git(workspace, "config", "user.name", "RepoSteward Test")
+    git(workspace, "config", "user.email", "test@example.com")
+    (workspace / "tracked.txt").write_text("retained source\n", encoding="utf-8")
+    git(workspace, "add", "tracked.txt")
+    git(workspace, "commit", "--quiet", "-m", "test: seed workspace")
+    head = git(workspace, "rev-parse", "HEAD")
+    age_tree(workspace)
+    return workspace, head
+
+
+def run_state(workspace: Path, head: str, **overrides: object) -> dict[str, object]:
+    result: dict[str, object] = {
+        "repository": "owner/repo",
+        "status": "submitted",
+        "worktree": str(workspace),
+        "updated_at": OLD_ISO,
+        "head_commit": head,
+        "terminal_checkpoint": True,
+    }
+    result.update(overrides)
+    return result
+
+
+class WorkspaceStorageTests(unittest.TestCase):
+    def test_selected_rescan_does_not_inventory_unrelated_workspace_trees(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspaces"
+            selected, selected_head = create_workspace(root)
+            unrelated, unrelated_head = create_workspace(
+                root, "issue-45-20200101T000000Z"
+            )
+            runs = {
+                "run-1": run_state(selected, selected_head),
+                "run-2": run_state(unrelated, unrelated_head),
+            }
+
+            inventory = scan_workspaces(
+                root,
+                repositories=("owner/repo",),
+                runs=runs,
+                paths=frozenset({"owner__repo/issue-44-20200101T000000Z"}),
+            )
+
+        self.assertEqual(
+            [item["path"] for item in inventory["items"]],
+            ["owner__repo/issue-44-20200101T000000Z"],
+        )
+
+    def test_statistics_count_workspace_without_following_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            root = base / "workspaces"
+            workspace, head = create_workspace(root)
+            outside = base / "outside.bin"
+            outside.write_bytes(b"x" * 1_000_000)
+            outside_size = outside.stat().st_size
+            os.symlink(outside, workspace / "outside-link")
+            age_tree(workspace)
+            runs = {"run-1": run_state(workspace, head)}
+
+            inventory = scan_workspaces(root, repositories=("owner/repo",), runs=runs)
+            categories, errors = workspace_statistics(
+                inventory, repository="owner/repo", cutoff=""
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(categories), 1)
+        self.assertEqual(categories[0]["records"], 1)
+        self.assertLess(categories[0]["bytes"], outside_size)
+
+    def test_submitted_clean_terminal_workspace_becomes_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspaces"
+            workspace, head = create_workspace(root)
+
+            with patch(
+                "reposteward.workspace_storage._git", wraps=workspace_storage._git
+            ) as git_command:
+                result = workspace_gc_inventory(
+                    root,
+                    repositories=("owner/repo",),
+                    runs={"run-1": run_state(workspace, head)},
+                    repository="owner/repo",
+                    cutoff=CUTOFF,
+                )
+
+        self.assertEqual(len(result["candidates"]), 1)
+        self.assertEqual(result["retained"], [])
+        self.assertEqual(result["candidates"][0]["head_commit"], head)
+        self.assertEqual(git_command.call_count, 1)
+
+    def test_dirty_and_unpushed_workspaces_are_retained(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspaces"
+            workspace, head = create_workspace(root)
+            (workspace / "untracked.txt").write_text("local work\n", encoding="utf-8")
+            age_tree(workspace)
+
+            dirty = workspace_gc_inventory(
+                root,
+                repositories=("owner/repo",),
+                runs={"run-1": run_state(workspace, head)},
+                repository="owner/repo",
+                cutoff=CUTOFF,
+            )
+
+            (workspace / "untracked.txt").unlink()
+            age_tree(workspace)
+            unpushed = workspace_gc_inventory(
+                root,
+                repositories=("owner/repo",),
+                runs={
+                    "run-1": run_state(
+                        workspace,
+                        head,
+                        status="failed",
+                        head_commit="",
+                    )
+                },
+                repository="owner/repo",
+                cutoff=CUTOFF,
+            )
+
+        self.assertIn("dirty_workspace", dirty["retained"][0]["reasons"])
+        self.assertIn("unpushed_commits", unpushed["retained"][0]["reasons"])
+
+    def test_any_active_run_retains_a_shared_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspaces"
+            workspace, head = create_workspace(root)
+            runs = {
+                "run-1": run_state(workspace, head),
+                "run-2": run_state(
+                    workspace,
+                    head,
+                    status="running",
+                    terminal_checkpoint=False,
+                ),
+            }
+
+            result = workspace_gc_inventory(
+                root,
+                repositories=("owner/repo",),
+                runs=runs,
+                repository="owner/repo",
+                cutoff=CUTOFF,
+            )
+
+        reasons = result["retained"][0]["reasons"]
+        self.assertIn("active_run", reasons)
+        self.assertIn("no_terminal_checkpoint", reasons)
+
+    def test_workspace_symlink_is_never_followed_or_collected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            root = base / "workspaces"
+            container = root / "owner__repo"
+            container.mkdir(parents=True)
+            outside = base / "outside"
+            outside.mkdir()
+            (outside / "keep.txt").write_text("keep\n", encoding="utf-8")
+            link = container / "issue-44-20200101T000000Z"
+            os.symlink(outside, link, target_is_directory=True)
+
+            result = workspace_gc_inventory(
+                root,
+                repositories=("owner/repo",),
+                runs={},
+                repository="owner/repo",
+                cutoff=CUTOFF,
+            )
+
+            outside_preserved = (outside / "keep.txt").exists()
+
+        self.assertEqual(result["candidates"], [])
+        self.assertIn("workspace_scan_unsafe", result["retained"][0]["reasons"])
+        self.assertTrue(outside_preserved)
+
+    def test_delete_rejects_workspace_replaced_after_planning(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspaces"
+            workspace, head = create_workspace(root)
+            result = workspace_gc_inventory(
+                root,
+                repositories=("owner/repo",),
+                runs={"run-1": run_state(workspace, head)},
+                repository="owner/repo",
+                cutoff=CUTOFF,
+            )
+            candidate = result["candidates"][0]
+            original = workspace.with_name(f"{workspace.name}-original")
+            workspace.rename(original)
+            workspace.mkdir()
+            (workspace / "keep.txt").write_text("replacement\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(OSError, "identity changed"):
+                delete_workspace(root, candidate)
+
+            self.assertTrue((workspace / "keep.txt").exists())
+
+
+class WorkspaceGcStore:
+    def __init__(self, safety: dict[str, dict[str, object]]) -> None:
+        self.safety = safety
+        self.audit: list[str] = []
+
+    def run_gc_safety(self) -> dict[str, dict[str, object]]:
+        return self.safety
+
+    def event_payload_gc_inventory(self, _cutoffs: dict[str, str]) -> dict:
+        return {"candidates": [], "retained": []}
+
+    def delete_event_payloads(
+        self, _digests: tuple[str, ...], *, retention_cutoffs: dict[str, str]
+    ) -> dict:
+        return {"deleted": [], "skipped": []}
+
+    def record_storage_gc(self, *, stage: str, **_kwargs: object) -> dict[str, str]:
+        self.audit.append(stage)
+        return {"id": f"audit-{len(self.audit)}", "stage": stage}
+
+
+class WorkspaceGcPipelineTests(unittest.TestCase):
+    def test_apply_deletes_reviewed_workspace_and_audits_transition(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            root = base / "workspaces"
+            workspace, head = create_workspace(root)
+            store = WorkspaceGcStore({"run-1": run_state(workspace, head)})
+            policy = RepositoryPolicy(name="owner/repo")
+            pipeline = object.__new__(Pipeline)
+            pipeline.config = SimpleNamespace(
+                state_dir=base / "state",
+                workspace_dir=root,
+                storage=StorageConfig(
+                    cache_retention_days=30,
+                    workspace_retention_days=30,
+                    max_gc_items=10,
+                ),
+                repositories={"owner/repo": policy},
+                github=SimpleNamespace(login="operator"),
+            )
+            pipeline.store = store
+
+            plan = pipeline.storage_gc(repository="owner/repo")
+            with patch.dict("os.environ", {"REPOSTEWARD_ENABLE_GC": "1"}):
+                applied = pipeline.storage_gc(repository="owner/repo", apply=True)
+
+            workspace_exists = workspace.exists()
+
+        self.assertEqual(plan["candidate_count"], 1)
+        self.assertTrue(plan["dry_run"])
+        self.assertFalse(workspace_exists)
+        self.assertEqual(store.audit, ["applying", "completed"])
+        self.assertEqual(len(applied["applied"]["deleted_workspaces"]), 1)
+        self.assertEqual(applied["applied"]["skipped_workspaces"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

Closes #44

## 问题与改动

RepoSteward 会持续创建隔离工作区，但原有存储统计和 GC 只覆盖数据库载荷与验证日志，终态工作区会长期占用磁盘，也没有足够证据判断是否可安全删除。

本 PR 将 RepoSteward 管理的工作区纳入 `storage stats` 和 `storage gc`：扫描只读取文件系统元数据且不跟随符号链接；GC 默认仍为 dry-run，只有超过用户级保留期、所有关联 run 均到达终态 Checkpoint、Git 状态干净且 HEAD 已由 submitted run 或远端引用证明可恢复时，工作区才会成为候选。apply 会再次核对目录身份、元数据快照、HEAD 和 run 状态，变化即跳过，并把删除或跳过结果写入现有 applying/completed 审计。

同时新增用户级 `storage.workspace_retention_days`（默认 30 天），同步初始化配置、示例、README 和架构说明。

## 验证

```text
uv run python -m unittest discover -s tests -v          # 272 tests passed
uv run ruff check .                                     # passed
uv run ruff format --check .                            # passed
uv run reposteward --help                               # passed
uv build --no-build-isolation                           # passed
```

以上命令已由 RepoSteward adopt 在隔离 Runner 中执行；依赖 Bootstrap 可联网，五项验证均在无网络容器中完成。ready run：`45882ae9c3224736a662cfd06458211f`。

## 风险与兼容性

- 不修改数据库 schema；`run_gc_safety()` 只扩展内部查询结果，历史 run 无需迁移。
- 实际删除仍同时要求 `--apply` 与 `REPOSTEWARD_ENABLE_GC=1`，不会改变默认只读行为。
- stats/dry-run 对每个纳管工作区执行一次线性元数据扫描；只有已过期且状态安全的工作区才执行 Git 检查。apply 的二次校验只重扫计划候选，不重扫所有近期工作区。
- 脏工作区、未推送提交、活跃或未知 run、缺少终态 Checkpoint、路径异常及工作区符号链接均 fail closed 并保留。

## 自动化辅助

使用 Codex 在独立分支和工作区中实现与测试；提交者已复核完整 diff、删除不变量、路径与符号链接处理、Git 可恢复性判断、扫描复杂度、文档和验证记录，并对本贡献负责。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
