### PR TITLE
fix(cli): preserve logs subcommand dispatch

### DIFF
--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -168,6 +168,7 @@ def _parser() -> argparse.ArgumentParser:
     logs.add_argument("run_id")
     logs.add_argument(
         "--command",
+        dest="log_command",
         type=int,
         default=None,
         help="one-based verification command number",
@@ -515,7 +516,7 @@ def main(argv: list[str] | None = None) -> int:
             _json(
                 pipeline.run_logs(
                     args.run_id,
-                    command_number=args.command,
+                    command_number=args.log_command,
                     tail_chars=args.tail_chars,
                 )
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,28 @@ class CliSetupTests(unittest.TestCase):
         pipeline.ci_failure_analysis.assert_called_once_with("owner/repo", 12)
         self.assertIn('"public_write": false', output.getvalue())
 
+    def test_logs_list_and_tail_are_routed_without_overwriting_command(self) -> None:
+        pipeline = MagicMock()
+        pipeline.run_logs.return_value = {"logs": [], "public_write": False}
+
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+            redirect_stdout(io.StringIO()),
+        ):
+            list_code = main(["logs", "run-1"])
+            tail_code = main(["logs", "run-1", "--command", "2", "--tail-chars", "321"])
+
+        self.assertEqual(list_code, 0)
+        self.assertEqual(tail_code, 0)
+        self.assertEqual(
+            pipeline.run_logs.call_args_list,
+            [
+                unittest.mock.call("run-1", command_number=None, tail_chars=12000),
+                unittest.mock.call("run-1", command_number=2, tail_chars=321),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #46

Keep the top-level logs dispatch key separate from the optional verification command number.

---

Uses argparse dest=log_command and covers both list and bounded-tail CLI routes.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
