### PR TITLE
feat(harness): declare runtime capabilities

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,6 +234,11 @@ uv run reposteward context import handoff.json
 - 不得 push、创建 PR、访问 GitHub 凭据或绕过验证策略；
 - 不支持的 Harness 必须显式失败，不能静默回退到另一个供应商。
 
+适配器还必须声明版本化 `HarnessCapabilities`。控制面只依据能力决定是否使用原生
+session 恢复等可选路径，不根据供应商名称猜测行为。缺少声明、版本未知或状态为
+`unknown` 的能力一律按不支持处理，并使用 Context Pack 等可移植路径安全降级。
+`doctor` 会输出同一份清单，便于接入新 Harness 时审计实际能力。
+
 当前内置适配器为默认的 `codex-cli` 和显式可选的 `codex-sdk`，现有本地提交可通过
 `external-workspace` 路径纳管。SDK 会优先恢复已有 thread；原生 thread 不存在或属于其他
 账号时，从 Context Pack 创建新 thread。Claude Code 和 DeepSeek 适配器仍可作为独立、小范围

--- a/src/reposteward/agent.py
+++ b/src/reposteward/agent.py
@@ -8,7 +8,12 @@ from typing import Any
 
 from .config import AgentConfig
 from .context import ContextPack
-from .harness import HarnessRequest
+from .harness import (
+    SUPPORTED,
+    CapabilitySupport,
+    HarnessCapabilities,
+    HarnessRequest,
+)
 from .models import AgentExecution, AgentMetrics, AgentResult
 from .workspace import sanitized_environment
 
@@ -84,6 +89,13 @@ RESULT_SCHEMA = {
 
 class CodexCliHarness:
     name = "codex-cli"
+    capabilities = HarnessCapabilities(
+        schema_version=1,
+        workspace_write=SUPPORTED,
+        structured_result=SUPPORTED,
+        native_session_resume=CapabilitySupport("unsupported", "ephemeral_process"),
+        usage_metrics=CapabilitySupport("best_effort", "event_stream_optional"),
+    )
 
     def __init__(self, config: AgentConfig) -> None:
         self.config = config

--- a/src/reposteward/codex_sdk.py
+++ b/src/reposteward/codex_sdk.py
@@ -17,7 +17,7 @@ from .agent import (
     build_harness_prompt,
 )
 from .config import AgentConfig
-from .harness import HarnessRequest
+from .harness import SUPPORTED, CapabilitySupport, HarnessCapabilities, HarnessRequest
 from .models import AgentExecution, AgentMetrics, AgentResult
 from .workspace import sanitized_environment
 
@@ -33,6 +33,13 @@ class CodexSdkHarness:
     """Optional adapter for the official Python Codex SDK."""
 
     name = "codex-sdk"
+    capabilities = HarnessCapabilities(
+        schema_version=1,
+        workspace_write=SUPPORTED,
+        structured_result=SUPPORTED,
+        native_session_resume=SUPPORTED,
+        usage_metrics=CapabilitySupport("best_effort", "sdk_usage_optional"),
+    )
 
     def __init__(
         self, config: AgentConfig, *, sdk_module: ModuleType | Any = None

--- a/src/reposteward/doctor.py
+++ b/src/reposteward/doctor.py
@@ -7,12 +7,18 @@ from typing import Any
 
 from .config import AppConfig
 from .github import GitHubClient, GitHubError, resolve_authentication
+from .harness import create_harness, harness_capabilities
 from .verifier import DockerVerifier
 
 
 def run_doctor(config: AppConfig) -> tuple[dict[str, Any], bool]:
     report: dict[str, Any] = {
-        "harness": {"name": config.agent.harness},
+        "harness": {
+            "name": config.agent.harness,
+            "capabilities": harness_capabilities(
+                create_harness(config.agent)
+            ).to_dict(),
+        },
         "tools": {},
         "github": {},
         "runner": {},

--- a/src/reposteward/harness.py
+++ b/src/reposteward/harness.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from .config import AgentConfig, ConfigError
 from .context import ContextPack
@@ -17,13 +17,91 @@ class HarnessRequest:
     native_session_id: str = ""
 
 
+CapabilityState = Literal["supported", "unsupported", "best_effort", "unknown"]
+CAPABILITY_STATES = frozenset({"supported", "unsupported", "best_effort", "unknown"})
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySupport:
+    state: CapabilityState
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        if self.state not in CAPABILITY_STATES:
+            raise ValueError(f"invalid harness capability state: {self.state!r}")
+        if not isinstance(self.reason, str):
+            raise TypeError("harness capability reason must be a string")
+
+    @property
+    def supported(self) -> bool:
+        return self.state == "supported"
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessCapabilities:
+    """Versioned, harness-neutral facts used for conservative orchestration."""
+
+    schema_version: int
+    workspace_write: CapabilitySupport
+    structured_result: CapabilitySupport
+    native_session_resume: CapabilitySupport
+    usage_metrics: CapabilitySupport
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.schema_version, int) or isinstance(
+            self.schema_version, bool
+        ):
+            raise TypeError("harness capability schema version must be an integer")
+        for name in (
+            "workspace_write",
+            "structured_result",
+            "native_session_resume",
+            "usage_metrics",
+        ):
+            if not isinstance(getattr(self, name), CapabilitySupport):
+                raise TypeError(f"harness capability {name} has an invalid value")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def unknown(cls, reason: str = "capabilities_not_declared") -> HarnessCapabilities:
+        value = CapabilitySupport("unknown", reason)
+        return cls(1, value, value, value, value)
+
+
+SUPPORTED = CapabilitySupport("supported")
+
+
 @runtime_checkable
 class Harness(Protocol):
     """A coding harness that edits one workspace and returns a normalized result."""
 
     name: str
+    capabilities: HarnessCapabilities
 
     def run(self, request: HarnessRequest) -> HarnessExecution: ...
+
+
+def harness_capabilities(harness: object) -> HarnessCapabilities:
+    """Return declared capabilities, failing closed for legacy adapters."""
+    value = getattr(harness, "capabilities", None)
+    if (
+        isinstance(value, HarnessCapabilities)
+        and value.schema_version == 1
+        and all(
+            isinstance(getattr(value, name, None), CapabilitySupport)
+            and getattr(value, name).state in CAPABILITY_STATES
+            for name in (
+                "workspace_write",
+                "structured_result",
+                "native_session_resume",
+                "usage_metrics",
+            )
+        )
+    ):
+        return value
+    return HarnessCapabilities.unknown()
 
 
 def create_harness(config: AgentConfig) -> Harness:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -48,7 +48,7 @@ from .dependencies import (
 )
 from .discovery import score_issue
 from .github import GitHubClient, GitHubError, PullRequest, resolve_token
-from .harness import Harness, HarnessRequest, create_harness
+from .harness import Harness, HarnessRequest, create_harness, harness_capabilities
 from .issues import (
     attach_proposal_marker,
     issue_review_digest,
@@ -1383,8 +1383,13 @@ class Pipeline:
                 "base_commit": base_commit,
             }
             self._validate_contribution_contract(worktree, policy)
-            native_session_id = self.store.latest_harness_session(
-                str(work_item["id"]), self.harness.name
+            capabilities = harness_capabilities(self.harness)
+            native_session_id = (
+                self.store.latest_harness_session(
+                    str(work_item["id"]), self.harness.name
+                )
+                if capabilities.native_session_resume.supported
+                else ""
             )
             context = self._create_context(
                 candidate,
@@ -2745,8 +2750,13 @@ class Pipeline:
                 details=failure_details,
             )
             run_dir = self.config.state_dir / "runs" / run_id
-            native_session_id = self.store.latest_harness_session(
-                context.work_item_id, self.harness.name
+            capabilities = harness_capabilities(self.harness)
+            native_session_id = (
+                self.store.latest_harness_session(
+                    context.work_item_id, self.harness.name
+                )
+                if capabilities.native_session_resume.supported
+                else ""
             )
             execution = self.harness.run(
                 HarnessRequest(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -29,7 +29,7 @@ from reposteward.context_budget import (
     build_follow_up_context,
     estimate_tokens,
 )
-from reposteward.harness import create_harness
+from reposteward.harness import SUPPORTED, HarnessCapabilities, create_harness
 from reposteward.models import (
     AgentExecution,
     AgentMetrics,
@@ -624,6 +624,13 @@ class HarnessContractTests(unittest.TestCase):
 
             class FakeHarness:
                 name = "fake-harness"
+                capabilities = HarnessCapabilities(
+                    schema_version=1,
+                    workspace_write=SUPPORTED,
+                    structured_result=SUPPORTED,
+                    native_session_resume=SUPPORTED,
+                    usage_metrics=SUPPORTED,
+                )
 
                 def __init__(self) -> None:
                     self.request = None

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from reposteward.agent import CodexCliHarness
+from reposteward.codex_sdk import CodexSdkHarness
+from reposteward.config import AgentConfig, load_config
+from reposteward.doctor import run_doctor
+from reposteward.harness import (
+    CapabilitySupport,
+    HarnessCapabilities,
+    harness_capabilities,
+)
+
+
+class HarnessCapabilitiesTests(unittest.TestCase):
+    def test_builtin_harnesses_publish_versioned_capabilities(self) -> None:
+        cli = CodexCliHarness(AgentConfig())
+        sdk = CodexSdkHarness(AgentConfig(harness="codex-sdk"))
+
+        self.assertEqual(cli.capabilities.schema_version, 1)
+        self.assertTrue(cli.capabilities.workspace_write.supported)
+        self.assertTrue(cli.capabilities.structured_result.supported)
+        self.assertEqual(cli.capabilities.native_session_resume.state, "unsupported")
+        self.assertTrue(sdk.capabilities.native_session_resume.supported)
+        self.assertEqual(sdk.capabilities.usage_metrics.state, "best_effort")
+
+    def test_legacy_or_invalid_manifest_fails_closed(self) -> None:
+        class LegacyHarness:
+            name = "legacy"
+
+        class FutureHarness:
+            name = "future"
+            capabilities = HarnessCapabilities.unknown("future_schema")
+
+        class MalformedHarness:
+            name = "malformed"
+            capabilities = HarnessCapabilities.unknown("malformed")
+
+        future = FutureHarness()
+        object.__setattr__(future.capabilities, "schema_version", 2)
+        malformed = MalformedHarness()
+        object.__setattr__(malformed.capabilities, "native_session_resume", "supported")
+
+        for harness in (LegacyHarness(), future, malformed):
+            capabilities = harness_capabilities(harness)
+            self.assertEqual(capabilities.schema_version, 1)
+            self.assertEqual(capabilities.workspace_write.state, "unknown")
+            self.assertFalse(capabilities.native_session_resume.supported)
+
+    def test_capability_values_are_validated_at_construction(self) -> None:
+        with self.assertRaisesRegex(ValueError, "invalid harness capability state"):
+            CapabilitySupport("yes")  # type: ignore[arg-type]
+        with self.assertRaisesRegex(TypeError, "reason must be a string"):
+            CapabilitySupport("supported", 1)  # type: ignore[arg-type]
+
+    def test_manifest_serialization_contains_no_implicit_booleans(self) -> None:
+        payload = CodexCliHarness(AgentConfig()).capabilities.to_dict()
+
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(
+            payload["native_session_resume"],
+            {"state": "unsupported", "reason": "ephemeral_process"},
+        )
+        self.assertEqual(
+            payload["usage_metrics"],
+            {"state": "best_effort", "reason": "event_stream_optional"},
+        )
+
+    def test_doctor_reports_the_adapter_manifest(self) -> None:
+        config = load_config(Path("examples/tiammomo.toml"), include_user=False)
+        completed = SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+        with (
+            patch("reposteward.doctor.shutil.which", return_value="/bin/tool"),
+            patch("reposteward.doctor.subprocess.run", return_value=completed),
+            patch(
+                "reposteward.doctor.DockerVerifier.image_available",
+                return_value=True,
+            ),
+            patch(
+                "reposteward.doctor.resolve_authentication",
+                return_value=(None, "missing"),
+            ),
+        ):
+            report, ok = run_doctor(config)
+
+        self.assertFalse(ok)
+        self.assertEqual(report["harness"]["capabilities"]["schema_version"], 1)
+        self.assertEqual(
+            report["harness"]["capabilities"]["native_session_resume"]["state"],
+            "unsupported",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #48

Declare versioned Harness capabilities and use them for conservative orchestration.

---

Codex CLI and SDK now publish explicit workspace, structured-result, native-resume, and usage support. Doctor renders the manifest, while the pipeline resumes native sessions only when the adapter declares valid support. Legacy, future-version, or malformed manifests fall back to an unknown capability set.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, and `uv build --no-build-isolation`.

Areas for careful review:
- Custom Harnesses without a valid v1 manifest no longer receive a native session ID; they continue through the portable Context Pack fallback.
- Capability states are runtime validated and do not grant support through truthy strings or vendor-name inference.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.