### PR TITLE
feat(publication): reconcile interrupted PR writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,11 @@ REPOSTEWARD_ENABLE_SUBMIT=1 \
 默认创建 Draft PR。`--reviewed-by` 必须等于用户配置中的 GitHub login，API token 的实际登录
 身份也必须一致。旧的 `STARFIX_ENABLE_SUBMIT=1` 暂时保留兼容读取。
 
+`submit` 会在 push、创建、重开或更新已有 PR 之前追加一个绑定 run、branch、head、目标仓库和
+操作者的持久意图，并在动作返回后追加规范化结果。若进程在远端成功后中断，下一次调用会先读取
+远端分支或 PR 对账：精确匹配时只补写本地状态，确认未执行时才继续，身份或 head 冲突时失败关闭。
+审计只保存稳定标识、摘要和有界结果，不保存 token、PR 完整正文或目标仓库内容。
+
 提交后可以增量查看变化：
 
 ```bash
@@ -566,7 +571,7 @@ uv run reposteward storage gc --repo owner/repository
 submitted run 或远端引用证明可恢复；活跃、未知、脏、未推送、路径异常和符号链接工作区都会保留。
 原始 GitHub 事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且
 每个 run 水位都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并
-始终保护事件索引、Checkpoint、Merge Decision、Merge Execution 和 GC 审计。
+始终保护事件索引、Checkpoint、Publication Attempt、Merge Decision、Merge Execution 和 GC 审计。
 
 实际应用需要命令参数和独立环境开关同时存在：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,13 @@ submit 与 merge 串行，不同 Issue 仍可并行。绑定租约时，每次�
 重新检查租约，并继续使用 head SHA、force-with-lease 等远端幂等条件。崩溃后的租约可在到期后接管，
 但旧 generation 不能继续写入本地事实，所有获取、续租、接管和释放动作都保留追加式审计记录。
 
+PR 发布采用与合并执行相同的 intent/result 边界。`publication_attempts` 对每个 push、create、
+reopen、existing-PR update 和补偿 close 先追加 `applying`，再追加有界 `completed` 结果；记录包含
+run、目标、branch、验证 head、预期远端 head、操作者和租约 generation，不包含 token、PR 正文或
+仓库内容。发现未完成 intent 时，接管者必须先读取远端 branch/PR：精确匹配则补全审计，确认未执行
+才继续，未知或冲突状态失败关闭。远端已成功但本地 run/checkpoint 未补齐时，同一 submit 可以只修复
+本地投影而不重复公开写入。
+
 事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
 的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
@@ -141,11 +148,14 @@ submit 与 merge 串行，不同 Issue 仍可并行。绑定租约时，每次�
 Checkpoint、Git 状态干净且 HEAD 可从 submitted run 或远端引用恢复时才会进入计划。apply 会再次
 核对目录身份、元数据快照、HEAD 和 run 状态，变化即跳过。GC 默认 dry-run；apply 同时要求
 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后追加审计。普通 GC 永不删除事件索引、
-Context Checkpoint、Portfolio Dependency、Merge Decision、Merge Execution 或自身审计。
+Context Checkpoint、Publication Attempt、Portfolio Dependency、Merge Decision、Merge Execution
+或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 - `merge_executions`：按 attempt 追加保存执行身份、指定决策、精确 head、方法、写入前意图与最终
   GitHub 结果；`applying` 没有对应 `completed` 时表示进程可能在外部写入期间中断，重试必须先回读。
+- `publication_attempts`：按 step 追加保存 PR 发布动作的 intent/result，并记录完成该阶段的租约
+  owner/generation；普通 GC 不删除，重试用未完成 step 对账远端事实。
 - `portfolio_dependency_events`：按依赖对追加保存维护者 confirm/revoke、当前 head、身份、来源和
   前一事件；事件 digest 唯一，读取时会同时校验物化列与规范化载荷。
 - `owner_review_attestations`：追加保存单维护者对精确 PR 事实的本地审查声明；物化 scope、规范化

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -967,6 +967,22 @@ class GitHubClient:
             ],
         }
 
+    def branch_head_sha(self, full_name: str, branch: str) -> str:
+        """Return one exact remote branch head, or empty when it does not exist."""
+        if not branch:
+            raise ValueError("branch must not be empty")
+        encoded = urllib.parse.quote(branch, safe="")
+        try:
+            payload, _ = self._request("GET", f"/repos/{full_name}/branches/{encoded}")
+        except GitHubError as exc:
+            if exc.status_code == 404:
+                return ""
+            raise
+        sha = str(((payload.get("commit") or {}).get("sha")) or "")
+        if len(sha) != 40 or any(value not in "0123456789abcdef" for value in sha):
+            raise GitHubError("GitHub branch response omitted a valid head SHA")
+        return sha
+
     def check_runs(self, upstream: str, ref: str) -> tuple[dict[str, Any], ...]:
         values = self._paginated_rest_values(
             f"/repos/{upstream}/commits/{urllib.parse.quote(ref, safe='')}/check-runs",

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -8,7 +8,7 @@ import sqlite3
 import subprocess
 import threading
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import asdict, replace
 from datetime import UTC, date, datetime, timedelta
@@ -76,7 +76,7 @@ from .usage import (
     session_resume_outcome,
 )
 from .verifier import DockerVerifier
-from .workspace import WorkspaceManager
+from .workspace import WorkspaceError, WorkspaceManager
 from .workspace_storage import (
     WORKSPACE_KIND,
     delete_workspace,
@@ -2226,6 +2226,7 @@ class Pipeline:
                 "github_event_index",
                 "merge_decision_audit",
                 "merge_execution_audit",
+                "publication_attempt_audit",
                 "portfolio_dependency_audit",
                 "storage_gc_audit",
             ],
@@ -3792,6 +3793,577 @@ class Pipeline:
             "public_write": public_write,
         }
 
+    @staticmethod
+    def _publication_pull_payload(
+        pull_request: PullRequest,
+        *,
+        public_write: bool,
+        reconciliation: str = "",
+    ) -> dict[str, Any]:
+        return {
+            "public_write": public_write,
+            "pull_number": pull_request.number,
+            "pull_url": pull_request.url,
+            "pull_state": pull_request.state,
+            "pull_draft": pull_request.draft,
+            "remote_head_sha": pull_request.head_sha,
+            "reconciliation": reconciliation,
+        }
+
+    def _publication_record(
+        self,
+        identity: dict[str, Any],
+        *,
+        stage: str,
+        outcome: str,
+        lease: RunLease,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self.store.append_publication_attempt(
+            **identity,
+            stage=stage,
+            outcome=outcome,
+            lease=lease,
+            payload=payload,
+        )
+
+    def _publication_step(
+        self,
+        *,
+        attempt_id: str,
+        run_id: str,
+        repository: str,
+        issue_number: int,
+        actor: str,
+        action: str,
+        destination: str,
+        branch: str,
+        head_sha: str,
+        base_branch: str,
+        expected_remote_sha: str = "",
+        target_pull_number: int = 0,
+        lease: RunLease,
+    ) -> dict[str, Any]:
+        identity = {
+            "attempt_id": attempt_id,
+            "step_id": uuid.uuid4().hex,
+            "run_id": run_id,
+            "repository": repository,
+            "issue_number": issue_number,
+            "actor": actor,
+            "action": action,
+            "destination": destination,
+            "branch": branch,
+            "head_sha": head_sha,
+            "base_branch": base_branch,
+            "expected_remote_sha": expected_remote_sha,
+            "target_pull_number": target_pull_number,
+        }
+        self._publication_record(
+            identity,
+            stage="applying",
+            outcome="pending",
+            lease=lease,
+            payload={},
+        )
+        return identity
+
+    @staticmethod
+    def _publication_pull_matches(
+        pull_request: PullRequest,
+        *,
+        destination: str,
+        branch: str,
+        base_branch: str,
+        head_sha: str = "",
+    ) -> bool:
+        expected_owner = destination.split("/", 1)[0].casefold()
+        return (
+            pull_request.head_owner.casefold() == expected_owner
+            and pull_request.head_branch == branch
+            and pull_request.base_branch == base_branch
+            and (not head_sha or pull_request.head_sha == head_sha)
+        )
+
+    def _reconcile_publication_step(
+        self,
+        client: GitHubClient,
+        row: dict[str, Any],
+        *,
+        lease: RunLease,
+    ) -> tuple[str, PullRequest | None]:
+        identity = {
+            key: row[key]
+            for key in (
+                "attempt_id",
+                "step_id",
+                "run_id",
+                "repository",
+                "issue_number",
+                "actor",
+                "action",
+                "destination",
+                "branch",
+                "head_sha",
+                "base_branch",
+                "expected_remote_sha",
+                "target_pull_number",
+            )
+        }
+        action = str(row["action"])
+        pull_request: PullRequest | None = None
+        payload: dict[str, Any]
+        try:
+            if action in {"push", "update"}:
+                remote_head = client.branch_head_sha(
+                    str(row["destination"]), str(row["branch"])
+                )
+                payload = {
+                    "public_write": False,
+                    "remote_head_sha": remote_head,
+                    "reconciliation": "remote_branch_read",
+                }
+                if remote_head == str(row["head_sha"]):
+                    outcome = "reconciled"
+                elif remote_head == str(row["expected_remote_sha"]):
+                    outcome = "not_applied"
+                else:
+                    outcome = "blocked"
+            elif action == "create":
+                pull_request = client.existing_pull_request(
+                    str(row["repository"]),
+                    owner=str(row["destination"]).split("/", 1)[0],
+                    branch=str(row["branch"]),
+                )
+                if pull_request is None:
+                    outcome = "not_applied"
+                    payload = {
+                        "public_write": False,
+                        "reconciliation": "pull_request_not_found",
+                    }
+                elif self._publication_pull_matches(
+                    pull_request,
+                    destination=str(row["destination"]),
+                    branch=str(row["branch"]),
+                    base_branch=str(row["base_branch"]),
+                    head_sha=str(row["head_sha"]),
+                ):
+                    outcome = "reconciled"
+                    payload = self._publication_pull_payload(
+                        pull_request,
+                        public_write=False,
+                        reconciliation="matching_pull_request_found",
+                    )
+                else:
+                    outcome = "blocked"
+                    payload = self._publication_pull_payload(
+                        pull_request,
+                        public_write=False,
+                        reconciliation="pull_request_identity_changed",
+                    )
+            else:
+                pull_number = int(row["target_pull_number"])
+                if pull_number < 1:
+                    raise PolicyError(
+                        "publication reconciliation requires a pull request number"
+                    )
+                pull_request = client.pull_request(str(row["repository"]), pull_number)
+                matches = self._publication_pull_matches(
+                    pull_request,
+                    destination=str(row["destination"]),
+                    branch=str(row["branch"]),
+                    base_branch=str(row["base_branch"]),
+                )
+                desired_state = "closed" if action == "close" else "open"
+                if not matches:
+                    outcome = "blocked"
+                    reconciliation = "pull_request_identity_changed"
+                elif pull_request.state.casefold() == desired_state:
+                    outcome = "reconciled"
+                    reconciliation = f"pull_request_{desired_state}"
+                else:
+                    outcome = "not_applied"
+                    reconciliation = f"pull_request_not_{desired_state}"
+                payload = self._publication_pull_payload(
+                    pull_request,
+                    public_write=False,
+                    reconciliation=reconciliation,
+                )
+        except GitHubError as exc:
+            raise PolicyError(
+                "incomplete publication result could not be reconciled"
+            ) from exc
+        self._publication_record(
+            identity,
+            stage="completed",
+            outcome=outcome,
+            lease=lease,
+            payload=payload,
+        )
+        if outcome == "blocked":
+            raise PolicyError(
+                "incomplete publication action conflicts with current remote state"
+            )
+        return outcome, pull_request
+
+    def _reconcile_incomplete_publication(
+        self,
+        client: GitHubClient,
+        *,
+        run_id: str,
+        details: dict[str, Any],
+        lease: RunLease,
+    ) -> None:
+        while rows := self.store.incomplete_publication_attempts(run_id, limit=500):
+            for row in rows:
+                if (
+                    str(row["head_sha"]) != str(details["commit_sha"])
+                    or str(row["branch"]) != str(details["branch"])
+                    or str(row["base_branch"]) != str(details["base_branch"])
+                ):
+                    identity = {
+                        key: row[key]
+                        for key in (
+                            "attempt_id",
+                            "step_id",
+                            "run_id",
+                            "repository",
+                            "issue_number",
+                            "actor",
+                            "action",
+                            "destination",
+                            "branch",
+                            "head_sha",
+                            "base_branch",
+                            "expected_remote_sha",
+                            "target_pull_number",
+                        )
+                    }
+                    self._publication_record(
+                        identity,
+                        stage="completed",
+                        outcome="blocked",
+                        lease=lease,
+                        payload={
+                            "public_write": False,
+                            "reconciliation": "verified_scope_changed",
+                        },
+                    )
+                    raise PolicyError(
+                        "incomplete publication action belongs to a different "
+                        "verified scope"
+                    )
+                self.store.validate_run_lease(lease)
+                self._reconcile_publication_step(client, row, lease=lease)
+
+    def _publication_action_completed(
+        self,
+        run_id: str,
+        *,
+        action: str,
+        pull_number: int = 0,
+    ) -> bool:
+        return self.store.publication_action_completed(
+            run_id,
+            action=action,
+            target_pull_number=pull_number,
+        )
+
+    def _publish_branch(
+        self,
+        client: GitHubClient,
+        *,
+        attempt_id: str,
+        run_id: str,
+        repository: str,
+        issue_number: int,
+        actor: str,
+        action: str,
+        destination: str,
+        branch: str,
+        head_sha: str,
+        base_branch: str,
+        expected_remote_sha: str,
+        target_pull_number: int,
+        worktree: Path,
+        lease: RunLease,
+    ) -> bool:
+        remote_head = client.branch_head_sha(destination, branch)
+        if remote_head == head_sha:
+            identity = self._publication_step(
+                attempt_id=attempt_id,
+                run_id=run_id,
+                repository=repository,
+                issue_number=issue_number,
+                actor=actor,
+                action=action,
+                destination=destination,
+                branch=branch,
+                head_sha=head_sha,
+                base_branch=base_branch,
+                expected_remote_sha=expected_remote_sha,
+                target_pull_number=target_pull_number,
+                lease=lease,
+            )
+            self._publication_record(
+                identity,
+                stage="completed",
+                outcome="already_current",
+                lease=lease,
+                payload={
+                    "public_write": False,
+                    "remote_head_sha": remote_head,
+                    "reconciliation": "branch_already_at_verified_head",
+                },
+            )
+            return False
+        if remote_head != expected_remote_sha:
+            raise PolicyError(
+                "remote publication branch changed before the audited push"
+            )
+        identity = self._publication_step(
+            attempt_id=attempt_id,
+            run_id=run_id,
+            repository=repository,
+            issue_number=issue_number,
+            actor=actor,
+            action=action,
+            destination=destination,
+            branch=branch,
+            head_sha=head_sha,
+            base_branch=base_branch,
+            expected_remote_sha=expected_remote_sha,
+            target_pull_number=target_pull_number,
+            lease=lease,
+        )
+        try:
+            self.store.validate_run_lease(lease)
+            self.workspaces.push(
+                worktree,
+                destination,
+                branch,
+                expected_remote_sha=expected_remote_sha,
+            )
+        except (WorkspaceError, subprocess.SubprocessError, OSError):
+            outcome, _pull = self._reconcile_publication_step(
+                client,
+                {**identity, "stage": "applying", "outcome": "pending"},
+                lease=lease,
+            )
+            if outcome == "reconciled":
+                return True
+            raise
+        self._publication_record(
+            identity,
+            stage="completed",
+            outcome="succeeded",
+            lease=lease,
+            payload={
+                "public_write": True,
+                "remote_head_sha": head_sha,
+                "reconciliation": "push_returned_success",
+            },
+        )
+        return True
+
+    def _publish_pull_action(
+        self,
+        client: GitHubClient,
+        *,
+        attempt_id: str,
+        run_id: str,
+        repository: str,
+        issue_number: int,
+        actor: str,
+        action: str,
+        destination: str,
+        branch: str,
+        head_sha: str,
+        base_branch: str,
+        target_pull_number: int,
+        lease: RunLease,
+        apply: Callable[[], PullRequest],
+    ) -> tuple[PullRequest, bool]:
+        identity = self._publication_step(
+            attempt_id=attempt_id,
+            run_id=run_id,
+            repository=repository,
+            issue_number=issue_number,
+            actor=actor,
+            action=action,
+            destination=destination,
+            branch=branch,
+            head_sha=head_sha,
+            base_branch=base_branch,
+            target_pull_number=target_pull_number,
+            lease=lease,
+        )
+        try:
+            self.store.validate_run_lease(lease)
+            pull_request = apply()
+        except GitHubError:
+            outcome, reconciled = self._reconcile_publication_step(
+                client,
+                {**identity, "stage": "applying", "outcome": "pending"},
+                lease=lease,
+            )
+            if outcome == "reconciled" and reconciled is not None:
+                return reconciled, True
+            raise
+        self._publication_record(
+            identity,
+            stage="completed",
+            outcome="succeeded",
+            lease=lease,
+            payload=self._publication_pull_payload(
+                pull_request,
+                public_write=True,
+                reconciliation=f"{action}_returned_success",
+            ),
+        )
+        return pull_request, True
+
+    def _record_current_pull(
+        self,
+        pull_request: PullRequest,
+        *,
+        attempt_id: str,
+        run_id: str,
+        repository: str,
+        issue_number: int,
+        actor: str,
+        action: str,
+        destination: str,
+        branch: str,
+        head_sha: str,
+        base_branch: str,
+        lease: RunLease,
+    ) -> None:
+        identity = self._publication_step(
+            attempt_id=attempt_id,
+            run_id=run_id,
+            repository=repository,
+            issue_number=issue_number,
+            actor=actor,
+            action=action,
+            destination=destination,
+            branch=branch,
+            head_sha=head_sha,
+            base_branch=base_branch,
+            target_pull_number=pull_request.number,
+            lease=lease,
+        )
+        self._publication_record(
+            identity,
+            stage="completed",
+            outcome="already_current",
+            lease=lease,
+            payload=self._publication_pull_payload(
+                pull_request,
+                public_write=False,
+                reconciliation="pull_request_already_at_verified_head",
+            ),
+        )
+
+    def _finalize_submission(
+        self,
+        *,
+        run: dict[str, Any],
+        details: dict[str, Any],
+        policy: RepositoryPolicy,
+        issue_number: int,
+        pull_request: PullRequest,
+        destination: str,
+        public_write: bool,
+        idempotent: bool,
+        attempt_id: str,
+    ) -> dict[str, Any]:
+        context_warning = ""
+        try:
+            submitted_details = {
+                **details,
+                "pr_url": pull_request.url,
+                "publication_destination": destination,
+                "publication_attempt_id": attempt_id,
+            }
+            self.store.update_run(
+                run["id"],
+                status="submitted",
+                stage="pull_request",
+                details=submitted_details,
+            )
+            self.store.set_candidate_status(policy.name, issue_number, "submitted")
+            self.store.record_submission(policy.name, issue_number, pull_request.url)
+            context_bundle = self.store.context_bundle(str(run["id"]))
+            if context_bundle is not None:
+                previous = context_bundle.get("checkpoint")
+                if not isinstance(previous, dict):
+                    previous = {}
+                already_submitted = previous.get("status") == "submitted" and any(
+                    isinstance(value, dict)
+                    and value.get("kind") == "pull_request"
+                    and value.get("locator") == pull_request.url
+                    for value in previous.get("evidence", ())
+                )
+                if not already_submitted:
+                    completed = tuple(previous.get("completed", ())) + (
+                        "Published the reviewed commit as a pull request.",
+                    )
+                    evidence = tuple(previous.get("evidence", ())) + (
+                        {
+                            "kind": "pull_request",
+                            "locator": pull_request.url,
+                            "status": "open",
+                            "digest": str(details["commit_sha"]),
+                            "summary": (
+                                "submitted through the explicit human review gate"
+                            ),
+                        },
+                    )
+                    self.store.save_checkpoint(
+                        work_item_id=str(context_bundle["work_item"]["id"]),
+                        run_id=str(run["id"]),
+                        context_pack_id=str(context_bundle["context_metadata"]["id"]),
+                        status="submitted",
+                        payload={
+                            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+                            "work_item_id": context_bundle["work_item"]["id"],
+                            "run_id": run["id"],
+                            "context_pack_id": context_bundle["context_metadata"]["id"],
+                            "status": "submitted",
+                            "head_commit": details["commit_sha"],
+                            "completed": completed,
+                            "remaining": (
+                                "Monitor CI and reviewer feedback through incremental follow-up.",
+                            ),
+                            "next_action": "monitor_pull_request",
+                            "blockers": (),
+                            "decisions": tuple(previous.get("decisions", ())),
+                            "evidence": evidence,
+                        },
+                    )
+                self.store.update_work_item_status(
+                    str(context_bundle["work_item"]["id"]), "submitted"
+                )
+        except (KeyError, TypeError, ValueError, sqlite3.Error, StoreError) as exc:
+            context_warning = (
+                f"pull request published; local state update failed: {exc}"
+            )
+        result = {
+            "pr_url": pull_request.url,
+            "pr_number": pull_request.number,
+            "draft": pull_request.draft,
+            "branch": details["branch"],
+            "submission_strategy": policy.submission_strategy,
+            "destination": destination,
+            "attempt_id": attempt_id,
+            "idempotent": idempotent,
+            "public_write": public_write,
+        }
+        if context_warning:
+            result["warning"] = context_warning
+        return result
+
     def submit(
         self,
         repository: str,
@@ -3831,7 +4403,8 @@ class Pipeline:
                 f"--reviewed-by must attest the configured account {self.config.github.login!r}"
             )
         token = resolve_token(self.config.github, required=True)
-        authenticated = GitHubClient(self.config.github, token).authenticated_login()
+        client = GitHubClient(self.config.github, token)
+        authenticated = client.authenticated_login()
         if authenticated.casefold() != self.config.github.login.casefold():
             raise GitHubError(
                 f"token belongs to {authenticated!r}, expected {self.config.github.login!r}"
@@ -3841,11 +4414,44 @@ class Pipeline:
             raise PolicyError(f"repository contribution gate is not satisfied: {gate}")
 
         run = self.store.latest_run(policy.name, issue_number)
-        if run is None or run["status"] != "ready":
+        if run is None or run["status"] not in {"ready", "submitted"}:
             raise PolicyError(
                 "no verified change is ready for human review and submission"
             )
         details = run["details"]
+        if run["status"] == "submitted":
+            match = re.search(r"/pull/(\d+)/?$", str(details.get("pr_url", "")))
+            if not match:
+                raise PolicyError("submitted run is missing its pull request identity")
+            pull_request = client.pull_request(policy.name, int(match.group(1)))
+            destination = str(details.get("publication_destination") or "")
+            if not destination:
+                destination = (
+                    policy.name
+                    if policy.submission_strategy == "same-repository"
+                    else f"{pull_request.head_owner}/{policy.name.split('/', 1)[1]}"
+                )
+            if not self._publication_pull_matches(
+                pull_request,
+                destination=destination,
+                branch=str(details.get("branch") or ""),
+                base_branch=str(details.get("base_branch") or ""),
+                head_sha=str(details.get("commit_sha") or ""),
+            ):
+                raise PolicyError(
+                    "submitted pull request no longer matches the verified run"
+                )
+            return self._finalize_submission(
+                run=run,
+                details=details,
+                policy=policy,
+                issue_number=issue_number,
+                pull_request=pull_request,
+                destination=destination,
+                public_write=False,
+                idempotent=True,
+                attempt_id=str(details.get("publication_attempt_id") or "recovery"),
+            )
         worktree = Path(details["worktree"])
         if not (worktree / ".git").exists():
             raise PolicyError(f"prepared worktree is missing: {worktree}")
@@ -3870,7 +4476,6 @@ class Pipeline:
         if details["branch"] == details["base_branch"]:
             raise PolicyError("publication branch must differ from the base branch")
 
-        client = GitHubClient(self.config.github, token)
         self._validate_contribution_contract(worktree, policy)
         body = self._pull_request_body(
             issue_number, details, reviewed_by, policy=policy
@@ -3880,6 +4485,13 @@ class Pipeline:
             if policy.submission_strategy == "fork"
             else policy.name.split("/", 1)[0]
         )
+        attempt_id = uuid.uuid4().hex
+        self._reconcile_incomplete_publication(
+            client,
+            run_id=str(run["id"]),
+            details=details,
+            lease=mutation_lease,
+        )
         closed_pull: PullRequest | None = None
         existing_pull: PullRequest | None = None
         if reopen_pull_request:
@@ -3888,9 +4500,10 @@ class Pipeline:
                     "a prepared repair cannot reopen another pull request"
                 )
             closed_pull = client.pull_request(policy.name, reopen_pull_request)
-            if closed_pull.state != "closed":
+            if closed_pull.state not in {"closed", "open"}:
                 raise PolicyError(
-                    f"pull request {policy.name}#{reopen_pull_request} is not closed"
+                    f"pull request {policy.name}#{reopen_pull_request} has unsupported "
+                    f"state {closed_pull.state!r}"
                 )
             expected = (
                 planned_head_owner.casefold(),
@@ -3908,7 +4521,16 @@ class Pipeline:
                     f"{planned_head_owner}:{details['branch']} -> "
                     f"{details['base_branch']}"
                 )
-            self._ensure_new_pull_capacity(client, policy)
+            if closed_pull.state == "closed":
+                self._ensure_new_pull_capacity(client, policy)
+            elif not self._publication_action_completed(
+                str(run["id"]),
+                action="reopen",
+                pull_number=reopen_pull_request,
+            ):
+                raise PolicyError(
+                    f"pull request {policy.name}#{reopen_pull_request} is already open"
+                )
         else:
             existing_pull = client.existing_pull_request(
                 policy.name,
@@ -3922,28 +4544,84 @@ class Pipeline:
         if head_owner.casefold() != planned_head_owner.casefold():
             raise PolicyError("publication target identity changed during submission")
 
+        public_write = False
         if reopen_pull_request:
             assert closed_pull is not None
-            self.store.validate_run_lease(mutation_lease)
-            pull_request = client.reopen_pull_request(
-                policy.name,
-                reopen_pull_request,
-                owner=head_owner,
-                branch=details["branch"],
-                base=details["base_branch"],
-                title=details["agent_result"]["pr_title"],
-                body=body,
-            )
-            try:
-                self.store.validate_run_lease(mutation_lease)
-                self.workspaces.push(
-                    worktree,
-                    destination,
-                    details["branch"],
-                    expected_remote_sha=closed_pull.head_sha,
+            reopened_here = False
+            pull_request = closed_pull
+            if closed_pull.state == "closed":
+                pull_request, reopened_here = self._publish_pull_action(
+                    client,
+                    attempt_id=attempt_id,
+                    run_id=str(run["id"]),
+                    repository=policy.name,
+                    issue_number=issue_number,
+                    actor=reviewed_by,
+                    action="reopen",
+                    destination=destination,
+                    branch=details["branch"],
+                    head_sha=details["commit_sha"],
+                    base_branch=details["base_branch"],
+                    target_pull_number=reopen_pull_request,
+                    lease=mutation_lease,
+                    apply=lambda: client.reopen_pull_request(
+                        policy.name,
+                        reopen_pull_request,
+                        owner=head_owner,
+                        branch=details["branch"],
+                        base=details["base_branch"],
+                        title=details["agent_result"]["pr_title"],
+                        body=body,
+                    ),
                 )
-            except Exception:
-                client.close_pull_request(policy.name, reopen_pull_request)
+                public_write = public_write or reopened_here
+            try:
+                public_write = (
+                    self._publish_branch(
+                        client,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="update",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        expected_remote_sha=closed_pull.head_sha,
+                        target_pull_number=reopen_pull_request,
+                        worktree=worktree,
+                        lease=mutation_lease,
+                    )
+                    or public_write
+                )
+            except (
+                WorkspaceError,
+                subprocess.SubprocessError,
+                OSError,
+                PolicyError,
+            ):
+                if reopened_here:
+                    _closed, close_write = self._publish_pull_action(
+                        client,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="close",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        target_pull_number=reopen_pull_request,
+                        lease=mutation_lease,
+                        apply=lambda: client.close_pull_request(
+                            policy.name, reopen_pull_request
+                        ),
+                    )
+                    public_write = public_write or close_write
                 raise
             pull_request = client.pull_request(policy.name, reopen_pull_request)
         else:
@@ -3961,100 +4639,148 @@ class Pipeline:
                     details=details,
                 )
             if existing_pull:
-                if existing_pull.base_branch != details["base_branch"]:
+                if not self._publication_pull_matches(
+                    existing_pull,
+                    destination=destination,
+                    branch=details["branch"],
+                    base_branch=details["base_branch"],
+                ):
                     raise PolicyError(
-                        f"pull request {policy.name}#{existing_pull.number} targets "
-                        f"{existing_pull.base_branch!r}, expected "
-                        f"{details['base_branch']!r}"
+                        f"pull request {policy.name}#{existing_pull.number} no longer "
+                        "matches the prepared publication branch"
                     )
-                self.store.validate_run_lease(mutation_lease)
-                self.workspaces.push(
-                    worktree,
-                    destination,
-                    details["branch"],
-                    expected_remote_sha=existing_pull.head_sha,
-                )
-                pull_request = client.pull_request(policy.name, existing_pull.number)
+                if existing_pull.head_sha == details["commit_sha"]:
+                    self._record_current_pull(
+                        existing_pull,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="update",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        lease=mutation_lease,
+                    )
+                    pull_request = existing_pull
+                else:
+                    public_write = self._publish_branch(
+                        client,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="update",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        expected_remote_sha=existing_pull.head_sha,
+                        target_pull_number=existing_pull.number,
+                        worktree=worktree,
+                        lease=mutation_lease,
+                    )
+                    pull_request = client.pull_request(
+                        policy.name, existing_pull.number
+                    )
             else:
-                self.store.validate_run_lease(mutation_lease)
-                self.workspaces.push(worktree, destination, details["branch"])
-                self.store.validate_run_lease(mutation_lease)
-                pull_request = client.create_pull_request(
+                public_write = self._publish_branch(
+                    client,
+                    attempt_id=attempt_id,
+                    run_id=str(run["id"]),
+                    repository=policy.name,
+                    issue_number=issue_number,
+                    actor=reviewed_by,
+                    action="push",
+                    destination=destination,
+                    branch=details["branch"],
+                    head_sha=details["commit_sha"],
+                    base_branch=details["base_branch"],
+                    expected_remote_sha="",
+                    target_pull_number=0,
+                    worktree=worktree,
+                    lease=mutation_lease,
+                )
+                pull_request = client.existing_pull_request(
                     policy.name,
                     owner=head_owner,
                     branch=details["branch"],
-                    base=details["base_branch"],
-                    title=details["agent_result"]["pr_title"],
-                    body=body,
-                    draft=self.config.safety.draft_pull_requests,
                 )
-        self.store.update_run(
-            run["id"],
-            status="submitted",
-            stage="pull_request",
-            details={**details, "pr_url": pull_request.url},
-        )
-        self.store.set_candidate_status(policy.name, issue_number, "submitted")
-        self.store.record_submission(policy.name, issue_number, pull_request.url)
-        context_warning = ""
-        try:
-            context_bundle = self.store.context_bundle(str(run["id"]))
-            if context_bundle is not None:
-                previous = context_bundle.get("checkpoint")
-                if not isinstance(previous, dict):
-                    previous = {}
-                completed = tuple(previous.get("completed", ())) + (
-                    "Published the reviewed commit as a pull request.",
-                )
-                evidence = tuple(previous.get("evidence", ())) + (
-                    {
-                        "kind": "pull_request",
-                        "locator": pull_request.url,
-                        "status": "open",
-                        "digest": str(details["commit_sha"]),
-                        "summary": "submitted through the explicit human review gate",
-                    },
-                )
-                self.store.save_checkpoint(
-                    work_item_id=str(context_bundle["work_item"]["id"]),
-                    run_id=str(run["id"]),
-                    context_pack_id=str(context_bundle["context_metadata"]["id"]),
-                    status="submitted",
-                    payload={
-                        "schema_version": CHECKPOINT_SCHEMA_VERSION,
-                        "work_item_id": context_bundle["work_item"]["id"],
-                        "run_id": run["id"],
-                        "context_pack_id": context_bundle["context_metadata"]["id"],
-                        "status": "submitted",
-                        "head_commit": details["commit_sha"],
-                        "completed": completed,
-                        "remaining": (
-                            "Monitor CI and reviewer feedback through incremental follow-up.",
+                if pull_request is not None:
+                    if not self._publication_pull_matches(
+                        pull_request,
+                        destination=destination,
+                        branch=details["branch"],
+                        base_branch=details["base_branch"],
+                        head_sha=details["commit_sha"],
+                    ):
+                        raise PolicyError(
+                            "a concurrently created pull request has conflicting facts"
+                        )
+                    self._record_current_pull(
+                        pull_request,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="create",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        lease=mutation_lease,
+                    )
+                else:
+                    pull_request, create_write = self._publish_pull_action(
+                        client,
+                        attempt_id=attempt_id,
+                        run_id=str(run["id"]),
+                        repository=policy.name,
+                        issue_number=issue_number,
+                        actor=reviewed_by,
+                        action="create",
+                        destination=destination,
+                        branch=details["branch"],
+                        head_sha=details["commit_sha"],
+                        base_branch=details["base_branch"],
+                        target_pull_number=0,
+                        lease=mutation_lease,
+                        apply=lambda: client.create_pull_request(
+                            policy.name,
+                            owner=head_owner,
+                            branch=details["branch"],
+                            base=details["base_branch"],
+                            title=details["agent_result"]["pr_title"],
+                            body=body,
+                            draft=self.config.safety.draft_pull_requests,
                         ),
-                        "next_action": "monitor_pull_request",
-                        "blockers": (),
-                        "decisions": tuple(previous.get("decisions", ())),
-                        "evidence": evidence,
-                    },
-                )
-                self.store.update_work_item_status(
-                    str(context_bundle["work_item"]["id"]), "submitted"
-                )
-        except (KeyError, TypeError, ValueError, sqlite3.Error) as exc:
-            # The public write already succeeded. Surface local continuity repair as
-            # a warning instead of reporting a false submission failure.
-            context_warning = f"pull request published; context update failed: {exc}"
-        result = {
-            "pr_url": pull_request.url,
-            "pr_number": pull_request.number,
-            "draft": pull_request.draft,
-            "branch": details["branch"],
-            "submission_strategy": policy.submission_strategy,
-            "destination": destination,
-        }
-        if context_warning:
-            result["warning"] = context_warning
-        return result
+                    )
+                    public_write = public_write or create_write
+        if not self._publication_pull_matches(
+            pull_request,
+            destination=destination,
+            branch=details["branch"],
+            base_branch=details["base_branch"],
+            head_sha=details["commit_sha"],
+        ):
+            raise PolicyError(
+                "published pull request does not match the verified commit"
+            )
+        return self._finalize_submission(
+            run=run,
+            details=details,
+            policy=policy,
+            issue_number=issue_number,
+            pull_request=pull_request,
+            destination=destination,
+            public_write=public_write,
+            idempotent=not public_write,
+            attempt_id=attempt_id,
+        )
 
     @staticmethod
     def _harness_label(details: dict[str, Any]) -> str:

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -16,7 +16,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -466,6 +466,46 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON run_lease_events(scope, sequence DESC)
         """,
     ),
+    15: (
+        """
+        CREATE TABLE IF NOT EXISTS publication_attempts (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            attempt_id TEXT NOT NULL,
+            step_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            repository TEXT NOT NULL,
+            issue_number INTEGER NOT NULL,
+            actor TEXT NOT NULL,
+            action TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            destination TEXT NOT NULL,
+            branch TEXT NOT NULL,
+            head_sha TEXT NOT NULL,
+            base_branch TEXT NOT NULL,
+            expected_remote_sha TEXT NOT NULL DEFAULT '',
+            target_pull_number INTEGER NOT NULL DEFAULT 0,
+            lease_owner TEXT NOT NULL,
+            lease_generation INTEGER NOT NULL,
+            payload TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(run_id) REFERENCES runs(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS publication_attempts_for_run
+        ON publication_attempts(run_id, sequence)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS publication_attempts_for_repository
+        ON publication_attempts(repository, issue_number, sequence DESC)
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS publication_attempts_stage_once
+        ON publication_attempts(step_id, stage)
+        """,
+    ),
 }
 
 
@@ -524,6 +564,22 @@ OWNER_REVIEW_FACT_KEYS = frozenset(
         "dependency_digest",
         "activity_digest",
         "rules_digest",
+    }
+)
+
+PUBLICATION_ACTIONS = frozenset({"push", "create", "reopen", "update", "close"})
+PUBLICATION_COMPLETED_OUTCOMES = frozenset(
+    {"succeeded", "reconciled", "already_current", "not_applied", "blocked", "failed"}
+)
+PUBLICATION_PAYLOAD_KEYS = frozenset(
+    {
+        "public_write",
+        "remote_head_sha",
+        "pull_number",
+        "pull_url",
+        "pull_state",
+        "pull_draft",
+        "reconciliation",
     }
 )
 
@@ -2056,6 +2112,17 @@ class Store:
                 """,
             ),
             (
+                "publication_attempt_audit",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(payload AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(created_at) AS newest_at
+                FROM publication_attempts
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
                 "portfolio_dependency_audit",
                 """
                 SELECT repository, COUNT(*) AS records,
@@ -3484,6 +3551,234 @@ class Store:
         value["eligible"] = bool(value["eligible"])
         value["payload"] = payload
         return value
+
+    def append_publication_attempt(
+        self,
+        *,
+        attempt_id: str,
+        step_id: str,
+        run_id: str,
+        repository: str,
+        issue_number: int,
+        actor: str,
+        action: str,
+        stage: str,
+        outcome: str,
+        destination: str,
+        branch: str,
+        head_sha: str,
+        base_branch: str,
+        expected_remote_sha: str = "",
+        target_pull_number: int = 0,
+        lease: RunLease,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Append one bounded publication intent or reconciliation result."""
+        if not attempt_id or not step_id or not run_id:
+            raise ValueError("publication attempt identities must not be empty")
+        repository = repository.casefold()
+        destination = destination.casefold()
+        actor = actor.strip()
+        if (
+            not repository
+            or not destination
+            or not actor
+            or not branch
+            or not base_branch
+        ):
+            raise ValueError("publication attempt fields must not be empty")
+        if issue_number < 1 or target_pull_number < 0:
+            raise ValueError("publication issue and pull numbers must be valid")
+        expected_lease_scope = f"issue:{repository}#{issue_number}"
+        if lease.scope != expected_lease_scope:
+            raise StoreError(
+                "publication lease does not match its repository and issue"
+            )
+        if action not in PUBLICATION_ACTIONS:
+            raise ValueError(f"unsupported publication action: {action!r}")
+        if stage not in {"applying", "completed"}:
+            raise ValueError(f"unsupported publication stage: {stage!r}")
+        allowed_outcomes = (
+            {"pending"} if stage == "applying" else PUBLICATION_COMPLETED_OUTCOMES
+        )
+        if outcome not in allowed_outcomes:
+            raise ValueError("publication stage and outcome do not match")
+        if not _is_lower_hex(head_sha, 40):
+            raise ValueError("publication head_sha must be a lowercase Git SHA")
+        if expected_remote_sha and not _is_lower_hex(expected_remote_sha, 40):
+            raise ValueError(
+                "publication expected_remote_sha must be empty or a lowercase Git SHA"
+            )
+        if len(branch) > 255 or len(base_branch) > 255:
+            raise ValueError("publication branch names are too long")
+        if not isinstance(payload, dict):
+            raise TypeError("publication payload must be an object")
+        unknown_payload = set(payload) - PUBLICATION_PAYLOAD_KEYS
+        if unknown_payload:
+            raise ValueError(
+                "publication payload contains unsupported fields: "
+                + ", ".join(sorted(unknown_payload))
+            )
+        if any(not isinstance(value, (str, int, bool)) for value in payload.values()):
+            raise TypeError("publication payload values must be bounded scalars")
+        encoded_payload = _canonical_json(payload)
+        if len(encoded_payload.encode()) > 4_096:
+            raise ValueError("publication payload exceeds 4096 bytes")
+        record_id = uuid.uuid4().hex
+        now = utc_now()
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            self._assert_run_lease_row(connection, lease)
+            run = connection.execute(
+                "SELECT repository, issue_number FROM runs WHERE id=?", (run_id,)
+            ).fetchone()
+            if run is None:
+                raise StoreError("publication attempt references a missing run")
+            if (
+                str(run["repository"]) != repository
+                or int(run["issue_number"]) != issue_number
+            ):
+                raise StoreError("publication attempt does not match its run")
+            previous = connection.execute(
+                """
+                SELECT attempt_id, run_id, repository, issue_number, actor, action,
+                       destination, branch, head_sha, base_branch,
+                       expected_remote_sha, target_pull_number
+                FROM publication_attempts WHERE step_id=? LIMIT 1
+                """,
+                (step_id,),
+            ).fetchone()
+            identity = {
+                "attempt_id": attempt_id,
+                "run_id": run_id,
+                "repository": repository,
+                "issue_number": issue_number,
+                "actor": actor,
+                "action": action,
+                "destination": destination,
+                "branch": branch,
+                "head_sha": head_sha,
+                "base_branch": base_branch,
+                "expected_remote_sha": expected_remote_sha,
+                "target_pull_number": target_pull_number,
+            }
+            if previous is not None and any(
+                previous[key] != value for key, value in identity.items()
+            ):
+                raise StoreError("publication step identity changed")
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO publication_attempts(
+                        id, attempt_id, step_id, run_id, repository, issue_number,
+                        actor, action, stage, outcome, destination, branch, head_sha,
+                        base_branch, expected_remote_sha, target_pull_number,
+                        lease_owner, lease_generation, payload, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record_id,
+                        attempt_id,
+                        step_id,
+                        run_id,
+                        repository,
+                        issue_number,
+                        actor,
+                        action,
+                        stage,
+                        outcome,
+                        destination,
+                        branch,
+                        head_sha,
+                        base_branch,
+                        expected_remote_sha,
+                        target_pull_number,
+                        lease.owner,
+                        lease.generation,
+                        encoded_payload,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise StoreError(
+                    "publication step already contains this stage"
+                ) from exc
+        return {
+            "id": record_id,
+            "attempt_id": attempt_id,
+            "step_id": step_id,
+            "action": action,
+            "stage": stage,
+            "outcome": outcome,
+            "lease_owner": lease.owner,
+            "lease_generation": lease.generation,
+            "created_at": now,
+        }
+
+    @staticmethod
+    def _publication_attempt(row: sqlite3.Row) -> dict[str, Any]:
+        value = dict(row)
+        value["payload"] = json.loads(str(value["payload"]))
+        return value
+
+    def publication_attempts(
+        self, run_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM publication_attempts
+                WHERE run_id=? ORDER BY sequence ASC LIMIT ?
+                """,
+                (run_id, limit),
+            ).fetchall()
+        return [self._publication_attempt(row) for row in rows]
+
+    def incomplete_publication_attempts(
+        self, run_id: str, *, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT applying.*
+                FROM publication_attempts applying
+                WHERE applying.run_id=? AND applying.stage='applying'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM publication_attempts completed
+                      WHERE completed.step_id=applying.step_id
+                        AND completed.stage='completed'
+                  )
+                ORDER BY applying.sequence ASC LIMIT ?
+                """,
+                (run_id, limit),
+            ).fetchall()
+        return [self._publication_attempt(row) for row in rows]
+
+    def publication_action_completed(
+        self,
+        run_id: str,
+        *,
+        action: str,
+        target_pull_number: int = 0,
+    ) -> bool:
+        if action not in PUBLICATION_ACTIONS:
+            raise ValueError(f"unsupported publication action: {action!r}")
+        if target_pull_number < 0:
+            raise ValueError("publication pull number must not be negative")
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT 1 FROM publication_attempts
+                WHERE run_id=? AND action=? AND stage='completed'
+                  AND outcome IN ('succeeded', 'reconciled', 'already_current')
+                  AND (?=0 OR target_pull_number=?)
+                LIMIT 1
+                """,
+                (run_id, action, target_pull_number, target_pull_number),
+            ).fetchone()
+        return row is not None
 
     def append_merge_execution(
         self,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -187,6 +187,41 @@ class GitHubOwnerReviewPolicyTests(unittest.TestCase):
         self.assertEqual(repository.owner_login, "owner")
 
 
+class GitHubBranchHeadTests(unittest.TestCase):
+    def test_branch_head_returns_an_exact_sha_and_encodes_slashes(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        with patch.object(
+            client,
+            "_request",
+            return_value=({"commit": {"sha": "a" * 40}}, None),
+        ) as request:
+            sha = client.branch_head_sha("owner/repo", "alice/feat/example")
+
+        self.assertEqual(sha, "a" * 40)
+        request.assert_called_once_with(
+            "GET", "/repos/owner/repo/branches/alice%2Ffeat%2Fexample"
+        )
+
+    def test_missing_branch_is_empty_and_malformed_sha_fails_closed(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        with patch.object(
+            client,
+            "_request",
+            side_effect=GitHubError("missing", status_code=404),
+        ):
+            self.assertEqual(client.branch_head_sha("owner/repo", "missing"), "")
+
+        with (
+            patch.object(
+                client,
+                "_request",
+                return_value=({"commit": {"sha": "not-a-sha"}}, None),
+            ),
+            self.assertRaisesRegex(GitHubError, "valid head SHA"),
+        ):
+            client.branch_head_sha("owner/repo", "main")
+
+
 class GitHubCompetingWorkTests(unittest.TestCase):
     def test_claim_comment_and_linked_pull_request_are_blockers(self) -> None:
         client = GitHubClient(GitHubConfig(), token="test-token")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -151,6 +151,7 @@ class StorageGcTests(unittest.TestCase):
         self.assertEqual(store.audit, [])
         self.assertIn("merge_decision_audit", result["protected_categories"])
         self.assertIn("merge_execution_audit", result["protected_categories"])
+        self.assertIn("publication_attempt_audit", result["protected_categories"])
         self.assertIn("portfolio_dependency_audit", result["protected_categories"])
 
     def test_gc_apply_requires_switch_then_audits_and_deletes(self) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -341,6 +341,33 @@ class StoreTests(unittest.TestCase):
             self.assertIsNotNone(table)
             self.assertIsNotNone(unique_stage)
 
+    def test_version_fourteen_database_receives_publication_attempt_audit(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.sqlite3"
+            Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                connection.execute("DROP TABLE publication_attempts")
+                connection.execute("PRAGMA user_version=14")
+
+            migrated = Store(path)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                table = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE name='publication_attempts'"
+                ).fetchone()
+                unique_stage = connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type='index'
+                      AND name='publication_attempts_stage_once'
+                    """
+                ).fetchone()
+
+            self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+            self.assertIsNotNone(table)
+            self.assertIsNotNone(unique_stage)
+
     def test_version_ten_database_receives_portfolio_dependency_audit(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "state.sqlite3"
@@ -1100,6 +1127,98 @@ class StoreTests(unittest.TestCase):
         )
         by_category = {value["category"]: value for value in statistics}
         self.assertEqual(by_category["merge_execution_audit"]["records"], 2)
+
+    def test_publication_attempts_are_bounded_append_only_and_recoverable(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Store(Path(directory) / "state.sqlite3")
+            run_id = store.start_run("owner/repo", 7, "publication")
+            lease_one = store.acquire_run_lease("issue:owner/repo#7", owner="worker-1")
+            identity = {
+                "attempt_id": "attempt-1",
+                "step_id": "step-1",
+                "run_id": run_id,
+                "repository": "Owner/Repo",
+                "issue_number": 7,
+                "actor": "alice",
+                "action": "push",
+                "destination": "Owner/Repo",
+                "branch": "alice/feat/example",
+                "head_sha": "a" * 40,
+                "base_branch": "main",
+                "expected_remote_sha": "b" * 40,
+                "target_pull_number": 12,
+            }
+            applying = store.append_publication_attempt(
+                **identity,
+                stage="applying",
+                outcome="pending",
+                lease=lease_one,
+                payload={},
+            )
+            pending = store.incomplete_publication_attempts(run_id)
+            store.release_run_lease(lease_one)
+            lease_two = store.acquire_run_lease("issue:owner/repo#7", owner="worker-2")
+            completed = store.append_publication_attempt(
+                **identity,
+                stage="completed",
+                outcome="reconciled",
+                lease=lease_two,
+                payload={
+                    "public_write": False,
+                    "remote_head_sha": "a" * 40,
+                    "reconciliation": "remote_branch_read",
+                },
+            )
+            records = store.publication_attempts(run_id)
+            remaining = store.incomplete_publication_attempts(run_id)
+            action_completed = store.publication_action_completed(
+                run_id, action="push", target_pull_number=12
+            )
+            other_pull_completed = store.publication_action_completed(
+                run_id, action="push", target_pull_number=13
+            )
+            statistics = {
+                value["category"]: value
+                for value in store.storage_statistics(repository="owner/repo")
+            }
+
+            with self.assertRaisesRegex(ValueError, "unsupported fields"):
+                store.append_publication_attempt(
+                    **{**identity, "step_id": "step-secret"},
+                    stage="applying",
+                    outcome="pending",
+                    lease=lease_two,
+                    payload={"token": "must-not-be-stored"},
+                )
+            with self.assertRaisesRegex(StoreError, "already contains"):
+                store.append_publication_attempt(
+                    **identity,
+                    stage="completed",
+                    outcome="succeeded",
+                    lease=lease_two,
+                    payload={"public_write": True},
+                )
+            with self.assertRaisesRegex(StoreError, "lease is stale"):
+                store.append_publication_attempt(
+                    **{**identity, "step_id": "step-stale"},
+                    stage="applying",
+                    outcome="pending",
+                    lease=lease_one,
+                    payload={},
+                )
+
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(remaining, [])
+        self.assertEqual(applying["lease_generation"], 1)
+        self.assertEqual(completed["lease_generation"], 2)
+        self.assertEqual(
+            [value["stage"] for value in records], ["applying", "completed"]
+        )
+        self.assertTrue(action_completed)
+        self.assertFalse(other_pull_completed)
+        self.assertEqual(statistics["publication_attempt_audit"]["records"], 2)
 
     def test_merge_decision_audit_rejects_tampered_material(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_submission_capacity.py
+++ b/tests/test_submission_capacity.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import unittest
 from contextlib import nullcontext
+from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -13,7 +14,8 @@ from reposteward.config import RepositoryPolicy
 from reposteward.github import GitHubError, PullRequest
 from reposteward.pipeline import Pipeline
 from reposteward.policy import PolicyError
-from reposteward.store import RunLease
+from reposteward.store import RunLease, StoreError
+from reposteward.workspace import WorkspaceError
 
 
 def _pull(number: int, *, author: str = "alice", draft: bool = False) -> PullRequest:
@@ -34,9 +36,12 @@ class _SubmissionStore:
     def __init__(self, details: dict) -> None:
         self.details = details
         self.updated: dict | None = None
+        self.publication: list[dict] = []
+        self.status = "ready"
+        self.fail_local_update_once = False
 
     def latest_run(self, _repository: str, _issue_number: int) -> dict:
-        return {"id": "run-1", "status": "ready", "details": self.details}
+        return {"id": "run-1", "status": self.status, "details": self.details}
 
     @staticmethod
     def acquire_run_lease(scope: str, *, owner: str, ttl_seconds: int) -> RunLease:
@@ -59,7 +64,12 @@ class _SubmissionStore:
         return None
 
     def update_run(self, _run_id: str, **values) -> None:
+        if self.fail_local_update_once:
+            self.fail_local_update_once = False
+            raise ValueError("simulated local interruption")
         self.updated = values
+        self.status = str(values["status"])
+        self.details = dict(values["details"])
 
     @staticmethod
     def set_candidate_status(
@@ -74,6 +84,47 @@ class _SubmissionStore:
     @staticmethod
     def context_bundle(_run_id: str) -> None:
         return None
+
+    def append_publication_attempt(self, **values) -> dict:
+        record = {**values, "id": f"event-{len(self.publication) + 1}"}
+        self.publication.append(record)
+        return record
+
+    def incomplete_publication_attempts(
+        self, run_id: str, *, limit: int = 100
+    ) -> list[dict]:
+        completed = {
+            value["step_id"]
+            for value in self.publication
+            if value["run_id"] == run_id and value["stage"] == "completed"
+        }
+        return [
+            value
+            for value in self.publication
+            if value["run_id"] == run_id
+            and value["stage"] == "applying"
+            and value["step_id"] not in completed
+        ][:limit]
+
+    def publication_attempts(self, run_id: str, *, limit: int = 100) -> list[dict]:
+        return [value for value in self.publication if value["run_id"] == run_id][
+            :limit
+        ]
+
+    def publication_action_completed(
+        self, run_id: str, *, action: str, target_pull_number: int = 0
+    ) -> bool:
+        return any(
+            value["run_id"] == run_id
+            and value["action"] == action
+            and value["stage"] == "completed"
+            and value["outcome"] in {"succeeded", "reconciled", "already_current"}
+            and (
+                not target_pull_number
+                or value["target_pull_number"] == target_pull_number
+            )
+            for value in self.publication
+        )
 
 
 class _SubmissionGitHub:
@@ -93,6 +144,18 @@ class _SubmissionGitHub:
         self.create_calls = 0
         self.repository_calls = 0
         self.reopen_calls = 0
+        self.close_calls = 0
+        self.create_error_after_write = False
+        self.reopen_error_after_write = False
+        self.push_error_after_write = False
+        self.remote_head = (
+            existing.head_sha
+            if existing is not None
+            else closed.head_sha
+            if closed
+            else ""
+        )
+        self.new_head = ""
 
     @staticmethod
     def authenticated_login() -> str:
@@ -114,9 +177,22 @@ class _SubmissionGitHub:
         self.repository_calls += 1
         return SimpleNamespace(can_push=True)
 
-    def create_pull_request(self, *_args, **_kwargs) -> PullRequest:
+    def create_pull_request(self, _repository: str, **kwargs) -> PullRequest:
         self.create_calls += 1
-        return _pull(99)
+        self.existing = PullRequest(
+            number=99,
+            url="https://github.com/owner/repo/pull/99",
+            state="open",
+            draft=bool(kwargs["draft"]),
+            author="alice",
+            head_owner=str(kwargs["owner"]),
+            head_branch=str(kwargs["branch"]),
+            head_sha=self.new_head,
+            base_branch=str(kwargs["base"]),
+        )
+        if self.create_error_after_write:
+            raise GitHubError("simulated create timeout")
+        return self.existing
 
     def pull_request(self, _repository: str, _number: int) -> PullRequest:
         pull = self.closed or self.existing
@@ -126,7 +202,26 @@ class _SubmissionGitHub:
     def reopen_pull_request(self, *_args, **_kwargs) -> PullRequest:
         self.reopen_calls += 1
         assert self.closed is not None
+        self.closed = replace(self.closed, state="open")
+        if self.reopen_error_after_write:
+            raise GitHubError("simulated reopen timeout")
         return self.closed
+
+    def close_pull_request(self, *_args, **_kwargs) -> PullRequest:
+        self.close_calls += 1
+        assert self.closed is not None
+        self.closed = replace(self.closed, state="closed")
+        return self.closed
+
+    def branch_head_sha(self, _repository: str, _branch: str) -> str:
+        return self.remote_head
+
+    def mark_pushed(self, head_sha: str) -> None:
+        self.remote_head = head_sha
+        if self.existing is not None:
+            self.existing = replace(self.existing, head_sha=head_sha)
+        if self.closed is not None:
+            self.closed = replace(self.closed, head_sha=head_sha)
 
 
 class SubmissionCapacityTests(unittest.TestCase):
@@ -216,6 +311,15 @@ class SubmissionCapacityTests(unittest.TestCase):
     def submit(
         self, pipeline: Pipeline, client: _SubmissionGitHub, *, reopen: int = 0
     ) -> dict:
+        client.new_head = pipeline.store.details["commit_sha"]
+
+        def push(*_args, **_kwargs) -> None:
+            client.mark_pushed(client.new_head)
+            if client.push_error_after_write:
+                client.push_error_after_write = False
+                raise WorkspaceError("simulated push transport failure")
+
+        pipeline.workspaces.push.side_effect = push
         with (
             patch.dict(os.environ, {"REPOSTEWARD_ENABLE_SUBMIT": "1"}),
             patch("reposteward.pipeline.resolve_token", return_value="token"),
@@ -252,7 +356,7 @@ class SubmissionCapacityTests(unittest.TestCase):
             author="alice",
             head_owner="owner",
             head_branch="alice/feat/example",
-            head_sha=self.head,
+            head_sha="f" * 40,
             base_branch="main",
         )
         client = _SubmissionGitHub(
@@ -301,6 +405,159 @@ class SubmissionCapacityTests(unittest.TestCase):
 
         self.assertEqual(client.open_calls, 1)
         self.assertEqual(client.reopen_calls, 0)
+        pipeline.workspaces.push.assert_not_called()
+
+    def test_new_pull_records_each_external_action_before_and_after_write(
+        self,
+    ) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub()
+
+        result = self.submit(pipeline, client)
+
+        events = pipeline.store.publication
+        self.assertTrue(result["public_write"])
+        self.assertFalse(result["idempotent"])
+        self.assertEqual(client.create_calls, 1)
+        self.assertEqual(
+            [(value["action"], value["stage"]) for value in events],
+            [
+                ("push", "applying"),
+                ("push", "completed"),
+                ("create", "applying"),
+                ("create", "completed"),
+            ],
+        )
+        self.assertTrue(all("token" not in value["payload"] for value in events))
+        self.assertTrue(all("body" not in value["payload"] for value in events))
+
+    def test_uncertain_push_is_reconciled_before_the_pull_is_created(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub()
+        client.push_error_after_write = True
+
+        result = self.submit(pipeline, client)
+
+        push_results = [
+            value
+            for value in pipeline.store.publication
+            if value["action"] == "push" and value["stage"] == "completed"
+        ]
+        self.assertEqual(push_results[0]["outcome"], "reconciled")
+        self.assertEqual(result["pr_number"], 99)
+        self.assertEqual(client.create_calls, 1)
+
+    def test_uncertain_create_is_reconciled_without_a_duplicate_request(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub()
+        client.create_error_after_write = True
+
+        result = self.submit(pipeline, client)
+
+        create_results = [
+            value
+            for value in pipeline.store.publication
+            if value["action"] == "create" and value["stage"] == "completed"
+        ]
+        self.assertEqual(create_results[0]["outcome"], "reconciled")
+        self.assertEqual(client.create_calls, 1)
+        self.assertEqual(result["pr_number"], 99)
+
+    def test_retry_repairs_local_state_without_repeating_remote_writes(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub()
+        pipeline.store.fail_local_update_once = True
+
+        first = self.submit(pipeline, client)
+        push_calls = pipeline.workspaces.push.call_count
+        second = self.submit(pipeline, client)
+
+        self.assertIn("local state update failed", first["warning"])
+        self.assertTrue(second["idempotent"])
+        self.assertFalse(second["public_write"])
+        self.assertEqual(pipeline.workspaces.push.call_count, push_calls)
+        self.assertEqual(client.create_calls, 1)
+        self.assertEqual(pipeline.store.status, "submitted")
+
+    def test_uncertain_reopen_is_reconciled_before_updating_the_branch(self) -> None:
+        pipeline = self.pipeline()
+        closed = PullRequest(
+            number=40,
+            url="https://github.com/owner/repo/pull/40",
+            state="closed",
+            draft=True,
+            author="alice",
+            head_owner="owner",
+            head_branch="alice/feat/example",
+            head_sha="f" * 40,
+            base_branch="main",
+        )
+        client = _SubmissionGitHub(closed=closed)
+        client.reopen_error_after_write = True
+
+        result = self.submit(pipeline, client, reopen=40)
+
+        reopen_results = [
+            value
+            for value in pipeline.store.publication
+            if value["action"] == "reopen" and value["stage"] == "completed"
+        ]
+        self.assertEqual(reopen_results[0]["outcome"], "reconciled")
+        self.assertEqual(client.reopen_calls, 1)
+        self.assertEqual(result["pr_number"], 40)
+
+    def test_lost_lease_after_reopen_does_not_issue_a_rollback_write(self) -> None:
+        pipeline = self.pipeline()
+        closed = PullRequest(
+            number=40,
+            url="https://github.com/owner/repo/pull/40",
+            state="closed",
+            draft=True,
+            author="alice",
+            head_owner="owner",
+            head_branch="alice/feat/example",
+            head_sha="f" * 40,
+            base_branch="main",
+        )
+        client = _SubmissionGitHub(closed=closed)
+        pipeline.store.validate_run_lease = Mock(
+            side_effect=[None, StoreError("stale publication lease")]
+        )
+
+        with self.assertRaisesRegex(StoreError, "stale publication lease"):
+            self.submit(pipeline, client, reopen=40)
+
+        self.assertEqual(client.reopen_calls, 1)
+        self.assertEqual(client.close_calls, 0)
+        pipeline.workspaces.push.assert_not_called()
+
+    def test_incomplete_attempt_for_an_old_head_fails_closed(self) -> None:
+        pipeline = self.pipeline()
+        client = _SubmissionGitHub()
+        pipeline.store.append_publication_attempt(
+            attempt_id="attempt-old",
+            step_id="step-old",
+            run_id="run-1",
+            repository="owner/repo",
+            issue_number=42,
+            actor="alice",
+            action="push",
+            stage="applying",
+            outcome="pending",
+            destination="owner/repo",
+            branch="alice/feat/example",
+            head_sha="e" * 40,
+            base_branch="main",
+            expected_remote_sha="",
+            target_pull_number=0,
+            lease=RunLease("issue:owner/repo#42", "old", 1, "expired"),
+            payload={},
+        )
+
+        with self.assertRaisesRegex(PolicyError, "different verified scope"):
+            self.submit(pipeline, client)
+
+        self.assertEqual(pipeline.store.publication[-1]["outcome"], "blocked")
         pipeline.workspaces.push.assert_not_called()
 
 


### PR DESCRIPTION
## 关联 Issue

Closes #60

## 问题与改动

`submit` 在 push、创建或重开 PR 已经远端成功、但客户端超时或本地状态尚未落盘时，缺少可恢复的持久意图，重试可能无法区分“未执行”和“已执行”。

本 PR 增加 schema v15 的 `publication_attempts` 追加式审计，在 push、create、reopen、existing-PR update 和补偿 close 前后记录绑定 run、验证 head、branch、目标、操作者与租约 generation 的 `applying/completed` 事件。未完成意图会先读取远端 branch/PR 对账：精确匹配时幂等补全，确认未执行时允许后续重试，身份或 head 冲突时失败关闭。远端成功但本地 run/checkpoint 更新中断时，重复 `submit` 只修复本地投影，不重复公开写入。

审计载荷采用字段白名单和大小上限，不保存 token、完整 PR 正文或目标仓库内容；普通 GC 将其作为受保护恢复证据。相关迁移、GitHub branch head 读取、租约接管、中断恢复、重复调用和冲突关闭均有回归测试。

## 验证

```text
uv run python -m unittest discover -s tests -v  # 314 tests passed
uvx ruff check .                                # passed
uvx ruff format --check .                       # passed
uv run reposteward --help                       # passed
uv lock --check                                 # passed
uv build                                        # passed
```

同一组正式命令已由 RepoSteward `adopt` 在无 GitHub 凭据的隔离 Runner 中再次执行并全部通过；review packet 绑定 commit `dc06d6367a87798e8f53d8ab7dd63fe6b071fc0c`。

## 风险与兼容性

- SQLite 从 v14 无损迁移到 v15，只新增审计表和索引，不改写历史数据。
- 正常发布的每个外部动作增加常数级 SQLite 追加和一次精确远端读取；未完成记录按 500 条分批线性对账，查询使用 `run_id` 与 `step_id/stage` 索引。
- 该路径不调用 Harness，不增加模型 token；审计载荷有界，普通 GC 不删除恢复证据。
- 未削弱人工提交开关、GitHub 身份校验、租约栅栏、精确 head 校验或 Draft PR 默认值。

## 自动化辅助

使用 Codex 协助实现和测试。维护者已人工检查完整 diff、异常边界、迁移、远端竞态、性能影响、敏感信息扫描、提交签名与 DCO，并对最终贡献负责。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
