### PR TITLE
feat(inbox): aggregate maintainer attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ uv run reposteward discover --repo owner/repository
 uv run reposteward list --all
 ```
 
+批量维护时，可用只读收件箱聚合待审提案、本地运行、CI、Review 和合并检查入口；
+该命令不会调用 Harness，也不会修改工作区或 GitHub：
+
+```bash
+uv run reposteward inbox --repo owner/repository --format text
+```
+
 检查贡献门禁并准备修复：
 
 ```bash

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -11,6 +11,7 @@ from .config import ConfigError, load_config
 from .dependencies import render_dependency_plan_text
 from .discovery import DiscoveryService
 from .doctor import run_doctor
+from .inbox import render_inbox_text
 from .issues import read_details
 from .pipeline import Pipeline
 from .portfolio import render_portfolio_text
@@ -278,6 +279,13 @@ def _parser() -> argparse.ArgumentParser:
     dependency_list.add_argument("repository")
     dependency_list.add_argument("--pull-number", type=int, default=0)
     dependency_list.add_argument("--limit", type=int, default=100)
+
+    inbox = subparsers.add_parser(
+        "inbox", help="aggregate maintainer attention without invoking a Harness"
+    )
+    inbox.add_argument("--repo", required=True, help="limit to owner/name")
+    inbox.add_argument("--limit", type=int, default=50)
+    inbox.add_argument("--format", choices=("json", "text"), default="json")
 
     follow_up = subparsers.add_parser(
         "follow-up",
@@ -600,6 +608,13 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
+            return 0
+        if args.command == "inbox":
+            result = pipeline.maintainer_inbox(args.repo, limit=args.limit)
+            if args.format == "text":
+                print(render_inbox_text(result))
+            else:
+                _json(result)
             return 0
         if args.command == "repair":
             _json(pipeline.prepare_repair(args.run_id))

--- a/src/reposteward/inbox.py
+++ b/src/reposteward/inbox.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+INBOX_SCHEMA_VERSION = 1
+MAX_TEXT_ITEMS = 100
+PULL_NUMBER = re.compile(r"/pull/([1-9][0-9]*)/?$")
+FAILED_CHECKS = {"failure", "timed_out", "cancelled", "action_required"}
+
+
+def _canonical_digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode()
+    ).hexdigest()
+
+
+def _pull_number(run: dict[str, Any]) -> int:
+    details = run.get("details")
+    if not isinstance(details, dict):
+        details = {}
+    url = str(details.get("pr_url") or run.get("submission_pr_url") or "")
+    match = PULL_NUMBER.search(url)
+    return int(match.group(1)) if match else 0
+
+
+def _item(
+    *,
+    item_id: str,
+    repository: str,
+    priority: int,
+    reason_code: str,
+    summary: str,
+    source_updated_at: str,
+    next_command: str,
+    run_id: str = "",
+    issue_number: int = 0,
+    pull_number: int = 0,
+) -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "repository": repository.casefold(),
+        "priority": priority,
+        "reason_code": reason_code,
+        "summary": summary,
+        "source_updated_at": source_updated_at,
+        "next_command": next_command,
+        "run_id": run_id,
+        "issue_number": issue_number,
+        "pull_number": pull_number,
+    }
+
+
+def build_maintainer_inbox(
+    repository: str,
+    *,
+    proposals: list[dict[str, Any]],
+    runs: list[dict[str, Any]],
+    portfolio: dict[str, Any] | None,
+    observed_at: str,
+    error: str = "",
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Join bounded local and GitHub facts into deterministic attention items."""
+    normalized_repository = repository.casefold()
+    items: list[dict[str, Any]] = []
+    for proposal in proposals:
+        item_id = str(proposal["project_item_id"])
+        items.append(
+            _item(
+                item_id=f"issue-proposal:{item_id}",
+                repository=normalized_repository,
+                priority=60,
+                reason_code="issue_proposal_review_required",
+                summary="在线 Issue 提案等待内容与重复项审核",
+                source_updated_at=str(proposal.get("updated_at") or ""),
+                next_command=(
+                    f"reposteward issue review {item_id} "
+                    f"--repository {normalized_repository}"
+                ),
+            )
+        )
+
+    pulls = {}
+    portfolio_complete = False
+    if portfolio is not None:
+        snapshot = portfolio.get("snapshot")
+        if isinstance(snapshot, dict):
+            portfolio_complete = bool(snapshot.get("complete"))
+            pulls = {
+                int(value["number"]): value
+                for value in snapshot.get("pull_requests", ())
+                if isinstance(value, dict) and value.get("number")
+            }
+    tracked_pulls: set[int] = set()
+    for run in runs:
+        run_id = str(run["id"])
+        issue_number = int(run["issue_number"])
+        status = str(run.get("status") or "")
+        updated_at = str(run.get("updated_at") or "")
+        pull_number = _pull_number(run)
+        if pull_number:
+            tracked_pulls.add(pull_number)
+        common = {
+            "item_id": f"run:{run_id}",
+            "repository": normalized_repository,
+            "source_updated_at": updated_at,
+            "run_id": run_id,
+            "issue_number": issue_number,
+            "pull_number": pull_number,
+        }
+        if status == "failed":
+            items.append(
+                _item(
+                    **common,
+                    priority=75,
+                    reason_code="run_failed",
+                    summary=f"Issue #{issue_number} 的本地运行失败",
+                    next_command=f"reposteward inspect {run_id}",
+                )
+            )
+            continue
+        if status == "ready":
+            items.append(
+                _item(
+                    **common,
+                    priority=50,
+                    reason_code="local_review_required",
+                    summary=f"Issue #{issue_number} 已验证，等待人工审阅",
+                    next_command=f"reposteward inspect {run_id}",
+                )
+            )
+            continue
+        if status != "submitted":
+            continue
+        pull = pulls.get(pull_number)
+        if pull is None or not pull.get("facts_complete"):
+            items.append(
+                _item(
+                    **common,
+                    priority=80,
+                    reason_code="refresh_required",
+                    summary=f"PR #{pull_number or '?'} 的在线事实缺失或不完整",
+                    next_command=f"reposteward follow-up {run_id}",
+                )
+            )
+            continue
+        checks = pull.get("checks") or ()
+        failed = any(
+            str(value.get("conclusion") or "").casefold() in FAILED_CHECKS
+            for value in checks
+            if isinstance(value, dict) and value.get("required")
+        )
+        if failed:
+            items.append(
+                _item(
+                    **common,
+                    priority=100,
+                    reason_code="required_ci_failed",
+                    summary=f"PR #{pull_number} 的必需 CI 失败",
+                    next_command=(
+                        f"reposteward ci diagnose {normalized_repository} {pull_number}"
+                    ),
+                )
+            )
+            continue
+        review = str(pull.get("review_decision") or "").casefold()
+        unresolved = int(pull.get("unresolved_conversations") or 0)
+        if review == "changes_requested" or unresolved:
+            items.append(
+                _item(
+                    **common,
+                    priority=90,
+                    reason_code="review_feedback_required",
+                    summary=f"PR #{pull_number} 有待处理的 Review 反馈",
+                    next_command=f"reposteward follow-up {run_id}",
+                )
+            )
+            continue
+        items.append(
+            _item(
+                **common,
+                priority=40,
+                reason_code="merge_check_required",
+                summary=f"PR #{pull_number} 等待完整合并资格判断",
+                next_command=f"reposteward merge-decision {run_id}",
+            )
+        )
+
+    for pull_number, pull in pulls.items():
+        if pull_number in tracked_pulls:
+            continue
+        facts_complete = bool(pull.get("facts_complete"))
+        items.append(
+            _item(
+                item_id=f"pull-request:{pull_number}",
+                repository=normalized_repository,
+                priority=30 if facts_complete else 80,
+                reason_code=(
+                    "untracked_pull_request" if facts_complete else "refresh_required"
+                ),
+                summary=(
+                    f"PR #{pull_number} 没有关联的 RepoSteward run"
+                    if facts_complete
+                    else f"未跟踪 PR #{pull_number} 的在线事实不完整"
+                ),
+                source_updated_at=str(pull.get("updated_at") or ""),
+                next_command=(f"reposteward portfolio inspect {normalized_repository}"),
+                pull_number=pull_number,
+            )
+        )
+
+    if error:
+        items.append(
+            _item(
+                item_id=f"repository:{normalized_repository}",
+                repository=normalized_repository,
+                priority=110,
+                reason_code="github_refresh_failed",
+                summary=f"GitHub 状态读取失败：{error[:300]}",
+                source_updated_at=observed_at,
+                next_command=f"reposteward inbox --repo {normalized_repository}",
+            )
+        )
+    ordered = sorted(
+        items,
+        key=lambda value: (
+            -int(value["priority"]),
+            str(value["source_updated_at"]),
+            str(value["id"]),
+        ),
+    )
+    limit = min(max(limit, 1), 500)
+    omitted = max(0, len(ordered) - limit)
+    selected = ordered[:limit]
+    facts = {
+        "schema_version": INBOX_SCHEMA_VERSION,
+        "repository": normalized_repository,
+        "items": selected,
+        "omitted_count": omitted,
+        "complete": not error and portfolio_complete,
+    }
+    return {
+        **facts,
+        "observed_at": observed_at,
+        "inbox_digest": _canonical_digest(facts),
+        "harness_invoked": False,
+        "workspace_modified": False,
+        "public_write": False,
+    }
+
+
+def render_inbox_text(result: dict[str, Any]) -> str:
+    lines = [
+        f"Maintainer inbox: {result['repository']}",
+        f"Complete: {'yes' if result['complete'] else 'no'}",
+        f"Items: {len(result['items'])}; omitted: {result['omitted_count']}",
+    ]
+    for item in result["items"][:MAX_TEXT_ITEMS]:
+        lines.append(
+            f"P{item['priority']} {item['reason_code']} {item['summary']}\n"
+            f"  next: {item['next_command']}"
+        )
+    return "\n".join(lines)

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -52,6 +52,7 @@ from .dependencies import (
 from .discovery import score_issue
 from .github import GitHubClient, GitHubError, PullRequest, resolve_token
 from .harness import Harness, HarnessRequest, create_harness, harness_capabilities
+from .inbox import build_maintainer_inbox
 from .issues import (
     attach_proposal_marker,
     issue_review_digest,
@@ -221,6 +222,26 @@ class Pipeline:
         pulls = self.github.open_pull_requests(policy.name)
         return self._portfolio_snapshot_from_pulls(
             policy, pulls, expected_digest=expected_digest
+        )
+
+    def maintainer_inbox(self, repository: str, *, limit: int = 50) -> dict[str, Any]:
+        """Aggregate bounded local and online facts without invoking a Harness."""
+        policy = self.policy(repository)
+        observed_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+        portfolio = None
+        error = ""
+        try:
+            portfolio = self.portfolio_snapshot(policy.name)
+        except GitHubError as exc:
+            error = str(exc)
+        return build_maintainer_inbox(
+            policy.name,
+            proposals=self.store.staged_issue_proposals(policy.name),
+            runs=self.store.latest_runs_for_repository(policy.name),
+            portfolio=portfolio,
+            observed_at=observed_at,
+            error=error,
+            limit=min(max(limit, 1), 500),
         )
 
     def _portfolio_snapshot_from_pulls(

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -673,6 +673,21 @@ class Store:
             ).fetchone()
         return dict(row) if row is not None else None
 
+    def staged_issue_proposals(
+        self, repository: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM issue_proposals
+                WHERE repository=? AND status='staged'
+                ORDER BY updated_at, project_item_id LIMIT ?
+                """,
+                (repository.casefold(), limit),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
     def record_issue_proposal(
         self,
         *,
@@ -2950,6 +2965,41 @@ class Store:
             return None
         result = dict(row)
         result["details"] = json.loads(result["details"])
+        return result
+
+    def latest_runs_for_repository(
+        self, repository: str, *, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Return one latest run per Issue without N+1 queries."""
+        limit = min(max(limit, 1), 1_000)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                WITH ranked AS (
+                    SELECT r.*, r.rowid AS run_rowid,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY repository, issue_number
+                               ORDER BY created_at DESC, r.rowid DESC
+                           ) AS run_rank
+                    FROM runs r WHERE repository=?
+                )
+                SELECT ranked.*, submissions.pr_url AS submission_pr_url
+                FROM ranked
+                LEFT JOIN submissions
+                  ON submissions.repository=ranked.repository
+                 AND submissions.issue_number=ranked.issue_number
+                WHERE run_rank=1
+                ORDER BY updated_at, id LIMIT ?
+                """,
+                (repository.casefold(), limit),
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = dict(row)
+            value.pop("run_rank", None)
+            value.pop("run_rowid", None)
+            value["details"] = json.loads(str(value["details"]))
+            result.append(value)
         return result
 
     def append_owner_review_attestation(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -284,6 +284,50 @@ class CliSetupTests(unittest.TestCase):
             ],
         )
 
+    def test_inbox_supports_json_and_text_without_a_harness(self) -> None:
+        result = {
+            "repository": "owner/repo",
+            "complete": True,
+            "items": [],
+            "omitted_count": 0,
+            "public_write": False,
+        }
+        pipeline = MagicMock()
+        pipeline.maintainer_inbox.return_value = result
+        json_output = io.StringIO()
+        text_output = io.StringIO()
+
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+        ):
+            with redirect_stdout(json_output):
+                json_code = main(["inbox", "--repo", "owner/repo"])
+            with redirect_stdout(text_output):
+                text_code = main(
+                    [
+                        "inbox",
+                        "--repo",
+                        "owner/repo",
+                        "--limit",
+                        "12",
+                        "--format",
+                        "text",
+                    ]
+                )
+
+        self.assertEqual(json_code, 0)
+        self.assertEqual(text_code, 0)
+        self.assertEqual(json.loads(json_output.getvalue()), result)
+        self.assertIn("Maintainer inbox: owner/repo", text_output.getvalue())
+        self.assertEqual(
+            pipeline.maintainer_inbox.call_args_list,
+            [
+                unittest.mock.call("owner/repo", limit=50),
+                unittest.mock.call("owner/repo", limit=12),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import unittest
+
+from reposteward.inbox import build_maintainer_inbox, render_inbox_text
+
+
+def _pull(
+    number: int,
+    *,
+    checks: list[dict] | None = None,
+    review: str = "APPROVED",
+    unresolved: int = 0,
+    complete: bool = True,
+) -> dict:
+    return {
+        "number": number,
+        "updated_at": "2026-08-22T00:00:00Z",
+        "facts_complete": complete,
+        "checks": checks or [],
+        "review_decision": review,
+        "unresolved_conversations": unresolved,
+    }
+
+
+def _run(run_id: str, status: str, *, issue: int, pull: int = 0) -> dict:
+    return {
+        "id": run_id,
+        "issue_number": issue,
+        "status": status,
+        "updated_at": "2026-08-22T00:00:00Z",
+        "details": {
+            "pr_url": f"https://github.com/owner/repo/pull/{pull}" if pull else ""
+        },
+        "submission_pr_url": "",
+    }
+
+
+class MaintainerInboxTests(unittest.TestCase):
+    def test_attention_is_deduplicated_and_sorted_by_priority(self) -> None:
+        checks = [
+            {
+                "name": "quality",
+                "required": True,
+                "conclusion": "failure",
+            }
+        ]
+        portfolio = {
+            "snapshot": {
+                "complete": True,
+                "pull_requests": [
+                    _pull(10, checks=checks),
+                    _pull(11, unresolved=1),
+                    _pull(12),
+                    _pull(99),
+                ],
+            }
+        }
+        result = build_maintainer_inbox(
+            "Owner/Repo",
+            proposals=[
+                {
+                    "project_item_id": "proposal-1",
+                    "updated_at": "2026-08-21T00:00:00Z",
+                }
+            ],
+            runs=[
+                _run("failed", "failed", issue=1),
+                _run("ready", "ready", issue=2),
+                _run("ci", "submitted", issue=3, pull=10),
+                _run("review", "submitted", issue=4, pull=11),
+                _run("merge", "submitted", issue=5, pull=12),
+            ],
+            portfolio=portfolio,
+            observed_at="2026-08-22T01:00:00+00:00",
+        )
+
+        self.assertTrue(result["complete"])
+        self.assertEqual(
+            [item["reason_code"] for item in result["items"]],
+            [
+                "required_ci_failed",
+                "review_feedback_required",
+                "run_failed",
+                "issue_proposal_review_required",
+                "local_review_required",
+                "merge_check_required",
+                "untracked_pull_request",
+            ],
+        )
+        self.assertEqual(len({item["id"] for item in result["items"]}), 7)
+        self.assertFalse(result["harness_invoked"])
+        self.assertFalse(result["workspace_modified"])
+        self.assertFalse(result["public_write"])
+
+    def test_partial_github_failure_fails_closed_and_obeys_limit(self) -> None:
+        result = build_maintainer_inbox(
+            "owner/repo",
+            proposals=[],
+            runs=[_run("submitted", "submitted", issue=1, pull=10)],
+            portfolio=None,
+            observed_at="2026-08-22T01:00:00+00:00",
+            error="rate limit",
+            limit=1,
+        )
+
+        self.assertFalse(result["complete"])
+        self.assertEqual(len(result["items"]), 1)
+        self.assertEqual(result["items"][0]["reason_code"], "github_refresh_failed")
+        self.assertEqual(result["omitted_count"], 1)
+
+    def test_incomplete_untracked_pull_requires_refresh(self) -> None:
+        result = build_maintainer_inbox(
+            "owner/repo",
+            proposals=[],
+            runs=[],
+            portfolio={
+                "snapshot": {
+                    "complete": False,
+                    "pull_requests": [_pull(99, complete=False)],
+                }
+            },
+            observed_at="2026-08-22T01:00:00+00:00",
+        )
+
+        self.assertFalse(result["complete"])
+        self.assertEqual(result["items"][0]["reason_code"], "refresh_required")
+        self.assertEqual(result["items"][0]["priority"], 80)
+
+    def test_empty_inbox_has_stable_text_and_digest(self) -> None:
+        arguments = {
+            "repository": "owner/repo",
+            "proposals": [],
+            "runs": [],
+            "portfolio": {"snapshot": {"complete": True, "pull_requests": []}},
+            "observed_at": "2026-08-22T01:00:00+00:00",
+        }
+        first = build_maintainer_inbox(**arguments)
+        second = build_maintainer_inbox(**arguments)
+
+        self.assertEqual(first["inbox_digest"], second["inbox_digest"])
+        self.assertIn("Items: 0", render_inbox_text(first))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -161,6 +161,50 @@ def _usage_run(store: Store, *, details: dict | None = None) -> tuple[str, str]:
 
 
 class StoreTests(unittest.TestCase):
+    def test_inbox_queries_return_only_staged_proposals_and_latest_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            store.record_issue_proposal(
+                project_item_id="staged",
+                project_id="project",
+                project_url="https://example.test/project",
+                draft_id="draft-1",
+                repository="owner/repo",
+                creator="alice",
+                content_digest="a" * 64,
+            )
+            store.record_issue_proposal(
+                project_item_id="published",
+                project_id="project",
+                project_url="https://example.test/project",
+                draft_id="draft-2",
+                repository="owner/repo",
+                creator="alice",
+                content_digest="b" * 64,
+            )
+            store.mark_issue_proposal_published(
+                "published", issue_number=7, issue_url="https://example.test/issues/7"
+            )
+            old_run = store.start_run("owner/repo", 7, "agent")
+            store.update_run(old_run, status="failed")
+            latest_run = store.start_run("owner/repo", 7, "verification")
+            store.update_run(latest_run, status="ready")
+            other_run = store.start_run("owner/repo", 8, "agent")
+            store.record_submission(
+                "owner/repo", 8, "https://github.com/owner/repo/pull/9"
+            )
+
+            proposals = store.staged_issue_proposals("OWNER/REPO")
+            runs = store.latest_runs_for_repository("OWNER/REPO")
+
+        self.assertEqual([value["project_item_id"] for value in proposals], ["staged"])
+        self.assertEqual({value["id"] for value in runs}, {latest_run, other_run})
+        submitted = next(value for value in runs if value["id"] == other_run)
+        self.assertEqual(
+            submitted["submission_pr_url"],
+            "https://github.com/owner/repo/pull/9",
+        )
+
     def test_legacy_unversioned_database_is_migrated_without_data_loss(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "state.sqlite3"


### PR DESCRIPTION
Closes #50

Add a deterministic, prompt-free maintainer inbox across Issue proposals, local runs, CI, review, and merge-check entry points.

---

The new `inbox` command performs bounded bulk Store queries and reuses one repository Portfolio snapshot. It ranks stable reason codes, emits an auditable digest and next command, and fails closed when GitHub or per-PR facts are incomplete. It does not invoke a Harness, modify a workspace, or write to GitHub.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`, and a live read-only inbox query against this repository.

Areas for careful review:
- Online cost follows Portfolio collection: one open-PR listing and one bounded fact snapshot per open PR, without duplicate reads inside the inbox layer.
- Incomplete tracked or untracked PR facts are labeled `refresh_required`; they are never presented as merge-ready.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.