### PR TITLE
fix(verifier): isolate dependency environment

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,11 @@ local draft ── explicit stage ──► Project Draft Issue
 - Runner 只安装依赖并执行已允许的验证命令，不接触宿主凭据。
 - 人类审阅者决定是否发布，并对最终提交负责。
 
+Runner 不把宿主工作区直接以读写方式交给容器。每次验证先创建一份临时快照，
+Bootstrap 和后续无网络命令共享该快照及专用 HOME/工具缓存，因此依赖只安装一次，
+但宿主 `.venv`、`node_modules` 和其他本地环境不会被替换。Git 元数据单独只读挂载；
+快照在成功或失败后都会清理，运行目录只保留有界日志和清理清单供审计。
+
 ## 仓库级 PR 组合视图
 
 单个 run 的 Checkpoint 不能回答多个开放 PR 是否修改同一批文件。Portfolio Inspector 因此从

--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
+import shutil
 import subprocess
+import tempfile
 import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from itertools import chain
 from pathlib import Path
 
 from .config import AppConfig, RepositoryPolicy
@@ -16,6 +23,25 @@ DANGEROUS_COMMAND = re.compile(
     re.IGNORECASE,
 )
 MAX_VERIFICATION_COMMANDS = 12
+UNTRACKED_SANDBOX_EXCLUDED_NAMES = frozenset(
+    {
+        ".git",
+        ".gradle",
+        ".mypy_cache",
+        ".nox",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "credentials",
+        "node_modules",
+        "secrets",
+        "target",
+        "venv",
+    }
+)
+SENSITIVE_SANDBOX_NAMES = frozenset({"credentials", "secrets"})
 
 
 class VerificationError(RuntimeError):
@@ -79,42 +105,214 @@ class DockerVerifier:
                 "missing required verification: " + ", ".join(missing_markers),
             )
 
-        results: list[CommandResult] = []
         verification_dir = run_dir / "verification" if run_dir is not None else None
-        if policy.bootstrap_commands:
-            bootstrap = " && ".join(policy.bootstrap_commands)
-            result = self._run_container(
-                worktree,
-                bootstrap,
-                network=True,
-                log_path=(
-                    verification_dir / "00-bootstrap.log"
-                    if verification_dir is not None
-                    else None
-                ),
-            )
-            results.append(result)
-            if result.exit_code:
-                return VerificationResult(
-                    False, tuple(results), "dependency bootstrap failed"
+        results: list[CommandResult] = []
+        with self._verification_sandbox(worktree, verification_dir) as sandbox:
+            sandbox_worktree, environment_dir, git_dir = sandbox
+            if policy.bootstrap_commands:
+                bootstrap = " && ".join(policy.bootstrap_commands)
+                result = self._run_container(
+                    sandbox_worktree,
+                    bootstrap,
+                    network=True,
+                    log_path=(
+                        verification_dir / "00-bootstrap.log"
+                        if verification_dir is not None
+                        else None
+                    ),
+                    environment_dir=environment_dir,
+                    git_dir=git_dir,
                 )
-        for index, command in enumerate(commands, start=1):
-            result = self._run_container(
-                worktree,
-                command,
-                network=False,
-                log_path=(
-                    verification_dir / f"{index:02d}-command.log"
-                    if verification_dir is not None
-                    else None
-                ),
-            )
-            results.append(result)
-            if result.exit_code:
-                return VerificationResult(
-                    False, tuple(results), f"verification failed: {command}"
+                results.append(result)
+                if result.exit_code:
+                    return VerificationResult(
+                        False, tuple(results), "dependency bootstrap failed"
+                    )
+            for index, command in enumerate(commands, start=1):
+                result = self._run_container(
+                    sandbox_worktree,
+                    command,
+                    network=False,
+                    log_path=(
+                        verification_dir / f"{index:02d}-command.log"
+                        if verification_dir is not None
+                        else None
+                    ),
+                    environment_dir=environment_dir,
+                    git_dir=git_dir,
                 )
-        return VerificationResult(True, tuple(results))
+                results.append(result)
+                if result.exit_code:
+                    return VerificationResult(
+                        False, tuple(results), f"verification failed: {command}"
+                    )
+            return VerificationResult(True, tuple(results))
+
+    @staticmethod
+    def _sandbox_ignore(_directory: str, names: list[str]) -> set[str]:
+        return {
+            name
+            for name in names
+            if name in UNTRACKED_SANDBOX_EXCLUDED_NAMES
+            or name == ".env"
+            or name.startswith(".env.")
+        }
+
+    @staticmethod
+    def _git_file_list(worktree: Path, *arguments: str) -> tuple[Path, ...]:
+        listing = subprocess.run(
+            ["git", "ls-files", *arguments, "-z"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            env={"PATH": os.environ.get("PATH", "")},
+        ).stdout
+        return tuple(Path(os.fsdecode(raw)) for raw in listing.split(b"\0") if raw)
+
+    @staticmethod
+    def _sensitive_path(relative: Path) -> bool:
+        return any(
+            part.casefold() in SENSITIVE_SANDBOX_NAMES
+            or part.casefold() == ".env"
+            or part.casefold().startswith(".env.")
+            for part in relative.parts
+        )
+
+    @classmethod
+    def _copy_workspace(cls, worktree: Path, target: Path) -> int:
+        """Copy tracked and non-ignored untracked files without scanning caches."""
+        tracked = cls._git_file_list(worktree, "--cached")
+        untracked = cls._git_file_list(worktree, "--others", "--exclude-standard")
+        target.mkdir(parents=True)
+        copied = 0
+        entries = chain(
+            ((value, True) for value in tracked),
+            ((value, False) for value in untracked),
+        )
+        for relative, is_tracked in entries:
+            if relative.is_absolute() or ".." in relative.parts:
+                raise VerificationError("Git returned an unsafe workspace path")
+            if cls._sensitive_path(relative):
+                if is_tracked:
+                    raise VerificationError(
+                        f"tracked sensitive path cannot enter verification: {relative}"
+                    )
+                continue
+            if not is_tracked and any(
+                part in UNTRACKED_SANDBOX_EXCLUDED_NAMES for part in relative.parts
+            ):
+                continue
+            source = worktree / relative
+            destination = target / relative
+            if source.is_symlink():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.symlink_to(os.readlink(source))
+            elif source.is_file():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination, follow_symlinks=False)
+            elif source.is_dir():
+                shutil.copytree(
+                    source,
+                    destination,
+                    symlinks=True,
+                    ignore=cls._sandbox_ignore,
+                    ignore_dangling_symlinks=True,
+                )
+            else:
+                continue
+            copied += 1
+        return copied
+
+    @staticmethod
+    def _git_paths(worktree: Path) -> tuple[Path, str]:
+        def resolve(value: str) -> Path:
+            path = Path(value)
+            return (
+                (worktree / path).resolve()
+                if not path.is_absolute()
+                else path.resolve()
+            )
+
+        common = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            text=True,
+            env={"PATH": os.environ.get("PATH", "")},
+        ).stdout.strip()
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            text=True,
+            env={"PATH": os.environ.get("PATH", "")},
+        ).stdout.strip()
+        common_path = resolve(common)
+        git_path = resolve(git_dir)
+        relative = git_path.relative_to(common_path)
+        container_git_dir = "/reposteward-git"
+        if relative.parts:
+            container_git_dir += "/" + relative.as_posix()
+        return common_path, container_git_dir
+
+    @contextmanager
+    def _verification_sandbox(
+        self, worktree: Path, verification_dir: Path | None
+    ) -> Iterator[tuple[Path, Path, Path]]:
+        temporary = None
+        if verification_dir is None:
+            temporary = tempfile.TemporaryDirectory(prefix="reposteward-verify-")
+            parent = Path(temporary.name)
+        else:
+            verification_dir.mkdir(parents=True, exist_ok=True)
+            parent = verification_dir
+        sandbox_root = parent / f"sandbox-{uuid.uuid4().hex}"
+        sandbox_worktree = sandbox_root / "workspace"
+        environment_dir = sandbox_root / "environment"
+        manifest_path = verification_dir / "sandbox.json" if verification_dir else None
+        common_git_dir: Path | None = None
+        try:
+            common_git_dir, container_git_dir = self._git_paths(worktree)
+            copied_files = self._copy_workspace(worktree, sandbox_worktree)
+            environment_dir.mkdir(parents=True)
+            (sandbox_worktree / ".git").write_text(
+                f"gitdir: {container_git_dir}\n", encoding="utf-8"
+            )
+            if manifest_path is not None:
+                manifest_path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "sandbox": "ephemeral_copy",
+                            "excluded_untracked_names": sorted(
+                                UNTRACKED_SANDBOX_EXCLUDED_NAMES
+                            ),
+                            "host_workspace_writable": False,
+                            "shared_dependency_environment": True,
+                            "copied_entries": copied_files,
+                            "cleaned": False,
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            yield sandbox_worktree, environment_dir, common_git_dir
+        finally:
+            if sandbox_root.exists():
+                shutil.rmtree(sandbox_root)
+            if manifest_path is not None and manifest_path.exists():
+                payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+                payload["cleaned"] = True
+                manifest_path.write_text(
+                    json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+            if temporary is not None:
+                temporary.cleanup()
 
     @staticmethod
     def _validate_command(command: str, policy: RepositoryPolicy) -> None:
@@ -140,8 +338,11 @@ class DockerVerifier:
         *,
         network: bool,
         log_path: Path | None = None,
+        environment_dir: Path | None = None,
+        git_dir: Path | None = None,
     ) -> CommandResult:
         runner = self.config.runner
+        environment_dir = environment_dir or worktree
         shell_command = f'mkdir -p "$HOME" && {command}'
         docker_command = [
             "docker",
@@ -164,18 +365,35 @@ class DockerVerifier:
             "--tmpfs",
             "/tmp:rw,exec,nosuid,nodev,size=2g",
             "-e",
-            "HOME=/tmp/reposteward-home",
+            "HOME=/reposteward-env/home",
             "-e",
             "CI=1",
+            "-e",
+            "XDG_CACHE_HOME=/reposteward-env/cache",
+            "-e",
+            "UV_CACHE_DIR=/reposteward-env/uv-cache",
+            "-e",
+            "UV_TOOL_DIR=/reposteward-env/uv-tools",
+            "-e",
+            "UV_PYTHON_INSTALL_DIR=/reposteward-env/uv-python",
+            "-e",
+            "PIP_CACHE_DIR=/reposteward-env/pip-cache",
+            "-e",
+            "npm_config_cache=/reposteward-env/npm-cache",
+            "-e",
+            "PNPM_HOME=/reposteward-env/pnpm-home",
+            "-e",
+            "GRADLE_USER_HOME=/reposteward-env/gradle",
             "-v",
             f"{worktree.resolve()}:/workspace:rw",
+            "-v",
+            f"{environment_dir.resolve()}:/reposteward-env:rw",
             "-w",
             "/workspace",
-            runner.image,
-            "bash",
-            "-lc",
-            shell_command,
         ]
+        if git_dir is not None:
+            docker_command.extend(["-v", f"{git_dir.resolve()}:/reposteward-git:ro"])
+        docker_command.extend([runner.image, "bash", "-lc", shell_command])
         start = time.monotonic()
         try:
             result = subprocess.run(

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from reposteward.config import RepositoryPolicy, RunnerConfig
+from reposteward.models import AgentResult, CommandResult
+from reposteward.verifier import DockerVerifier, VerificationError
+
+
+def _repository(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=root, check=True
+    )
+    (root / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=root, check=True)
+
+
+class VerificationSandboxTests(unittest.TestCase):
+    def _verifier(self) -> DockerVerifier:
+        verifier = DockerVerifier(
+            SimpleNamespace(
+                runner=RunnerConfig(),
+                safety=SimpleNamespace(require_verification=True),
+            )
+        )
+        verifier.image_available = lambda: True  # type: ignore[method-assign]
+        return verifier
+
+    def test_bootstrap_and_offline_commands_share_only_the_ephemeral_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / ".venv").mkdir()
+            (worktree / ".venv" / "host-marker").write_text("host")
+            (worktree / "node_modules").mkdir()
+            (worktree / ".env").write_text("SECRET=value\n")
+            run_dir = root / "run"
+            observed: list[tuple[Path, Path, bool]] = []
+
+            def run_container(
+                sandbox: Path,
+                command: str,
+                *,
+                network: bool,
+                log_path: Path | None = None,
+                environment_dir: Path | None = None,
+                git_dir: Path | None = None,
+            ) -> CommandResult:
+                assert environment_dir is not None
+                assert git_dir is not None
+                observed.append((sandbox, environment_dir, network))
+                self.assertNotEqual(sandbox, worktree)
+                self.assertFalse((sandbox / "node_modules").exists())
+                self.assertFalse((sandbox / ".env").exists())
+                if network:
+                    (sandbox / ".venv").mkdir()
+                    (environment_dir / "cache-marker").write_text("cached")
+                else:
+                    self.assertTrue((sandbox / ".venv").is_dir())
+                    self.assertTrue((environment_dir / "cache-marker").is_file())
+                return CommandResult(command, 0, "", 0.01)
+
+            verifier = self._verifier()
+            verifier._run_container = run_container  # type: ignore[method-assign]
+            policy = RepositoryPolicy(
+                name="owner/repo",
+                bootstrap_commands=("uv sync",),
+                verification_prefixes=("uv run ",),
+            )
+            result = verifier.verify(
+                worktree,
+                policy,
+                AgentResult("summary", "fix(repo): test", "notes", ("uv run test",)),
+                run_dir=run_dir,
+            )
+            manifest = json.loads(
+                (run_dir / "verification" / "sandbox.json").read_text()
+            )
+            host_marker = (worktree / ".venv" / "host-marker").read_text()
+
+        self.assertTrue(result.passed)
+        self.assertEqual([value[2] for value in observed], [True, False])
+        self.assertEqual(observed[0][0], observed[1][0])
+        self.assertEqual(observed[0][1], observed[1][1])
+        self.assertFalse(observed[0][0].exists())
+        self.assertEqual(host_marker, "host")
+        self.assertTrue(manifest["cleaned"])
+        self.assertFalse(manifest["host_workspace_writable"])
+
+    def test_failed_bootstrap_still_removes_the_sandbox(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            run_dir = root / "run"
+            sandbox_paths: list[Path] = []
+
+            def fail(sandbox: Path, command: str, **_kwargs: object) -> CommandResult:
+                sandbox_paths.append(sandbox)
+                return CommandResult(command, 1, "failed", 0.01)
+
+            verifier = self._verifier()
+            verifier._run_container = fail  # type: ignore[method-assign]
+            policy = RepositoryPolicy(
+                name="owner/repo",
+                bootstrap_commands=("uv sync",),
+                verification_prefixes=("uv run ",),
+            )
+            result = verifier.verify(
+                worktree,
+                policy,
+                AgentResult("summary", "fix(repo): test", "notes", ("uv run test",)),
+                run_dir=run_dir,
+            )
+
+            manifest = json.loads(
+                (run_dir / "verification" / "sandbox.json").read_text()
+            )
+            sandbox_exists = sandbox_paths[0].exists()
+
+        self.assertFalse(result.passed)
+        self.assertEqual(result.reason, "dependency bootstrap failed")
+        self.assertFalse(sandbox_exists)
+        self.assertTrue(manifest["cleaned"])
+
+    def test_tracked_dependency_named_path_is_copied(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            tracked_target = worktree / "target" / "source.txt"
+            tracked_target.parent.mkdir()
+            tracked_target.write_text("tracked source\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "target/source.txt"], cwd=worktree, check=True
+            )
+            destination = root / "snapshot"
+
+            copied = DockerVerifier._copy_workspace(worktree, destination)
+
+            self.assertGreaterEqual(copied, 2)
+            self.assertEqual(
+                (destination / "target" / "source.txt").read_text(encoding="utf-8"),
+                "tracked source\n",
+            )
+
+    def test_tracked_sensitive_path_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / ".ENV.test").write_text("SECRET=value\n", encoding="utf-8")
+            subprocess.run(["git", "add", ".ENV.test"], cwd=worktree, check=True)
+
+            with self.assertRaisesRegex(
+                VerificationError, "tracked sensitive path cannot enter verification"
+            ):
+                DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_container_receives_shared_cache_and_read_only_git_mounts(self) -> None:
+        verifier = self._verifier()
+        completed = subprocess.CompletedProcess(
+            args=["docker"], returncode=0, stdout="", stderr=""
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            environment = root / "environment"
+            git_dir = root / "git"
+            for path in (workspace, environment, git_dir):
+                path.mkdir()
+            with patch(
+                "reposteward.verifier.subprocess.run", return_value=completed
+            ) as run:
+                verifier._run_container(
+                    workspace,
+                    "uv run test",
+                    network=False,
+                    environment_dir=environment,
+                    git_dir=git_dir,
+                )
+
+        command = run.call_args.args[0]
+        self.assertIn(f"{workspace.resolve()}:/workspace:rw", command)
+        self.assertIn(f"{environment.resolve()}:/reposteward-env:rw", command)
+        self.assertIn(f"{git_dir.resolve()}:/reposteward-git:ro", command)
+        self.assertIn("none", command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #47

Run bootstrap and offline verification in one disposable workspace and dependency environment.

---

Copies tracked and non-ignored files, mounts Git metadata read-only, shares tool caches within the run, excludes untracked dependency/cache paths, rejects tracked sensitive paths, and cleans the sandbox on success or failure.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`, plus a real Docker bootstrap/offline verification run.

Areas for careful review:
- Snapshot cost is linear in tracked and non-ignored workspace files; dependency/cache directories are skipped only when untracked.
- Tracked `.env*`, `credentials`, or `secrets` paths fail closed instead of entering the verifier.
- Git metadata is mounted read-only; the host workspace and dependency directories are never mounted writable.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.