### PR TITLE
feat(governance): support explicit single-maintainer issue review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ opens pull requests only after repository-specific gates and local human review.
   gates, not ranking hints.
 - Never automate security reports or mass comments. Repository Issue creation must
   pass through the configured online Project draft, a fresh duplicate/security
-  review digest, a distinct reviewer, and the separate promotion gate.
+  review digest, the reviewer policy from trusted user configuration, and the
+  separate promotion gate. Distinct review remains the default; self-review is
+  allowed only when `issue_review.require_distinct_reviewer = false` is explicitly
+  set in the user-owned configuration for a single-maintainer repository.
 - Keep public-repository tests inside the hardened verifier container.
 
 For Issue triage, implementation handoff, PR preparation, and CI/reviewer follow-up,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ RepoSteward 采用 Issue 驱动、聚焦 PR、自动检查和人工 Review 的�
 请先创建或认领 Issue，再开始实现。
 
 多人共同准备 Issue 时，先使用团队配置的 GitHub Project Draft Issue 作为线上提案。提案在转换为
-正式 Issue 前必须重新检查最新正文、潜在重复项和安全风险，并由提案创建者之外的 reviewer 确认。
+正式 Issue 前必须重新检查最新正文、潜在重复项和安全风险。默认要求提案创建者之外的 reviewer
+确认；单维护者仓库只有在可信用户配置显式设置 `require_distinct_reviewer = false` 时才允许创建者
+自行审核并转换。项目级配置不能降低这一要求。两种模式都不能绕过 review digest、重复项确认、
+安全扫描、GitHub 身份校验、环境开关或独立的 promotion 调用。
 
 ## 开始前
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ uv run reposteward issue review PROJECT_ITEM_ID_OR_URL \
   --repository owner/repository
 ```
 
-另一位 reviewer 检查 Project 正文和所有潜在重复项后，使用该次 review 返回的精确摘要进行转换：
+符合当前 reviewer 策略的维护者检查 Project 正文和所有潜在重复项后，使用该次 review 返回的精确
+摘要进行转换：
 
 ```bash
 REPOSTEWARD_ENABLE_ISSUE_PROMOTION=1 \
@@ -222,8 +223,13 @@ REPOSTEWARD_ENABLE_ISSUE_PROMOTION=1 \
   --duplicates-reviewed
 ```
 
-线上正文、Project、重复项结果或目标仓库发生变化时，旧摘要失效，必须重新 review。默认禁止提案
-创建者自行转换；检测到凭据或疑似安全漏洞时，暂存和转换都会失败，必须改用私有报告渠道。
+线上正文、Project、重复项结果或目标仓库发生变化时，旧摘要失效，必须重新 review。默认配置
+`require_distinct_reviewer = true`，禁止提案创建者自行转换；单维护者仓库可在用户配置的
+`[issue_review]` 中显式设为 `false`，或在初始化时使用 `--allow-issue-self-review`，此时同一维护者
+可以通过本地 CLI 审核并转换。该配置属于可信用户层，项目级 `.reposteward.toml` 不能覆盖。附带的
+GitHub Actions 模板仍固定采用默认的团队第二人模式；无论采用哪种模式，最新 digest、重复项确认、
+安全扫描、身份校验、环境开关和独立 promotion 都保持强制。检测到凭据或疑似安全漏洞时必须改用
+私有报告渠道。
 GitHub Actions 的人工审查与转换流程见 [`docs/github-actions.md`](docs/github-actions.md)。
 Project 页面 URL 里的数字 `itemId` 也可直接使用，因此不经本地 `stage` 而在线创建的提案同样可审核。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,9 @@ RepoSteward 在 Harness 之外持续保存这些信息，并提供稳定的控�
 - 可移植交接：不依赖某个供应商的会话 ID，也不依赖某个 GPT 账号的历史记录。
 
 Issue 在进入实现流水线前也采用准备/发布分离：GitHub Project Draft Issue 是多人共享的线上
-提案，仓库正式 Issue 是经过第二人审核后的工作契约。二者不能由一次无审核写操作直接贯通。
+提案，仓库正式 Issue 是经过配置化 reviewer 策略审核后的工作契约。团队模式默认要求第二人审核；
+单维护者模式只有在可信用户配置显式关闭 distinct reviewer 时才允许自审。二者不能由一次无审核
+写操作直接贯通。
 
 Harness 仍然可以保留自己的原生 session，作为命中缓存或继续推理的加速信息；它不是任务事实
 的唯一副本。
@@ -51,7 +53,7 @@ local draft ── explicit stage ──► Project Draft Issue
                                       │ online edits
                                       ▼
                          duplicate + security review digest
-                                      │ distinct reviewer
+                                      │ configured reviewer policy
                                       ▼
                               repository Issue
 ```

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -49,6 +49,12 @@ Issue 写权限；私有仓库还需要相应的 `repo` 访问。实际权限应
 - `reposteward-issue-review`：保护只读 Project token；
 - `reposteward-issue-publishing`：配置 required reviewers，并只允许受保护的默认分支部署。
 
+RepoSteward 默认使用 `require_distinct_reviewer = true`。只有单维护者在可信用户配置中显式设为
+`false` 时，提案创建者才可以同时作为 `--reviewed-by`；项目级配置无法覆盖 `[issue_review]`。
+当前附带 workflow 每次都生成默认配置，因此固定用于团队第二人模式。单维护者自审应使用本地受控
+CLI，而不是移除 workflow 的 Environment 保护。关闭 distinct reviewer 不会关闭最新 digest、
+重复项确认、安全扫描、发布身份校验、显式环境开关或 promotion 的独立调用。
+
 同时为默认分支配置 Ruleset，要求 PR、CI 和 Code Owner review。不要允许任意功能分支直接运行
 带上述 secrets 的 workflow。
 

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -16,6 +16,8 @@ signoff_commits = true
 project_owner = "your-github-login-or-organization"
 project_number = 1
 project_owner_type = "user"
+# Keep this true for team repositories. A single maintainer may explicitly set
+# it to false only in the trusted per-user configuration.
 require_distinct_reviewer = true
 
 [discovery]

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -45,6 +45,11 @@ def _parser() -> argparse.ArgumentParser:
         choices=("user", "organization"),
         default="user",
     )
+    initialize.add_argument(
+        "--allow-issue-self-review",
+        action="store_true",
+        help="allow a single maintainer to review and promote their own Issue proposal",
+    )
     initialize.add_argument("--force", action="store_true")
 
     repo = subparsers.add_parser("repo", help="manage project repositories")
@@ -366,6 +371,7 @@ def main(argv: list[str] | None = None) -> int:
                     issue_project_owner=args.issue_project_owner,
                     issue_project_number=args.issue_project_number,
                     issue_project_owner_type=args.issue_project_owner_type,
+                    require_distinct_reviewer=not args.allow_issue_self_review,
                     force=args.force,
                 )
             )

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -54,6 +54,7 @@ def render_user_config(
     issue_project_owner: str = "",
     issue_project_number: int = 0,
     issue_project_owner_type: str = "user",
+    require_distinct_reviewer: bool = True,
 ) -> str:
     return f"""config_version = {CONFIG_VERSION}
 
@@ -76,7 +77,7 @@ gh_auth_command = ["gh", "auth", "token", "--hostname", "github.com"]
 project_owner = {_toml_string(issue_project_owner)}
 project_number = {issue_project_number}
 project_owner_type = {_toml_string(issue_project_owner_type)}
-require_distinct_reviewer = true
+require_distinct_reviewer = {str(require_distinct_reviewer).lower()}
 
 [safety]
 max_active_pull_requests = 4
@@ -139,6 +140,7 @@ def initialize_user_config(
     issue_project_owner: str = "",
     issue_project_number: int = 0,
     issue_project_owner_type: str = "user",
+    require_distinct_reviewer: bool = True,
     force: bool = False,
 ) -> dict[str, Any]:
     if not login:
@@ -166,6 +168,7 @@ def initialize_user_config(
             issue_project_owner=issue_project_owner.strip(),
             issue_project_number=issue_project_number,
             issue_project_owner_type=issue_project_owner_type,
+            require_distinct_reviewer=require_distinct_reviewer,
         ),
         force=force,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,26 @@ class CliSetupTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["github_login"], "alice")
 
+    def test_init_can_explicitly_allow_issue_self_review(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "user.toml"
+
+            with redirect_stdout(io.StringIO()):
+                exit_code = main(
+                    [
+                        "init",
+                        "--path",
+                        str(path),
+                        "--login",
+                        "alice",
+                        "--allow-issue-self-review",
+                    ]
+                )
+            config = load_config(path)
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(config.issue_review.require_distinct_reviewer)
+
     def test_issue_draft_is_local_only(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_issue_proposals.py
+++ b/tests/test_issue_proposals.py
@@ -104,7 +104,13 @@ def proposal(
 
 
 class IssueProposalTests(unittest.TestCase):
-    def _pipeline(self, root: Path, *, login: str = "reviewer") -> Pipeline:
+    def _pipeline(
+        self,
+        root: Path,
+        *,
+        login: str = "reviewer",
+        require_distinct_reviewer: bool = True,
+    ) -> Pipeline:
         path = root / "config.toml"
         path.write_text(
             f"""config_version = 1
@@ -119,7 +125,7 @@ git_email = {f"{login}@example.com"!r}
 project_owner = "example"
 project_number = 1
 project_owner_type = "user"
-require_distinct_reviewer = true
+require_distinct_reviewer = {str(require_distinct_reviewer).lower()}
 [repositories."owner/repo"]
 """,
             encoding="utf-8",
@@ -269,6 +275,41 @@ require_distinct_reviewer = true
                     review_digest=report["review_digest"],
                     duplicates_reviewed=True,
                 )
+
+    def test_single_maintainer_can_self_approve_when_explicitly_configured(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            pipeline = self._pipeline(
+                Path(directory),
+                login="author",
+                require_distinct_reviewer=False,
+            )
+            client = FakeProposalClient(proposal(creator="author"), login="author")
+            pipeline.github = client
+            report = pipeline.issue_proposal_review(
+                "PVTI_example", repository="owner/repo"
+            )
+            with (
+                patch.dict("os.environ", {"REPOSTEWARD_ENABLE_ISSUE_PROMOTION": "1"}),
+                patch.object(
+                    pipeline,
+                    "_authenticated_publication_client",
+                    return_value=client,
+                ),
+            ):
+                published = pipeline.promote_issue_proposal(
+                    "PVTI_example",
+                    repository="owner/repo",
+                    reviewed_by="author",
+                    review_digest=report["review_digest"],
+                    duplicates_reviewed=True,
+                )
+
+        self.assertFalse(report["distinct_reviewer_required"])
+        self.assertTrue(published["public_write"])
+        self.assertEqual(published["issue_number"], 42)
+        self.assertEqual(client.converted, 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -82,6 +82,19 @@ class SetupTests(unittest.TestCase):
         self.assertEqual(parsed["issue_review"]["project_number"], 7)
         self.assertEqual(parsed["issue_review"]["project_owner_type"], "organization")
 
+    def test_init_can_explicitly_allow_single_maintainer_self_review(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+
+            initialize_user_config(
+                path=path,
+                login="alice",
+                require_distinct_reviewer=False,
+            )
+            parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+
+        self.assertFalse(parsed["issue_review"]["require_distinct_reviewer"])
+
     def test_repo_add_creates_project_config_that_layers_over_user_config(self) -> None:
         with TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## 关联 Issue

Closes #58

## 问题与改动

`require_distinct_reviewer = false` 已能让单维护者自行审核 Issue 提案，但仓库规范仍把第二人审核写成无条件要求，`init` 也没有显式入口生成该配置。

本 PR 统一 `AGENTS.md`、贡献指南、README、架构和操作文档中的两种模式，并增加 `reposteward init --allow-issue-self-review`。默认值仍为 `true`，项目级配置不能覆盖可信用户层；Project Draft、最新 review digest、重复项确认、安全扫描、身份校验、环境开关和独立 promotion 调用均保持强制。

仓库附带的 GitHub Actions 模板继续固定采用团队第二人模式，不在本 PR 中修改高风险 workflow。

## 验证

隔离 Runner 基于提交 `b981eb5a58819b25693146ad433fed198faec8f0` 执行：

```text
uv run python -m unittest discover -s tests -v  # 303 tests passed
uv run ruff check .                             # passed
uv run ruff format --check .                    # passed
uv run reposteward --help                       # passed
uv build                                        # passed
```

## 风险与兼容性

默认配置和初始化行为保持第二人审核；只有可信用户显式使用新开关时才允许自审。没有数据库迁移、协议变更、依赖变更或性能热路径影响。GitHub Actions 的自审模式不在本 PR 范围内。

## 自动化辅助

使用 Codex 协助检查代码、修改实现和运行验证。`tiammomo` 已复核完整 diff、提交签名、DCO、测试结果和公开说明，并对本次提交负责。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
