### PR TITLE
feat(runs): guard mutations with leases

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,13 @@ SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化�
 - `github_pr_watermarks`：保存每个 run 已经形成 Review Checkpoint 的事件序号。事件先幂等入库，
 Checkpoint 与水位再在同一事务中提交，因此中断后可以安全重试。
 
+会改变上述事实的长任务按 `repository + Issue` 获取 SQLite 运行租约。租约包含 owner、
+generation 和过期时间，并由执行进程续租；同一 Issue 的 prepare、adopt、repair、follow-up、
+submit 与 merge 串行，不同 Issue 仍可并行。绑定租约时，每次短 Store 操作在同一 SQLite 写事务内
+完成 generation 点查和状态写入；事务不会跨 Harness、Docker 或 GitHub 等慢边界。远端写入前还会
+重新检查租约，并继续使用 head SHA、force-with-lease 等远端幂等条件。崩溃后的租约可在到期后接管，
+但旧 generation 不能继续写入本地事实，所有获取、续租、接管和释放动作都保留追加式审计记录。
+
 事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
 的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -6,7 +6,10 @@ import os
 import re
 import sqlite3
 import subprocess
+import threading
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, replace
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -64,7 +67,7 @@ from .portfolio import build_portfolio_snapshot
 from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
-from .store import Store, StoreError
+from .store import RunLease, Store, StoreError
 from .usage import (
     build_usage_report,
     compact_usage_budget,
@@ -137,6 +140,42 @@ class Pipeline:
         self.harness = harness or create_harness(config.agent)
         self.verifier = DockerVerifier(config)
         self.workspaces = WorkspaceManager(config)
+
+    @contextmanager
+    def _mutation_lease(self, repository: str, issue_number: int) -> Iterator[RunLease]:
+        """Serialize one Issue lifecycle while allowing unrelated Issues in parallel."""
+        scope = f"issue:{repository.casefold()}#{issue_number}"
+        owner = f"{os.getpid()}:{uuid.uuid4().hex}"
+        lease = self.store.acquire_run_lease(scope, owner=owner, ttl_seconds=90)
+        stopped = threading.Event()
+
+        def heartbeat() -> None:
+            nonlocal lease
+            while not stopped.wait(30):
+                try:
+                    lease = self.store.renew_run_lease(lease, ttl_seconds=90)
+                except (OSError, sqlite3.Error, StoreError):
+                    # A later retry may recover while the current lease is active.
+                    continue
+
+        thread = threading.Thread(
+            target=heartbeat,
+            name=f"reposteward-lease-{issue_number}",
+            daemon=True,
+        )
+        thread.start()
+        try:
+            with self.store.bind_run_lease(lease):
+                yield lease
+            self.store.validate_run_lease(lease)
+        finally:
+            stopped.set()
+            thread.join(timeout=1)
+            try:
+                self.store.release_run_lease(lease)
+            except (OSError, sqlite3.Error, StoreError):
+                # A stale owner must not remove a successor's lease.
+                pass
 
     def policy(self, repository: str) -> RepositoryPolicy:
         try:
@@ -1361,6 +1400,10 @@ class Pipeline:
         )
 
     def prepare(self, repository: str, issue_number: int) -> dict[str, Any]:
+        with self._mutation_lease(repository, issue_number):
+            return self._prepare_leased(repository, issue_number)
+
+    def _prepare_leased(self, repository: str, issue_number: int) -> dict[str, Any]:
         policy = self.policy(repository)
         candidate = self.ensure_candidate(repository, issue_number)
         if candidate.blockers:
@@ -1532,6 +1575,26 @@ class Pipeline:
             raise
 
     def adopt(
+        self,
+        repository: str,
+        issue_number: int,
+        *,
+        worktree: Path,
+        summary_text: str,
+        implementation_notes: str,
+        verification_commands: tuple[str, ...],
+    ) -> dict[str, Any]:
+        with self._mutation_lease(repository, issue_number):
+            return self._adopt_leased(
+                repository,
+                issue_number,
+                worktree=worktree,
+                summary_text=summary_text,
+                implementation_notes=implementation_notes,
+                verification_commands=verification_commands,
+            )
+
+    def _adopt_leased(
         self,
         repository: str,
         issue_number: int,
@@ -2316,7 +2379,11 @@ class Pipeline:
 
     def follow_up(self, run_id: str) -> dict[str, Any]:
         """Commit and return GitHub activity changed since the previous check."""
-        return self._follow_up(run_id, commit=True)
+        run = self.store.run(run_id)
+        if run is None:
+            raise KeyError(f"run not found: {run_id}")
+        with self._mutation_lease(str(run["repository"]), int(run["issue_number"])):
+            return self._follow_up(run_id, commit=True)
 
     def _follow_up(self, run_id: str, *, commit: bool) -> dict[str, Any]:
         """Collect one event batch, optionally advancing its Review Checkpoint."""
@@ -2554,6 +2621,15 @@ class Pipeline:
         return committed
 
     def prepare_repair(self, source_run_id: str) -> dict[str, Any]:
+        source_run = self.store.run(source_run_id)
+        if source_run is None:
+            raise KeyError(f"run not found: {source_run_id}")
+        with self._mutation_lease(
+            str(source_run["repository"]), int(source_run["issue_number"])
+        ):
+            return self._prepare_repair_leased(source_run_id)
+
+    def _prepare_repair_leased(self, source_run_id: str) -> dict[str, Any]:
         """Prepare one contributor repair from newly committed PR activity."""
         source_run = self.store.run(source_run_id)
         if source_run is None:
@@ -3350,6 +3426,27 @@ class Pipeline:
     def execute_merge(
         self, run_id: str, *, decision_id: str, reviewed_by: str
     ) -> dict[str, Any]:
+        run = self.store.run(run_id)
+        if run is None:
+            raise KeyError(f"run not found: {run_id}")
+        with self._mutation_lease(
+            str(run["repository"]), int(run["issue_number"])
+        ) as lease:
+            return self._execute_merge_leased(
+                run_id,
+                decision_id=decision_id,
+                reviewed_by=reviewed_by,
+                mutation_lease=lease,
+            )
+
+    def _execute_merge_leased(
+        self,
+        run_id: str,
+        *,
+        decision_id: str,
+        reviewed_by: str,
+        mutation_lease: RunLease,
+    ) -> dict[str, Any]:
         """Execute one fresh eligible maintainer decision behind explicit gates."""
         run = self.store.run(run_id)
         if run is None:
@@ -3597,6 +3694,7 @@ class Pipeline:
 
         public_write = False
         try:
+            self.store.validate_run_lease(mutation_lease)
             public_write = True
             result = self.github.merge_pull_request(
                 repository,
@@ -3680,6 +3778,24 @@ class Pipeline:
         *,
         reviewed_by: str,
         reopen_pull_request: int = 0,
+    ) -> dict[str, Any]:
+        with self._mutation_lease(repository, issue_number) as lease:
+            return self._submit_leased(
+                repository,
+                issue_number,
+                reviewed_by=reviewed_by,
+                reopen_pull_request=reopen_pull_request,
+                mutation_lease=lease,
+            )
+
+    def _submit_leased(
+        self,
+        repository: str,
+        issue_number: int,
+        *,
+        reviewed_by: str,
+        reopen_pull_request: int = 0,
+        mutation_lease: RunLease,
     ) -> dict[str, Any]:
         policy = self.policy(repository)
         submit_enabled = os.environ.get("REPOSTEWARD_ENABLE_SUBMIT") == "1"
@@ -3787,6 +3903,7 @@ class Pipeline:
 
         if reopen_pull_request:
             assert closed_pull is not None
+            self.store.validate_run_lease(mutation_lease)
             pull_request = client.reopen_pull_request(
                 policy.name,
                 reopen_pull_request,
@@ -3797,6 +3914,7 @@ class Pipeline:
                 body=body,
             )
             try:
+                self.store.validate_run_lease(mutation_lease)
                 self.workspaces.push(
                     worktree,
                     destination,
@@ -3828,6 +3946,7 @@ class Pipeline:
                         f"{existing_pull.base_branch!r}, expected "
                         f"{details['base_branch']!r}"
                     )
+                self.store.validate_run_lease(mutation_lease)
                 self.workspaces.push(
                     worktree,
                     destination,
@@ -3836,7 +3955,9 @@ class Pipeline:
                 )
                 pull_request = client.pull_request(policy.name, existing_pull.number)
             else:
+                self.store.validate_run_lease(mutation_lease)
                 self.workspaces.push(worktree, destination, details["branch"])
+                self.store.validate_run_lease(mutation_lease)
                 pull_request = client.create_pull_request(
                     policy.name,
                     owner=head_owner,

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -7,6 +7,8 @@ import sqlite3
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -14,7 +16,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -438,11 +440,45 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON harness_usage_events(work_item_id, sequence)
         """,
     ),
+    14: (
+        """
+        CREATE TABLE IF NOT EXISTS run_leases (
+            scope TEXT PRIMARY KEY,
+            owner TEXT NOT NULL,
+            generation INTEGER NOT NULL CHECK(generation >= 1),
+            expires_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS run_lease_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            scope TEXT NOT NULL,
+            owner TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS run_lease_events_for_scope
+        ON run_lease_events(scope, sequence DESC)
+        """,
+    ),
 }
 
 
 class StoreError(RuntimeError):
     """The local state database cannot be opened or migrated safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunLease:
+    scope: str
+    owner: str
+    generation: int
+    expires_at: str
 
 
 def utc_now() -> str:
@@ -510,16 +546,33 @@ USAGE_METRIC_KEYS = frozenset(
 class Store:
     def __init__(self, path: Path) -> None:
         self.path = path
+        self._run_lease_context: ContextVar[RunLease | None] = ContextVar(
+            f"reposteward_run_lease_{id(self)}", default=None
+        )
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._initialize()
 
+    @staticmethod
+    def _begin_immediate(connection: sqlite3.Connection) -> None:
+        if not connection.in_transaction:
+            connection.execute("BEGIN IMMEDIATE")
+
     @contextmanager
-    def _connection(self) -> Iterator[sqlite3.Connection]:
+    def _connection(
+        self, *, guard_bound_lease: bool = True
+    ) -> Iterator[sqlite3.Connection]:
         connection = sqlite3.connect(self.path)
         connection.row_factory = sqlite3.Row
         connection.execute("PRAGMA foreign_keys=ON")
         connection.execute("PRAGMA busy_timeout=5000")
         try:
+            lease = self._run_lease_context.get() if guard_bound_lease else None
+            if lease is not None:
+                # Keep the fencing check and any following write in one short
+                # transaction. The lock is released when this Store call returns;
+                # it is never held across Harness, Docker, or GitHub operations.
+                self._begin_immediate(connection)
+                self._assert_run_lease_row(connection, lease)
             yield connection
             connection.commit()
         except Exception:
@@ -543,7 +596,7 @@ class Store:
                 statements = MIGRATIONS.get(version)
                 if statements is None:
                     raise StoreError(f"missing database migration {version}")
-                connection.execute("BEGIN IMMEDIATE")
+                self._begin_immediate(connection)
                 try:
                     for statement in statements:
                         if version == 7 and statement.startswith(
@@ -794,7 +847,7 @@ class Store:
         )
         now = utc_now()
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             self._validate_run_work_item(
                 connection, run_id, work_item_id, context_payload=payload
             )
@@ -916,7 +969,7 @@ class Store:
         native_session_id: str = "",
     ) -> None:
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             context = connection.execute(
                 """
                 SELECT work_item_id, run_id FROM context_packs WHERE id=?
@@ -1049,7 +1102,7 @@ class Store:
             raise ValueError("Harness usage trim_reasons must be non-negative counts")
 
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             scope = connection.execute(
                 """
                 SELECT h.work_item_id, h.harness, h.model,
@@ -1495,7 +1548,7 @@ class Store:
             payload=payload,
         )
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             return self._insert_checkpoint(
                 connection,
                 work_item_id=work_item_id,
@@ -1574,7 +1627,7 @@ class Store:
         event_values = self._github_event_values(activity)
         now = utc_now()
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             run = connection.execute(
                 "SELECT repository, details FROM runs WHERE id=?", (run_id,)
             ).fetchone()
@@ -1724,7 +1777,7 @@ class Store:
         if pull_number < 1 or sequence < 0:
             raise ValueError("pull number must be positive and sequence non-negative")
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             run = connection.execute(
                 "SELECT repository FROM runs WHERE id=?", (run_id,)
             ).fetchone()
@@ -1790,7 +1843,7 @@ class Store:
             }
             self._validate_checkpoint_record(payload=checkpoint, **checkpoint_args)
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             watermark = connection.execute(
                 "SELECT * FROM github_pr_watermarks WHERE run_id=?", (run_id,)
             ).fetchone()
@@ -2229,7 +2282,7 @@ class Store:
         }
         deleted = []
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             inventory = self._event_payload_gc_inventory(connection, normalized)
             eligible = {value["digest"]: value for value in inventory["candidates"]}
             for digest in sorted(requested & eligible.keys()):
@@ -2439,7 +2492,7 @@ class Store:
         )
         serialized = json.dumps(bundle, ensure_ascii=False)
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             existing = connection.execute(
                 """
                 SELECT id, work_item_id, imported_at FROM context_imports
@@ -2602,6 +2655,230 @@ class Store:
             if cursor.rowcount != 1:
                 raise KeyError(f"candidate not found: {repository}#{issue_number}")
 
+    @staticmethod
+    def _lease_inputs(
+        scope: str,
+        owner: str,
+        ttl_seconds: int,
+        now: datetime | None,
+    ) -> tuple[str, str, datetime, str, str]:
+        normalized_scope = scope.strip().casefold()
+        normalized_owner = owner.strip()
+        if not normalized_scope or len(normalized_scope) > 500:
+            raise ValueError("run lease scope must contain at most 500 characters")
+        if not normalized_owner or len(normalized_owner) > 128:
+            raise ValueError("run lease owner must contain at most 128 characters")
+        if isinstance(ttl_seconds, bool) or not 5 <= ttl_seconds <= 86_400:
+            raise ValueError("run lease ttl_seconds must be between 5 and 86400")
+        current = now or datetime.now(UTC)
+        if current.tzinfo is None:
+            raise ValueError("run lease time must include a timezone")
+        current = current.astimezone(UTC)
+        current_text = current.isoformat(timespec="microseconds")
+        expires_at = (current + timedelta(seconds=ttl_seconds)).isoformat(
+            timespec="microseconds"
+        )
+        return (
+            normalized_scope,
+            normalized_owner,
+            current,
+            current_text,
+            expires_at,
+        )
+
+    @staticmethod
+    def _append_run_lease_event(
+        connection: sqlite3.Connection,
+        lease: RunLease,
+        action: str,
+        created_at: str,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO run_lease_events(
+                scope, owner, generation, action, expires_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                lease.scope,
+                lease.owner,
+                lease.generation,
+                action,
+                lease.expires_at,
+                created_at,
+            ),
+        )
+
+    def acquire_run_lease(
+        self,
+        scope: str,
+        *,
+        owner: str,
+        ttl_seconds: int = 90,
+        now: datetime | None = None,
+    ) -> RunLease:
+        normalized_scope, normalized_owner, _, current_text, expires_at = (
+            self._lease_inputs(scope, owner, ttl_seconds, now)
+        )
+        with self._connection(guard_bound_lease=False) as connection:
+            self._begin_immediate(connection)
+            row = connection.execute(
+                "SELECT * FROM run_leases WHERE scope=?", (normalized_scope,)
+            ).fetchone()
+            if row is None:
+                generation = 1
+                action = "acquired"
+                connection.execute(
+                    """
+                    INSERT INTO run_leases(
+                        scope, owner, generation, expires_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        normalized_scope,
+                        normalized_owner,
+                        generation,
+                        expires_at,
+                        current_text,
+                    ),
+                )
+            else:
+                current_owner = str(row["owner"])
+                active = str(row["expires_at"]) > current_text
+                if active and current_owner != normalized_owner:
+                    raise StoreError(
+                        f"run lease is already held for {normalized_scope}"
+                    )
+                generation = int(row["generation"])
+                if not active:
+                    generation += 1
+                    action = (
+                        "taken_over"
+                        if current_owner != normalized_owner
+                        else "reacquired"
+                    )
+                else:
+                    action = "renewed"
+                connection.execute(
+                    """
+                    UPDATE run_leases
+                    SET owner=?, generation=?, expires_at=?, updated_at=?
+                    WHERE scope=?
+                    """,
+                    (
+                        normalized_owner,
+                        generation,
+                        expires_at,
+                        current_text,
+                        normalized_scope,
+                    ),
+                )
+            lease = RunLease(normalized_scope, normalized_owner, generation, expires_at)
+            self._append_run_lease_event(connection, lease, action, current_text)
+        return lease
+
+    def renew_run_lease(
+        self,
+        lease: RunLease,
+        *,
+        ttl_seconds: int = 90,
+        now: datetime | None = None,
+    ) -> RunLease:
+        scope, owner, _, current_text, expires_at = self._lease_inputs(
+            lease.scope, lease.owner, ttl_seconds, now
+        )
+        renewed = RunLease(scope, owner, lease.generation, expires_at)
+        with self._connection(guard_bound_lease=False) as connection:
+            self._begin_immediate(connection)
+            cursor = connection.execute(
+                """
+                UPDATE run_leases SET expires_at=?, updated_at=?
+                WHERE scope=? AND owner=? AND generation=? AND expires_at>?
+                """,
+                (
+                    expires_at,
+                    current_text,
+                    scope,
+                    owner,
+                    lease.generation,
+                    current_text,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise StoreError(f"run lease is stale for {scope}")
+            self._append_run_lease_event(connection, renewed, "renewed", current_text)
+        return renewed
+
+    @staticmethod
+    def _assert_run_lease_row(
+        connection: sqlite3.Connection,
+        lease: RunLease,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        current = now or datetime.now(UTC)
+        if current.tzinfo is None:
+            raise ValueError("run lease time must include a timezone")
+        current_text = current.astimezone(UTC).isoformat(timespec="microseconds")
+        row = connection.execute(
+            """
+            SELECT 1 FROM run_leases
+            WHERE scope=? AND owner=? AND generation=? AND expires_at>?
+            """,
+            (lease.scope, lease.owner, lease.generation, current_text),
+        ).fetchone()
+        if row is None:
+            raise StoreError(f"run lease is stale for {lease.scope}")
+
+    def validate_run_lease(
+        self, lease: RunLease, *, now: datetime | None = None
+    ) -> None:
+        with self._connection(guard_bound_lease=False) as connection:
+            self._assert_run_lease_row(connection, lease, now=now)
+
+    def release_run_lease(self, lease: RunLease) -> None:
+        created_at = utc_now()
+        released = RunLease(lease.scope, lease.owner, lease.generation, created_at)
+        with self._connection(guard_bound_lease=False) as connection:
+            self._begin_immediate(connection)
+            cursor = connection.execute(
+                """
+                UPDATE run_leases SET expires_at=?, updated_at=?
+                WHERE scope=? AND owner=? AND generation=?
+                """,
+                (
+                    created_at,
+                    created_at,
+                    lease.scope,
+                    lease.owner,
+                    lease.generation,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise StoreError(f"run lease is stale for {lease.scope}")
+            self._append_run_lease_event(connection, released, "released", created_at)
+
+    @contextmanager
+    def bind_run_lease(self, lease: RunLease) -> Iterator[None]:
+        """Require guarded run updates in the current execution context."""
+        token = self._run_lease_context.set(lease)
+        try:
+            yield
+        finally:
+            self._run_lease_context.reset(token)
+
+    def run_lease_events(self, scope: str, *, limit: int = 100) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM run_lease_events
+                WHERE scope=? ORDER BY sequence DESC LIMIT ?
+                """,
+                (scope.strip().casefold(), limit),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
     def start_run(self, repository: str, issue_number: int, stage: str) -> str:
         run_id = uuid.uuid4().hex
         now = utc_now()
@@ -2624,6 +2901,7 @@ class Store:
         stage: str | None = None,
         worktree: str | None = None,
         details: dict[str, Any] | None = None,
+        lease: RunLease | None = None,
     ) -> None:
         assignments = ["status=?", "updated_at=?"]
         values: list[Any] = [status, utc_now()]
@@ -2638,6 +2916,11 @@ class Store:
             values.append(json.dumps(details, ensure_ascii=False))
         values.append(run_id)
         with self._connection() as connection:
+            effective_lease = lease
+            if effective_lease is not None:
+                if self._run_lease_context.get() is None:
+                    self._begin_immediate(connection)
+                self._assert_run_lease_row(connection, effective_lease)
             connection.execute(
                 f"UPDATE runs SET {', '.join(assignments)} WHERE id=?", values
             )
@@ -2716,7 +2999,7 @@ class Store:
         now = utc_now()
         attestation_id = uuid.uuid4().hex
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             run = connection.execute(
                 "SELECT repository FROM runs WHERE id=?", (normalized["run_id"],)
             ).fetchone()
@@ -2930,7 +3213,7 @@ class Store:
         ):
             raise ValueError("dependency head_sha must be 40 lowercase hex chars")
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
+            self._begin_immediate(connection)
             previous = connection.execute(
                 """
                 SELECT id, head_sha, action, actor, source,

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -10,7 +11,7 @@ from reposteward.context import repository_policy_digest
 from reposteward.github import GitHubError, PullRequest
 from reposteward.pipeline import Pipeline
 from reposteward.policy import PolicyError
-from reposteward.store import StoreError
+from reposteward.store import RunLease, StoreError
 
 
 class StubStore:
@@ -27,6 +28,7 @@ class StubStore:
         return {
             "id": run_id,
             "repository": "owner/repo",
+            "issue_number": 7,
             "status": "submitted",
             "details": {
                 "pr_url": "https://github.com/owner/repo/pull/12",
@@ -35,6 +37,26 @@ class StubStore:
                 "branch": "alice/feat/example",
             },
         }
+
+    @staticmethod
+    def acquire_run_lease(scope: str, *, owner: str, ttl_seconds: int) -> RunLease:
+        return RunLease(scope, owner, 1, "2999-01-01T00:00:00+00:00")
+
+    @staticmethod
+    def renew_run_lease(lease: RunLease, *, ttl_seconds: int) -> RunLease:
+        return lease
+
+    @staticmethod
+    def bind_run_lease(_lease: RunLease):
+        return nullcontext()
+
+    @staticmethod
+    def validate_run_lease(_lease: RunLease) -> None:
+        return None
+
+    @staticmethod
+    def release_run_lease(_lease: RunLease) -> None:
+        return None
 
     def context_bundle(self, _run_id: str) -> dict:
         return {

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -18,6 +19,17 @@ from reposteward.models import (
 )
 from reposteward.pipeline import Pipeline, _canonical_digest, _repair_feedback
 from reposteward.policy import DiffSummary, PolicyError
+from reposteward.store import RunLease
+
+
+def _lease_aware_store(store: Mock) -> Mock:
+    lease = RunLease(
+        "issue:owner/repo#7", "test-worker", 1, "2999-01-01T00:00:00+00:00"
+    )
+    store.acquire_run_lease.return_value = lease
+    store.renew_run_lease.return_value = lease
+    store.bind_run_lease.return_value = nullcontext()
+    return store
 
 
 def _follow(**extra: object) -> dict:
@@ -82,7 +94,7 @@ class RepairTests(unittest.TestCase):
             ("src/example.py",),
         )
         pipeline = object.__new__(Pipeline)
-        pipeline.store = Mock()
+        pipeline.store = _lease_aware_store(Mock())
         pipeline.store.commit_github_follow_up.return_value = {"sequence": 9}
         source = {
             "id": "source",
@@ -106,7 +118,7 @@ class RepairTests(unittest.TestCase):
         pipeline.config = SimpleNamespace(
             repositories={"owner/repo": RepositoryPolicy(name="owner/repo")}
         )
-        pipeline.store = Mock()
+        pipeline.store = _lease_aware_store(Mock())
         pipeline.store.run.return_value = {
             "id": "source",
             "repository": "owner/repo",
@@ -127,7 +139,7 @@ class RepairTests(unittest.TestCase):
         pipeline.config = SimpleNamespace(
             repositories={"owner/repo": RepositoryPolicy(name="owner/repo")}
         )
-        pipeline.store = Mock()
+        pipeline.store = _lease_aware_store(Mock())
         pipeline.store.run.return_value = {
             "id": "source",
             "repository": "owner/repo",
@@ -216,7 +228,7 @@ class RepairTests(unittest.TestCase):
                 },
             }
             ready = {"id": "repair", "repository": "owner/repo", "issue_number": 7}
-            store = Mock()
+            store = _lease_aware_store(Mock())
             store.run.side_effect = lambda run_id: (
                 source if run_id == "source" else ready
             )
@@ -316,7 +328,7 @@ class RepairSubmissionTests(unittest.TestCase):
             "snapshot_digest": _canonical_digest(snapshot),
         }
         pipeline = object.__new__(Pipeline)
-        pipeline.store = Mock()
+        pipeline.store = _lease_aware_store(Mock())
         pipeline.store.run.return_value = {"status": "submitted"}
         pipeline.store.ingest_github_pr_activity.return_value = {
             "previous_sequence": 9,
@@ -342,7 +354,7 @@ class RepairSubmissionTests(unittest.TestCase):
         policy = RepositoryPolicy(name="owner/repo")
         snapshot = {"head_sha": "a" * 40, "base_sha": "b" * 40}
         pipeline = object.__new__(Pipeline)
-        pipeline.store = Mock()
+        pipeline.store = _lease_aware_store(Mock())
         pipeline.store.run.return_value = {"status": "submitted"}
         pipeline.store.ingest_github_pr_activity.return_value = {
             "previous_sequence": 9,

--- a/tests/test_run_leases.py
+++ b/tests/test_run_leases.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock
+
+from reposteward.pipeline import Pipeline
+from reposteward.store import SCHEMA_VERSION, Store, StoreError
+
+
+class RunLeaseStoreTests(unittest.TestCase):
+    def test_schema_thirteen_database_receives_lease_tables_without_data_loss(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            store = Store(path)
+            run_id = store.start_run("owner/repo", 7, "agent")
+            with sqlite3.connect(path) as connection:
+                connection.execute("DROP TABLE run_lease_events")
+                connection.execute("DROP TABLE run_leases")
+                connection.execute("PRAGMA user_version=13")
+
+            migrated = Store(path)
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(migrated.run(run_id))
+            lease = migrated.acquire_run_lease("issue:owner/repo#7", owner="worker-1")
+            migrated.release_run_lease(lease)
+
+    def test_only_one_concurrent_owner_acquires_a_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            now = datetime(2026, 8, 22, tzinfo=UTC)
+
+            def acquire(owner: str) -> str:
+                try:
+                    return store.acquire_run_lease(
+                        "issue:owner/repo#7", owner=owner, now=now
+                    ).owner
+                except StoreError:
+                    return "blocked"
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(acquire, ("worker-1", "worker-2")))
+
+        self.assertEqual(results.count("blocked"), 1)
+        self.assertEqual(len(set(results) - {"blocked"}), 1)
+
+    def test_unrelated_issue_scopes_can_both_make_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+
+            def acquire(issue_number: int) -> str:
+                return store.acquire_run_lease(
+                    f"issue:owner/repo#{issue_number}", owner=f"worker-{issue_number}"
+                ).scope
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                scopes = set(executor.map(acquire, (7, 8)))
+
+        self.assertEqual(scopes, {"issue:owner/repo#7", "issue:owner/repo#8"})
+
+    def test_expired_takeover_rejects_old_generation_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            run_id = store.start_run("owner/repo", 7, "agent")
+            started = datetime.now(UTC)
+            first = store.acquire_run_lease(
+                "issue:owner/repo#7", owner="worker-1", ttl_seconds=30, now=started
+            )
+            renewed = store.renew_run_lease(
+                first,
+                ttl_seconds=30,
+                now=started + timedelta(seconds=10),
+            )
+            second = store.acquire_run_lease(
+                "issue:owner/repo#7",
+                owner="worker-2",
+                ttl_seconds=30,
+                now=started + timedelta(seconds=41),
+            )
+
+            self.assertGreater(second.generation, renewed.generation)
+            store.update_run(run_id, status="ready", lease=second)
+            with (
+                self.assertRaisesRegex(StoreError, "stale"),
+                store.bind_run_lease(renewed),
+            ):
+                store.update_run(run_id, status="failed")
+            with self.assertRaisesRegex(StoreError, "stale"):
+                store.release_run_lease(renewed)
+            current = store.run(run_id)
+            assert current is not None
+            status = current["status"]
+            store.release_run_lease(second)
+            actions = [
+                value["action"]
+                for value in reversed(store.run_lease_events("issue:owner/repo#7"))
+            ]
+
+        self.assertEqual(status, "ready")
+        self.assertEqual(actions, ["acquired", "renewed", "taken_over", "released"])
+
+    def test_bound_lease_fences_all_store_writes_after_takeover(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            started = datetime.now(UTC)
+            first = store.acquire_run_lease(
+                "issue:owner/repo#7", owner="worker-1", ttl_seconds=30, now=started
+            )
+            store.acquire_run_lease(
+                "issue:owner/repo#7",
+                owner="worker-2",
+                ttl_seconds=30,
+                now=started + timedelta(seconds=31),
+            )
+
+            with (
+                self.assertRaisesRegex(StoreError, "stale"),
+                store.bind_run_lease(first),
+            ):
+                store.start_run("owner/repo", 8, "agent")
+
+            self.assertIsNone(store.latest_run("owner/repo", 8))
+
+
+class PipelineRunLeaseTests(unittest.TestCase):
+    def test_prepare_holds_and_releases_one_issue_scoped_lease(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pipeline = object.__new__(Pipeline)
+            pipeline.store = Store(Path(directory) / "state.sqlite3")
+            pipeline._prepare_leased = Mock(return_value={"run_id": "run-1"})
+
+            result = pipeline.prepare("Owner/Repo", 7)
+            events = list(
+                reversed(pipeline.store.run_lease_events("issue:owner/repo#7"))
+            )
+
+        self.assertEqual(result, {"run_id": "run-1"})
+        pipeline._prepare_leased.assert_called_once_with("Owner/Repo", 7)
+        self.assertEqual(
+            [value["action"] for value in events], ["acquired", "released"]
+        )
+
+    def test_nested_mutation_of_the_same_issue_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pipeline = object.__new__(Pipeline)
+            pipeline.store = Store(Path(directory) / "state.sqlite3")
+
+            with (
+                pipeline._mutation_lease("owner/repo", 7),
+                self.assertRaisesRegex(StoreError, "already held"),
+                pipeline._mutation_lease("owner/repo", 7),
+            ):
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_submission_capacity.py
+++ b/tests/test_submission_capacity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ from reposteward.config import RepositoryPolicy
 from reposteward.github import GitHubError, PullRequest
 from reposteward.pipeline import Pipeline
 from reposteward.policy import PolicyError
+from reposteward.store import RunLease
 
 
 def _pull(number: int, *, author: str = "alice", draft: bool = False) -> PullRequest:
@@ -35,6 +37,26 @@ class _SubmissionStore:
 
     def latest_run(self, _repository: str, _issue_number: int) -> dict:
         return {"id": "run-1", "status": "ready", "details": self.details}
+
+    @staticmethod
+    def acquire_run_lease(scope: str, *, owner: str, ttl_seconds: int) -> RunLease:
+        return RunLease(scope, owner, 1, "2999-01-01T00:00:00+00:00")
+
+    @staticmethod
+    def renew_run_lease(lease: RunLease, *, ttl_seconds: int) -> RunLease:
+        return lease
+
+    @staticmethod
+    def bind_run_lease(_lease: RunLease):
+        return nullcontext()
+
+    @staticmethod
+    def validate_run_lease(_lease: RunLease) -> None:
+        return None
+
+    @staticmethod
+    def release_run_lease(_lease: RunLease) -> None:
+        return None
 
     def update_run(self, _run_id: str, **values) -> None:
         self.updated = values


### PR DESCRIPTION
Closes #49

Fence long-lived Issue mutations with renewable, generation-based SQLite leases.

---

Adds the v14 lease schema and append-only events, atomic acquire/renew/takeover/release operations, ContextVar-bound Store fencing, 30-second heartbeats, and immediate revalidation before GitHub push, PR creation/reopen, or merge. The Pipeline serializes one Issue lifecycle while unrelated Issues remain independently runnable.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, and `uv build --no-build-isolation`.

Areas for careful review:
- This is a forward-only SQLite migration from schema 13 to 14; older RepoSteward binaries intentionally refuse a newer database.
- Each bound Store call uses one primary-key lease lookup in the same short SQLite transaction as its write. Locks are not held across Harness, Docker, or GitHub waits.
- A local benchmark measured about 0.052 ms additional time per fenced update; heartbeats occur every 30 seconds. Lease events are append-only audit records.
- GitHub writes are rechecked immediately beforehand and retain their existing head-SHA or force-with-lease guards.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.