### PR TITLE
feat(queue): persist recoverable task scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,44 @@ uv run reposteward list --all
 uv run reposteward inbox --repo owner/repository --format text
 ```
 
+需要跨进程、账号或 Harness 保存批量待办顺序时，可先把稳定控制面引用写入本地任务队列；enqueue
+不会执行任务、调用 Harness 或写入 GitHub：
+
+```bash
+uv run reposteward queue enqueue owner/repository prepare --issue 123 --priority 20
+uv run reposteward queue enqueue owner/repository follow-up --run-id RUN_ID
+uv run reposteward queue enqueue owner/repository submit --issue 123 \
+  --reviewed-by your-github-login --depends-on PREVIOUS_TASK_ID
+uv run reposteward queue inspect --repo owner/repository
+uv run reposteward queue inspect --task-id TASK_ID
+```
+
+同一仓库、动作、稳定引用、参数摘要和依赖的重复 enqueue 返回原任务；需要显式创建新一轮时传入新的
+`--idempotency-key`。任务按 priority 和入队顺序 claim，只有前置任务 completed 后才可执行。失败会
+区分可重试与 `manual_required`；瞬时错误按 5 秒起、最多 300 秒退避，并受 `--max-attempts` 限制。
+人工修正后可以显式 retry，未运行或租约已过期的任务可以 cancel：
+
+```bash
+REPOSTEWARD_ENABLE_QUEUE_APPLY=1 \
+  uv run reposteward queue retry TASK_ID --by your-github-login
+
+REPOSTEWARD_ENABLE_QUEUE_APPLY=1 \
+  uv run reposteward queue cancel TASK_ID --by your-github-login --reason superseded
+```
+
+执行队列需要独立开关；`submit`、owner attestation 和 `merge` 仍分别要求自己的原有开关与身份门禁，
+队列不会代为开启：
+
+```bash
+REPOSTEWARD_ENABLE_QUEUE_APPLY=1 \
+  uv run reposteward queue apply --repo owner/repository --limit 4
+```
+
+每个任务在慢 Harness、Runner 或 GitHub 调用期间由短 SQLite 事务续租，不持有数据库写锁。进程崩溃
+后过期任务可由新 worker 接管，旧 generation 不能提交结果。任务只保存 work item/run/Issue/PR ID、
+动作白名单和有界标量参数，不保存 prompt、token、评论正文或绝对工作区路径；attempt 审计不参与
+普通 GC。
+
 检查贡献门禁并准备修复：
 
 ```bash
@@ -571,7 +609,8 @@ uv run reposteward storage gc --repo owner/repository
 submitted run 或远端引用证明可恢复；活跃、未知、脏、未推送、路径异常和符号链接工作区都会保留。
 原始 GitHub 事件正文没有默认期限；只有仓库显式配置 `event_payload_retention_days` 后，超过期限且
 每个 run 水位都已覆盖的正文才进入候选。计划会列出每个候选、预计可回收字节及保留原因汇总，并
-始终保护事件索引、Checkpoint、Publication Attempt、Merge Decision、Merge Execution 和 GC 审计。
+始终保护事件索引、Checkpoint、Task Queue、Publication Attempt、Merge Decision、Merge Execution
+和 GC 审计。
 
 实际应用需要命令参数和独立环境开关同时存在：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,15 @@ run、目标、branch、验证 head、预期远端 head、操作者和租约 gen
 才继续，未知或冲突状态失败关闭。远端已成功但本地 run/checkpoint 未补齐时，同一 submit 可以只修复
 本地投影而不重复公开写入。
 
+持久任务队列只保存控制面意图。`queue_tasks` 物化 pending、running、completed、failed 和 cancelled
+状态，并以稳定引用与参数摘要实现幂等 enqueue、priority 排序和单向 task dependency；参数采用动作级
+白名单、有界标量和绝对路径拒绝规则。`queue_attempts` 追加记录 enqueue、claim、takeover、结果、
+取消和人工重排，不保存 prompt、token、评论正文、工作区路径或完整动作结果。claim 在短
+`BEGIN IMMEDIATE` 事务中原子完成，外部动作期间不持有 SQLite 锁，只用短事务心跳续租；过期租约可
+提升 generation 接管，旧 generation 的结果写入失败关闭。Pipeline apply 每次即时 claim 一个任务，
+并调用既有 prepare/follow-up/repair/submit/merge 门禁；队列开关不能替代各公开写入动作自己的环境、
+身份和事实校验。瞬时失败有界退避，策略或参数失败进入显式人工处理状态。
+
 事件正文默认没有清理期限。只有仓库策略显式设置正整数 `event_payload_retention_days`，且同一 PR
 的每个 run 水位都已经越过该事件时，正文才可成为 GC 候选。候选在删除事务内重新计算；删除会先
 写 tombstone，再移除 Blob。无配置、保留期内或任一 run 尚未形成 Checkpoint 的正文都必须保留。
@@ -148,14 +157,16 @@ run、目标、branch、验证 head、预期远端 head、操作者和租约 gen
 Checkpoint、Git 状态干净且 HEAD 可从 submitted run 或远端引用恢复时才会进入计划。apply 会再次
 核对目录身份、元数据快照、HEAD 和 run 状态，变化即跳过。GC 默认 dry-run；apply 同时要求
 `--apply` 和 `REPOSTEWARD_ENABLE_GC=1`，并在删除前后追加审计。普通 GC 永不删除事件索引、
-Context Checkpoint、Publication Attempt、Portfolio Dependency、Merge Decision、Merge Execution
-或自身审计。
+Context Checkpoint、Task Queue、Publication Attempt、Portfolio Dependency、Merge Decision、
+Merge Execution 或自身审计。
 - `merge_decisions`：追加保存每次合并评估的 head/base、policy、GitHub 快照与决策摘要；重复评估
   不覆盖旧结果，便于解释状态变化。
 - `merge_executions`：按 attempt 追加保存执行身份、指定决策、精确 head、方法、写入前意图与最终
   GitHub 结果；`applying` 没有对应 `completed` 时表示进程可能在外部写入期间中断，重试必须先回读。
 - `publication_attempts`：按 step 追加保存 PR 发布动作的 intent/result，并记录完成该阶段的租约
   owner/generation；普通 GC 不删除，重试用未完成 step 对账远端事实。
+- `queue_tasks` / `queue_attempts`：保存有界调度意图、当前状态、依赖、租约 generation 和追加式
+  attempt 历史；普通 GC 不删除，存储统计单独报告 control 与 audit 占用。
 - `portfolio_dependency_events`：按依赖对追加保存维护者 confirm/revoke、当前 head、身份、来源和
   前一事件；事件 digest 唯一，读取时会同时校验物化列与规范化载荷。
 - `owner_review_attestations`：追加保存单维护者对精确 PR 事实的本地审查声明；物化 scope、规范化

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -335,6 +335,68 @@ def _parser() -> argparse.ArgumentParser:
         help="update and reopen a closed PR instead of creating a new one",
     )
 
+    queue = subparsers.add_parser(
+        "queue", help="manage the persistent control-plane task queue"
+    )
+    queue_commands = queue.add_subparsers(dest="queue_command", required=True)
+    queue_enqueue = queue_commands.add_parser(
+        "enqueue", help="persist one idempotent task without executing it"
+    )
+    queue_enqueue.add_argument("repository")
+    queue_enqueue.add_argument(
+        "action",
+        choices=(
+            "prepare",
+            "follow-up",
+            "repair",
+            "submit",
+            "merge-decision",
+            "merge-attest",
+            "merge",
+        ),
+    )
+    queue_enqueue.add_argument("--issue", type=int, default=0)
+    queue_enqueue.add_argument("--pull-number", type=int, default=0)
+    queue_enqueue.add_argument("--run-id", default="")
+    queue_enqueue.add_argument("--work-item-id", default="")
+    queue_enqueue.add_argument("--priority", type=int, default=0)
+    queue_enqueue.add_argument("--depends-on", default="")
+    queue_enqueue.add_argument("--max-attempts", type=int, default=3)
+    queue_enqueue.add_argument("--idempotency-key", default="")
+    queue_enqueue.add_argument("--reviewed-by", default="")
+    queue_enqueue.add_argument("--decision-id", default="")
+    queue_enqueue.add_argument("--reopen", type=int, default=0)
+    queue_inspect = queue_commands.add_parser(
+        "inspect", help="read queue state and bounded attempt history"
+    )
+    queue_inspect.add_argument("--repo", default="")
+    queue_inspect.add_argument("--task-id", default="")
+    queue_inspect.add_argument(
+        "--state",
+        action="append",
+        choices=("pending", "running", "completed", "failed", "cancelled"),
+        default=[],
+    )
+    queue_inspect.add_argument("--limit", type=int, default=100)
+    queue_apply = queue_commands.add_parser(
+        "apply", help="explicitly execute ready tasks through Pipeline gates"
+    )
+    queue_apply.add_argument("--repo", default="")
+    queue_apply.add_argument("--worker", default="")
+    queue_apply.add_argument("--limit", type=int, default=1)
+    queue_apply.add_argument("--lease-seconds", type=int, default=900)
+    queue_cancel = queue_commands.add_parser(
+        "cancel", help="cancel one inactive or expired task"
+    )
+    queue_cancel.add_argument("task_id")
+    queue_cancel.add_argument("--by", required=True)
+    queue_cancel.add_argument("--reason", default="operator_cancelled")
+    queue_retry = queue_commands.add_parser(
+        "retry", help="explicitly requeue one failed or cancelled task"
+    )
+    queue_retry.add_argument("task_id")
+    queue_retry.add_argument("--by", required=True)
+
     run = subparsers.add_parser(
         "run", help="discover and prepare top auto-enabled issues"
     )
@@ -652,6 +714,59 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
             return 0
+        if args.command == "queue":
+            if args.queue_command == "enqueue":
+                _json(
+                    pipeline.enqueue_task(
+                        args.repository,
+                        action=args.action,
+                        issue_number=args.issue,
+                        pull_number=args.pull_number,
+                        run_id=args.run_id,
+                        work_item_id=args.work_item_id,
+                        priority=args.priority,
+                        depends_on_task_id=args.depends_on,
+                        max_attempts=args.max_attempts,
+                        idempotency_key=args.idempotency_key,
+                        reviewed_by=args.reviewed_by,
+                        decision_id=args.decision_id,
+                        reopen_pull_request=args.reopen,
+                    )
+                )
+                return 0
+            if args.queue_command == "inspect":
+                _json(
+                    pipeline.queue_inspect(
+                        repository=args.repo,
+                        task_id=args.task_id,
+                        states=tuple(args.state),
+                        limit=args.limit,
+                    )
+                )
+                return 0
+            if args.queue_command == "apply":
+                _json(
+                    pipeline.apply_queue(
+                        repository=args.repo,
+                        worker=args.worker,
+                        limit=args.limit,
+                        lease_seconds=args.lease_seconds,
+                    )
+                )
+                return 0
+            if args.queue_command == "cancel":
+                _json(
+                    pipeline.cancel_task(
+                        args.task_id,
+                        cancelled_by=args.by,
+                        reason_code=args.reason,
+                    )
+                )
+                return 0
+            if args.queue_command == "retry":
+                _json(pipeline.requeue_task(args.task_id, requeued_by=args.by))
+                return 0
+            raise AssertionError(f"unhandled queue command: {args.queue_command}")
         if args.command == "run":
             service = DiscoveryService(config, pipeline.github, pipeline.store)
             service.discover()

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -68,7 +68,7 @@ from .portfolio import build_portfolio_snapshot
 from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
-from .store import RunLease, Store, StoreError
+from .store import QueueLease, RunLease, Store, StoreError
 from .usage import (
     build_usage_report,
     compact_usage_budget,
@@ -2227,6 +2227,8 @@ class Pipeline:
                 "merge_decision_audit",
                 "merge_execution_audit",
                 "publication_attempt_audit",
+                "task_queue_control",
+                "task_queue_attempt_audit",
                 "portfolio_dependency_audit",
                 "storage_gc_audit",
             ],
@@ -2346,6 +2348,336 @@ class Pipeline:
             payload=applied,
         )
         return {**result, "audit": [applying, completed], "applied": applied}
+
+    def enqueue_task(
+        self,
+        repository: str,
+        *,
+        action: str,
+        issue_number: int = 0,
+        pull_number: int = 0,
+        run_id: str = "",
+        work_item_id: str = "",
+        priority: int = 0,
+        depends_on_task_id: str = "",
+        max_attempts: int = 3,
+        idempotency_key: str = "",
+        reviewed_by: str = "",
+        decision_id: str = "",
+        reopen_pull_request: int = 0,
+    ) -> dict[str, Any]:
+        """Persist one bounded control-plane task without executing it."""
+        policy = self.policy(repository)
+        parameters: dict[str, Any] = {}
+        if action in {"submit", "merge-attest", "merge"}:
+            parameters["reviewed_by"] = reviewed_by
+        if action == "merge":
+            parameters["decision_id"] = decision_id
+        if action == "submit" and reopen_pull_request:
+            parameters["reopen_pull_request"] = reopen_pull_request
+        task = self.store.enqueue_queue_task(
+            policy.name,
+            action=action,
+            enqueued_by=self.config.github.login,
+            work_item_id=work_item_id,
+            run_id=run_id,
+            issue_number=issue_number,
+            pull_number=pull_number,
+            parameters=parameters,
+            priority=priority,
+            depends_on_task_id=depends_on_task_id,
+            max_attempts=max_attempts,
+            idempotency_key=idempotency_key,
+        )
+        return {"task": task, "public_write": False}
+
+    def queue_inspect(
+        self,
+        *,
+        repository: str = "",
+        task_id: str = "",
+        states: tuple[str, ...] = (),
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """Return queue state and attempt metadata without invoking a Harness."""
+        normalized = self.policy(repository).name if repository else ""
+        tasks = self.store.queue_tasks(
+            repository=normalized,
+            task_id=task_id,
+            states=states,
+            limit=limit,
+        )
+        summary = self.store.queue_task_summary(repository=normalized)
+        if task_id:
+            summary = {
+                "counts": {
+                    state: sum(task["state"] == state for task in tasks)
+                    for state in (
+                        "pending",
+                        "running",
+                        "completed",
+                        "failed",
+                        "cancelled",
+                    )
+                },
+                "manual_required": sum(bool(task["manual_required"]) for task in tasks),
+                "dependency_blocked": sum(
+                    bool(task["blocked_by_dependency"]) for task in tasks
+                ),
+            }
+        result: dict[str, Any] = {
+            "repository": normalized,
+            "task_id": task_id,
+            **summary,
+            "tasks": tasks,
+            "public_write": False,
+        }
+        if task_id:
+            result["attempts"] = self.store.queue_attempts(task_id, limit=limit)
+        return result
+
+    @staticmethod
+    def _queue_result(task: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+        stable: dict[str, Any] = {}
+        for key in (
+            "run_id",
+            "status",
+            "stage",
+            "pr_number",
+            "pr_url",
+            "merge_commit_sha",
+            "merged",
+            "idempotent",
+            "public_write",
+            "next_action",
+        ):
+            value = result.get(key)
+            if isinstance(value, (str, int, bool)) and value != "":
+                stable[key] = value
+        audit = result.get("audit")
+        if task["action"] == "merge-decision" and isinstance(audit, dict):
+            decision_id = audit.get("id")
+            if isinstance(decision_id, str):
+                stable["decision_id"] = decision_id
+        if "run_id" not in stable and task.get("run_id"):
+            stable["run_id"] = str(task["run_id"])
+        stable.setdefault("public_write", False)
+        return stable
+
+    @staticmethod
+    def _queue_failure(exc: Exception) -> tuple[str, bool]:
+        if isinstance(exc, GitHubError):
+            transient = exc.status_code in {408, 425, 429} or (
+                exc.status_code is not None and exc.status_code >= 500
+            )
+            return ("github_transient" if transient else "github_rejected", transient)
+        if isinstance(exc, sqlite3.OperationalError):
+            return "storage_busy", True
+        if isinstance(exc, (WorkspaceError, OSError)):
+            return "workspace_or_io_error", True
+        if isinstance(exc, PolicyError):
+            return "policy_blocked", False
+        if isinstance(exc, (KeyError, TypeError, ValueError)):
+            return "invalid_task", False
+        return "execution_failed", False
+
+    def _execute_queued_action(self, task: dict[str, Any]) -> dict[str, Any]:
+        action = str(task["action"])
+        repository = str(task["repository"])
+        parameters = dict(task["parameters"])
+        run_id = str(task.get("run_id") or "")
+        if action == "prepare":
+            return self.prepare(repository, int(task["issue_number"]))
+        if action == "follow-up":
+            return self.follow_up(run_id)
+        if action == "repair":
+            return self.prepare_repair(run_id)
+        if action == "submit":
+            return self.submit(
+                repository,
+                int(task["issue_number"]),
+                reviewed_by=str(parameters["reviewed_by"]),
+                reopen_pull_request=int(parameters.get("reopen_pull_request") or 0),
+            )
+        if action == "merge-decision":
+            return self.merge_decision(run_id)
+        if action == "merge-attest":
+            return self.attest_owner_review(
+                run_id, reviewed_by=str(parameters["reviewed_by"])
+            )
+        if action == "merge":
+            return self.execute_merge(
+                run_id,
+                decision_id=str(parameters["decision_id"]),
+                reviewed_by=str(parameters["reviewed_by"]),
+            )
+        raise PolicyError(f"unsupported queued action: {action!r}")
+
+    @staticmethod
+    def _queue_lease_heartbeat(
+        store: Store,
+        lease: QueueLease,
+        *,
+        lease_seconds: int,
+        stopped: threading.Event,
+        lease_lost: threading.Event,
+    ) -> None:
+        interval = max(1, min(30, lease_seconds // 3))
+        while not stopped.wait(interval):
+            try:
+                store.renew_queue_lease(lease, lease_seconds=lease_seconds)
+            except StoreError:
+                lease_lost.set()
+                return
+            except (OSError, sqlite3.Error):
+                continue
+
+    def apply_queue(
+        self,
+        *,
+        repository: str = "",
+        worker: str = "",
+        limit: int = 1,
+        lease_seconds: int = 900,
+    ) -> dict[str, Any]:
+        """Explicitly execute persisted tasks through their existing Pipeline gates."""
+        if os.environ.get("REPOSTEWARD_ENABLE_QUEUE_APPLY") != "1":
+            raise PolicyError(
+                "queue apply is disabled; set REPOSTEWARD_ENABLE_QUEUE_APPLY=1"
+            )
+        if not 1 <= limit <= 100:
+            raise ValueError("queue apply limit must be between 1 and 100")
+        if not 5 <= lease_seconds <= 86_400:
+            raise ValueError("queue lease_seconds must be between 5 and 86400")
+        normalized = self.policy(repository).name if repository else ""
+        queue_worker = worker.strip() or f"{os.getpid()}:{uuid.uuid4().hex}"
+        outcomes: list[dict[str, Any]] = []
+        any_public_write = False
+        for _index in range(limit):
+            claimed = self.store.claim_queue_tasks(
+                worker=queue_worker,
+                limit=1,
+                lease_seconds=lease_seconds,
+                repository=normalized,
+            )
+            if not claimed:
+                break
+            task = claimed[0]
+            lease = task.pop("lease")
+            if not isinstance(lease, QueueLease):
+                raise StoreError("queue claim returned an invalid lease")
+            stopped = threading.Event()
+            lease_lost = threading.Event()
+
+            thread = threading.Thread(
+                target=self._queue_lease_heartbeat,
+                args=(self.store, lease),
+                kwargs={
+                    "lease_seconds": lease_seconds,
+                    "stopped": stopped,
+                    "lease_lost": lease_lost,
+                },
+                name=f"reposteward-queue-{task['id']}",
+                daemon=True,
+            )
+            thread.start()
+            try:
+                result = self._execute_queued_action(task)
+            except (
+                GitHubError,
+                KeyError,
+                OSError,
+                PolicyError,
+                RuntimeError,
+                sqlite3.Error,
+                subprocess.SubprocessError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                stopped.set()
+                thread.join(timeout=1)
+                error_code, retryable = self._queue_failure(exc)
+                if lease_lost.is_set():
+                    outcomes.append(
+                        {
+                            "task_id": task["id"],
+                            "action": task["action"],
+                            "status": "lease_lost",
+                            "error_code": error_code,
+                        }
+                    )
+                    continue
+                failed = self.store.fail_queue_task(
+                    lease, error_code=error_code, retryable=retryable
+                )
+                outcomes.append(
+                    {
+                        "task_id": task["id"],
+                        "action": task["action"],
+                        "status": "failed",
+                        "error_code": error_code,
+                        "retryable": retryable,
+                        "manual_required": bool(failed["manual_required"]),
+                    }
+                )
+                continue
+            finally:
+                stopped.set()
+                thread.join(timeout=1)
+            if lease_lost.is_set():
+                outcomes.append(
+                    {
+                        "task_id": task["id"],
+                        "action": task["action"],
+                        "status": "lease_lost",
+                    }
+                )
+                continue
+            stable_result = self._queue_result(task, result)
+            completed = self.store.complete_queue_task(lease, result=stable_result)
+            any_public_write = any_public_write or bool(
+                stable_result.get("public_write")
+            )
+            outcomes.append(
+                {
+                    "task_id": task["id"],
+                    "action": task["action"],
+                    "status": completed["state"],
+                    "result": stable_result,
+                }
+            )
+        return {
+            "repository": normalized,
+            "worker": queue_worker,
+            "requested_limit": limit,
+            "processed": len(outcomes),
+            "outcomes": outcomes,
+            "public_write": any_public_write,
+        }
+
+    def cancel_task(
+        self, task_id: str, *, cancelled_by: str, reason_code: str
+    ) -> dict[str, Any]:
+        if os.environ.get("REPOSTEWARD_ENABLE_QUEUE_APPLY") != "1":
+            raise PolicyError(
+                "queue mutation is disabled; set REPOSTEWARD_ENABLE_QUEUE_APPLY=1"
+            )
+        return {
+            "task": self.store.cancel_queue_task(
+                task_id, cancelled_by=cancelled_by, reason_code=reason_code
+            ),
+            "public_write": False,
+        }
+
+    def requeue_task(self, task_id: str, *, requeued_by: str) -> dict[str, Any]:
+        if os.environ.get("REPOSTEWARD_ENABLE_QUEUE_APPLY") != "1":
+            raise PolicyError(
+                "queue mutation is disabled; set REPOSTEWARD_ENABLE_QUEUE_APPLY=1"
+            )
+        return {
+            "task": self.store.requeue_queue_task(task_id, requeued_by=requeued_by),
+            "public_write": False,
+        }
 
     @staticmethod
     def _follow_up_diff_snippets(

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import re
 import sqlite3
 import uuid
 from collections.abc import Iterator
@@ -16,7 +17,7 @@ from typing import Any
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
     1: (
@@ -506,6 +507,80 @@ MIGRATIONS: dict[int, tuple[str, ...]] = {
         ON publication_attempts(step_id, stage)
         """,
     ),
+    16: (
+        """
+        CREATE TABLE IF NOT EXISTS queue_tasks (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            dedupe_key TEXT NOT NULL UNIQUE,
+            repository TEXT NOT NULL,
+            action TEXT NOT NULL,
+            work_item_id TEXT,
+            run_id TEXT,
+            issue_number INTEGER NOT NULL DEFAULT 0,
+            pull_number INTEGER NOT NULL DEFAULT 0,
+            parameters TEXT NOT NULL,
+            parameters_digest TEXT NOT NULL,
+            idempotency_digest TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            state TEXT NOT NULL,
+            depends_on_task_id TEXT,
+            max_attempts INTEGER NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            manual_required INTEGER NOT NULL DEFAULT 0,
+            last_error_code TEXT NOT NULL DEFAULT '',
+            lease_owner TEXT NOT NULL DEFAULT '',
+            lease_generation INTEGER NOT NULL DEFAULT 0,
+            lease_expires_at TEXT NOT NULL DEFAULT '',
+            available_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(work_item_id) REFERENCES work_items(id),
+            FOREIGN KEY(run_id) REFERENCES runs(id),
+            FOREIGN KEY(depends_on_task_id) REFERENCES queue_tasks(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS queue_tasks_claim
+        ON queue_tasks(
+            state, manual_required, available_at, priority DESC, sequence
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS queue_tasks_for_repository
+        ON queue_tasks(
+            repository, state, manual_required, available_at,
+            priority DESC, sequence
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS queue_tasks_expired_leases
+        ON queue_tasks(state, lease_expires_at, attempt_count)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS queue_tasks_for_dependency
+        ON queue_tasks(depends_on_task_id, state)
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS queue_attempts (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            task_id TEXT NOT NULL,
+            generation INTEGER NOT NULL,
+            worker TEXT NOT NULL,
+            event TEXT NOT NULL,
+            outcome TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            payload_digest TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(task_id) REFERENCES queue_tasks(id)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS queue_attempts_for_task
+        ON queue_attempts(task_id, sequence)
+        """,
+    ),
 }
 
 
@@ -517,6 +592,14 @@ class StoreError(RuntimeError):
 class RunLease:
     scope: str
     owner: str
+    generation: int
+    expires_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class QueueLease:
+    task_id: str
+    worker: str
     generation: int
     expires_at: str
 
@@ -580,6 +663,50 @@ PUBLICATION_PAYLOAD_KEYS = frozenset(
         "pull_state",
         "pull_draft",
         "reconciliation",
+    }
+)
+
+QUEUE_ACTIONS = frozenset(
+    {
+        "prepare",
+        "follow-up",
+        "repair",
+        "submit",
+        "merge-decision",
+        "merge-attest",
+        "merge",
+    }
+)
+QUEUE_STATES = frozenset({"pending", "running", "completed", "failed", "cancelled"})
+QUEUE_PARAMETER_KEYS = frozenset({"reviewed_by", "decision_id", "reopen_pull_request"})
+QUEUE_RESULT_KEYS = frozenset(
+    {
+        "run_id",
+        "status",
+        "stage",
+        "pr_number",
+        "pr_url",
+        "decision_id",
+        "merge_commit_sha",
+        "merged",
+        "idempotent",
+        "public_write",
+        "next_action",
+        "error_code",
+        "retryable",
+        "manual_required",
+    }
+)
+QUEUE_EVENTS = frozenset(
+    {
+        "enqueued",
+        "claimed",
+        "taken_over",
+        "completed",
+        "failed",
+        "cancelled",
+        "requeued",
+        "attempts_exhausted",
     }
 )
 
@@ -2123,6 +2250,31 @@ class Store:
                 """,
             ),
             (
+                "task_queue_control",
+                """
+                SELECT repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(parameters AS BLOB))), 0) AS bytes,
+                       MIN(created_at) AS oldest_at, MAX(updated_at) AS newest_at
+                FROM queue_tasks
+                WHERE (?='' OR repository=?) AND (?='' OR created_at>=?)
+                GROUP BY repository
+                """,
+            ),
+            (
+                "task_queue_attempt_audit",
+                """
+                SELECT tasks.repository, COUNT(*) AS records,
+                       COALESCE(SUM(length(CAST(attempts.payload AS BLOB))), 0) AS bytes,
+                       MIN(attempts.created_at) AS oldest_at,
+                       MAX(attempts.created_at) AS newest_at
+                FROM queue_attempts attempts
+                JOIN queue_tasks tasks ON tasks.id=attempts.task_id
+                WHERE (?='' OR tasks.repository=?)
+                  AND (?='' OR attempts.created_at>=?)
+                GROUP BY tasks.repository
+                """,
+            ),
+            (
                 "portfolio_dependency_audit",
                 """
                 SELECT repository, COUNT(*) AS records,
@@ -2960,6 +3112,881 @@ class Store:
                 (scope.strip().casefold(), limit),
             ).fetchall()
         return [dict(row) for row in rows]
+
+    @staticmethod
+    def _queue_timestamp(now: datetime | None = None) -> tuple[datetime, str]:
+        current = now or datetime.now(UTC)
+        if current.tzinfo is None:
+            raise ValueError("queue time must include a timezone")
+        normalized = current.astimezone(UTC)
+        return normalized, normalized.isoformat(timespec="microseconds")
+
+    @staticmethod
+    def _queue_worker(worker: str) -> str:
+        normalized = worker.strip()
+        if (
+            not normalized
+            or len(normalized) > 128
+            or any(character in normalized for character in "\r\n")
+            or normalized.startswith(("/", "~"))
+            or re.match(r"^[A-Za-z]:[\\/]", normalized)
+        ):
+            raise ValueError("queue worker must contain 1 to 128 characters")
+        return normalized
+
+    @staticmethod
+    def _queue_payload(payload: dict[str, Any], *, allowed_keys: frozenset[str]) -> str:
+        if not isinstance(payload, dict):
+            raise TypeError("queue payload must be an object")
+        unknown = set(payload) - allowed_keys
+        if unknown:
+            raise ValueError(
+                "queue payload contains unsupported fields: "
+                + ", ".join(sorted(unknown))
+            )
+        for value in payload.values():
+            if not isinstance(value, (str, int, bool)):
+                raise TypeError("queue payload values must be bounded scalars")
+            if isinstance(value, str):
+                if len(value) > 512:
+                    raise ValueError("queue payload string exceeds 512 characters")
+                if value.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", value):
+                    raise ValueError("queue payload must not contain absolute paths")
+        encoded = _canonical_json(payload)
+        if len(encoded.encode()) > 4_096:
+            raise ValueError("queue payload exceeds 4096 bytes")
+        return encoded
+
+    @staticmethod
+    def _validate_queue_parameters(action: str, parameters: dict[str, Any]) -> None:
+        required: dict[str, frozenset[str]] = {
+            "prepare": frozenset(),
+            "follow-up": frozenset(),
+            "repair": frozenset(),
+            "merge-decision": frozenset(),
+            "submit": frozenset({"reviewed_by"}),
+            "merge-attest": frozenset({"reviewed_by"}),
+            "merge": frozenset({"reviewed_by", "decision_id"}),
+        }
+        required_keys = required[action]
+        missing = required_keys - set(parameters)
+        if missing:
+            raise ValueError(
+                "queue action is missing parameters: " + ", ".join(sorted(missing))
+            )
+        allowed = required_keys | (
+            frozenset({"reopen_pull_request"}) if action == "submit" else frozenset()
+        )
+        unexpected = set(parameters) - allowed
+        if unexpected:
+            raise ValueError(
+                "queue action has unexpected parameters: "
+                + ", ".join(sorted(unexpected))
+            )
+        reviewed_by = parameters.get("reviewed_by")
+        if reviewed_by is not None and (
+            not isinstance(reviewed_by, str)
+            or not reviewed_by.strip()
+            or len(reviewed_by) > 128
+        ):
+            raise ValueError("queue reviewed_by must contain 1 to 128 characters")
+        decision_id = parameters.get("decision_id")
+        if decision_id is not None and (
+            not isinstance(decision_id, str) or not _is_lower_hex(decision_id, 32)
+        ):
+            raise ValueError("queue decision_id must be 32 lowercase hex characters")
+        reopen = parameters.get("reopen_pull_request")
+        if reopen is not None and (
+            isinstance(reopen, bool) or not isinstance(reopen, int) or reopen < 0
+        ):
+            raise ValueError("queue reopen_pull_request must not be negative")
+
+    @staticmethod
+    def _queue_task(row: sqlite3.Row | dict[str, Any]) -> dict[str, Any]:
+        value = dict(row)
+        for key in ("work_item_id", "run_id", "depends_on_task_id"):
+            value[key] = str(value.get(key) or "")
+        action = str(value["action"])
+        if action not in QUEUE_ACTIONS or str(value["state"]) not in QUEUE_STATES:
+            raise StoreError("queue task contains an unsupported action or state")
+        try:
+            parameters = json.loads(str(value["parameters"]))
+            if not isinstance(parameters, dict):
+                raise TypeError("queue parameters are not an object")
+            Store._validate_queue_parameters(action, parameters)
+            encoded_parameters = Store._queue_payload(
+                parameters, allowed_keys=QUEUE_PARAMETER_KEYS
+            )
+        except (TypeError, ValueError) as exc:
+            raise StoreError("queue task parameters were modified") from exc
+        if hashlib.sha256(encoded_parameters.encode()).hexdigest() != str(
+            value["parameters_digest"]
+        ):
+            raise StoreError("queue task parameters were modified")
+        material = {
+            "repository": str(value["repository"]),
+            "action": action,
+            "work_item_id": value["work_item_id"],
+            "run_id": value["run_id"],
+            "issue_number": int(value["issue_number"]),
+            "pull_number": int(value["pull_number"]),
+            "parameters_digest": str(value["parameters_digest"]),
+            "depends_on_task_id": value["depends_on_task_id"],
+            "idempotency_digest": str(value["idempotency_digest"]),
+        }
+        if _json_digest(material) != str(value["dedupe_key"]):
+            raise StoreError("queue task identity was modified")
+        value["parameters"] = parameters
+        value["manual_required"] = bool(value["manual_required"])
+        return value
+
+    def _append_queue_attempt(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        task_id: str,
+        generation: int,
+        worker: str,
+        event: str,
+        outcome: str,
+        payload: dict[str, Any],
+        created_at: str,
+    ) -> dict[str, Any]:
+        if event not in QUEUE_EVENTS:
+            raise ValueError(f"unsupported queue event: {event!r}")
+        if outcome not in QUEUE_STATES:
+            raise ValueError(f"unsupported queue outcome: {outcome!r}")
+        encoded = self._queue_payload(payload, allowed_keys=QUEUE_RESULT_KEYS)
+        payload_digest = hashlib.sha256(encoded.encode()).hexdigest()
+        event_id = uuid.uuid4().hex
+        try:
+            connection.execute(
+                """
+                INSERT INTO queue_attempts(
+                    id, task_id, generation, worker, event, outcome, payload,
+                    payload_digest, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    task_id,
+                    generation,
+                    worker,
+                    event,
+                    outcome,
+                    encoded,
+                    payload_digest,
+                    created_at,
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise StoreError("queue attempt event already exists") from exc
+        return {
+            "id": event_id,
+            "task_id": task_id,
+            "generation": generation,
+            "worker": worker,
+            "event": event,
+            "outcome": outcome,
+            "payload": payload,
+            "created_at": created_at,
+        }
+
+    def enqueue_queue_task(
+        self,
+        repository: str,
+        *,
+        action: str,
+        enqueued_by: str,
+        work_item_id: str = "",
+        run_id: str = "",
+        issue_number: int = 0,
+        pull_number: int = 0,
+        parameters: dict[str, Any] | None = None,
+        priority: int = 0,
+        depends_on_task_id: str = "",
+        max_attempts: int = 3,
+        idempotency_key: str = "",
+    ) -> dict[str, Any]:
+        normalized_repository = repository.strip().casefold()
+        if not re.fullmatch(r"[^/\s]+/[^/\s]+", normalized_repository):
+            raise ValueError("queue repository must use owner/name")
+        if action not in QUEUE_ACTIONS:
+            raise ValueError(f"unsupported queue action: {action!r}")
+        worker = self._queue_worker(enqueued_by)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in (issue_number, pull_number)
+        ):
+            raise ValueError("queue issue and pull numbers must not be negative")
+        if isinstance(priority, bool) or not isinstance(priority, int):
+            raise TypeError("queue priority must be an integer")
+        if not -1_000 <= priority <= 1_000:
+            raise ValueError("queue priority must be between -1000 and 1000")
+        if isinstance(max_attempts, bool) or not isinstance(max_attempts, int):
+            raise TypeError("queue max_attempts must be an integer")
+        if not 1 <= max_attempts <= 20:
+            raise ValueError("queue max_attempts must be between 1 and 20")
+        if len(idempotency_key) > 128:
+            raise ValueError("queue idempotency key exceeds 128 characters")
+        for label, reference in (
+            ("work_item_id", work_item_id),
+            ("run_id", run_id),
+            ("depends_on_task_id", depends_on_task_id),
+        ):
+            if len(reference) > 128 or any(
+                character.isspace() for character in reference
+            ):
+                raise ValueError(f"queue {label} must be a bounded identifier")
+        values = dict(parameters or {})
+        self._validate_queue_parameters(action, values)
+        encoded_parameters = self._queue_payload(
+            values, allowed_keys=QUEUE_PARAMETER_KEYS
+        )
+        if action in {"prepare", "submit"}:
+            if issue_number < 1 or run_id or work_item_id or pull_number:
+                raise ValueError(
+                    f"queue action {action!r} requires only an issue reference"
+                )
+        elif not run_id:
+            raise ValueError(f"queue action {action!r} requires run_id")
+        now = utc_now()
+        task_id = uuid.uuid4().hex
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            if run_id:
+                run = connection.execute(
+                    "SELECT repository, issue_number, details FROM runs WHERE id=?",
+                    (run_id,),
+                ).fetchone()
+                if run is None:
+                    raise StoreError("queue task references a missing run")
+                if str(run["repository"]) != normalized_repository:
+                    raise StoreError("queue run belongs to another repository")
+                run_issue = int(run["issue_number"])
+                if issue_number and issue_number != run_issue:
+                    raise StoreError("queue issue does not match its run")
+                issue_number = run_issue
+                if pull_number:
+                    details = json.loads(str(run["details"]))
+                    match = re.search(
+                        r"/pull/(\d+)/?$", str(details.get("pr_url") or "")
+                    )
+                    if match is None or int(match.group(1)) != pull_number:
+                        raise StoreError("queue pull number does not match its run")
+            normalized_work_item_id = work_item_id or None
+            if normalized_work_item_id:
+                item = connection.execute(
+                    "SELECT repository FROM work_items WHERE id=?",
+                    (normalized_work_item_id,),
+                ).fetchone()
+                if item is None:
+                    raise StoreError("queue task references a missing work item")
+                if str(item["repository"]) != normalized_repository:
+                    raise StoreError("queue work item belongs to another repository")
+                if run_id:
+                    binding = connection.execute(
+                        """
+                        SELECT 1 FROM harness_runs
+                        WHERE run_id=? AND work_item_id=?
+                        """,
+                        (run_id, normalized_work_item_id),
+                    ).fetchone()
+                    if binding is None:
+                        raise StoreError(
+                            "queue run and work item do not share a context binding"
+                        )
+            normalized_dependency = depends_on_task_id or None
+            if normalized_dependency:
+                dependency = connection.execute(
+                    "SELECT repository FROM queue_tasks WHERE id=?",
+                    (normalized_dependency,),
+                ).fetchone()
+                if dependency is None:
+                    raise StoreError("queue dependency task does not exist")
+                if str(dependency["repository"]) != normalized_repository:
+                    raise StoreError("queue dependency belongs to another repository")
+            idempotency_digest = hashlib.sha256(idempotency_key.encode()).hexdigest()
+            material = {
+                "repository": normalized_repository,
+                "action": action,
+                "work_item_id": normalized_work_item_id or "",
+                "run_id": run_id,
+                "issue_number": issue_number,
+                "pull_number": pull_number,
+                "parameters_digest": hashlib.sha256(
+                    encoded_parameters.encode()
+                ).hexdigest(),
+                "depends_on_task_id": normalized_dependency or "",
+                "idempotency_digest": idempotency_digest,
+            }
+            dedupe_key = _json_digest(material)
+            cursor = connection.execute(
+                """
+                INSERT INTO queue_tasks(
+                    id, dedupe_key, repository, action, work_item_id, run_id,
+                    issue_number, pull_number, parameters, parameters_digest,
+                    idempotency_digest, priority, state, depends_on_task_id, max_attempts,
+                    available_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+                ON CONFLICT(dedupe_key) DO NOTHING
+                """,
+                (
+                    task_id,
+                    dedupe_key,
+                    normalized_repository,
+                    action,
+                    normalized_work_item_id,
+                    run_id or None,
+                    issue_number,
+                    pull_number,
+                    encoded_parameters,
+                    material["parameters_digest"],
+                    idempotency_digest,
+                    priority,
+                    normalized_dependency,
+                    max_attempts,
+                    now,
+                    now,
+                    now,
+                ),
+            )
+            idempotent = cursor.rowcount == 0
+            row = connection.execute(
+                "SELECT * FROM queue_tasks WHERE dedupe_key=?", (dedupe_key,)
+            ).fetchone()
+            if row is None:
+                raise StoreError("queue task was not persisted")
+            if not idempotent:
+                self._append_queue_attempt(
+                    connection,
+                    task_id=task_id,
+                    generation=0,
+                    worker=worker,
+                    event="enqueued",
+                    outcome="pending",
+                    payload={},
+                    created_at=now,
+                )
+        return {**self._queue_task(row), "idempotent": idempotent}
+
+    def queue_tasks(
+        self,
+        *,
+        repository: str = "",
+        task_id: str = "",
+        states: tuple[str, ...] = (),
+        limit: int = 100,
+        now: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        normalized_repository = repository.casefold()
+        unknown_states = set(states) - QUEUE_STATES
+        if unknown_states:
+            raise ValueError(
+                "unsupported queue states: " + ", ".join(sorted(unknown_states))
+            )
+        limit = min(max(limit, 1), 500)
+        _current, current_text = self._queue_timestamp(now)
+        state_filter = ""
+        parameters: list[object] = [
+            normalized_repository,
+            normalized_repository,
+            task_id,
+            task_id,
+        ]
+        if states:
+            placeholders = ",".join("?" for _ in states)
+            state_filter = f"AND tasks.state IN ({placeholders})"
+            parameters.extend(states)
+        parameters.append(limit)
+        with self._connection() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT tasks.*, dependency.state AS dependency_state
+                FROM queue_tasks tasks
+                LEFT JOIN queue_tasks dependency
+                  ON dependency.id=tasks.depends_on_task_id
+                WHERE (?='' OR tasks.repository=?)
+                  AND (?='' OR tasks.id=?) {state_filter}
+                ORDER BY tasks.priority DESC, tasks.sequence ASC LIMIT ?
+                """,
+                parameters,
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = self._queue_task(row)
+            dependency_state = str(value.pop("dependency_state") or "")
+            value["dependency_state"] = dependency_state
+            value["blocked_by_dependency"] = bool(
+                value["depends_on_task_id"] and dependency_state != "completed"
+            )
+            value["lease_expired"] = bool(
+                value["state"] == "running"
+                and value["lease_expires_at"]
+                and str(value["lease_expires_at"]) <= current_text
+            )
+            value["attention"] = (
+                "manual"
+                if value["manual_required"]
+                else "dependency"
+                if value["blocked_by_dependency"]
+                else "lease_expired"
+                if value["lease_expired"]
+                else ""
+            )
+            result.append(value)
+        return result
+
+    def queue_task_summary(self, *, repository: str = "") -> dict[str, Any]:
+        normalized_repository = repository.casefold()
+        counts = {state: 0 for state in QUEUE_STATES}
+        manual_required = 0
+        dependency_blocked = 0
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT tasks.state, COUNT(*) AS records,
+                       SUM(tasks.manual_required) AS manual_required,
+                       SUM(CASE
+                           WHEN tasks.depends_on_task_id IS NOT NULL
+                            AND dependency.state<>'completed' THEN 1 ELSE 0
+                       END) AS dependency_blocked
+                FROM queue_tasks tasks
+                LEFT JOIN queue_tasks dependency
+                  ON dependency.id=tasks.depends_on_task_id
+                WHERE (?='' OR tasks.repository=?)
+                GROUP BY tasks.state
+                """,
+                (normalized_repository, normalized_repository),
+            ).fetchall()
+        for row in rows:
+            counts[str(row["state"])] = int(row["records"])
+            manual_required += int(row["manual_required"] or 0)
+            dependency_blocked += int(row["dependency_blocked"] or 0)
+        return {
+            "counts": counts,
+            "manual_required": manual_required,
+            "dependency_blocked": dependency_blocked,
+        }
+
+    def queue_attempts(self, task_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+        limit = min(max(limit, 1), 500)
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM (
+                    SELECT * FROM queue_attempts
+                    WHERE task_id=? ORDER BY sequence DESC LIMIT ?
+                ) recent ORDER BY sequence ASC
+                """,
+                (task_id, limit),
+            ).fetchall()
+        result = []
+        for row in rows:
+            value = dict(row)
+            try:
+                payload = json.loads(str(value["payload"]))
+                if not isinstance(payload, dict):
+                    raise TypeError("queue attempt payload is not an object")
+                encoded = self._queue_payload(payload, allowed_keys=QUEUE_RESULT_KEYS)
+            except (TypeError, ValueError) as exc:
+                raise StoreError("queue attempt payload was modified") from exc
+            if hashlib.sha256(encoded.encode()).hexdigest() != str(
+                value["payload_digest"]
+            ):
+                raise StoreError("queue attempt payload was modified")
+            value["payload"] = payload
+            result.append(value)
+        return result
+
+    def claim_queue_tasks(
+        self,
+        *,
+        worker: str,
+        limit: int = 1,
+        lease_seconds: int = 900,
+        repository: str = "",
+        now: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        normalized_worker = self._queue_worker(worker)
+        if not 1 <= limit <= 100:
+            raise ValueError("queue claim limit must be between 1 and 100")
+        if not 5 <= lease_seconds <= 86_400:
+            raise ValueError("queue lease_seconds must be between 5 and 86400")
+        current, current_text = self._queue_timestamp(now)
+        expires_at = (current + timedelta(seconds=lease_seconds)).isoformat(
+            timespec="microseconds"
+        )
+        normalized_repository = repository.casefold()
+        claimed: list[dict[str, Any]] = []
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            exhausted = connection.execute(
+                """
+                SELECT * FROM queue_tasks
+                WHERE state='running' AND lease_expires_at<=?
+                  AND attempt_count>=max_attempts
+                  AND (?='' OR repository=?)
+                ORDER BY sequence ASC
+                LIMIT ?
+                """,
+                (
+                    current_text,
+                    normalized_repository,
+                    normalized_repository,
+                    limit,
+                ),
+            ).fetchall()
+            for row in exhausted:
+                connection.execute(
+                    """
+                    UPDATE queue_tasks
+                    SET state='failed', manual_required=1,
+                        last_error_code='attempt_limit_exhausted',
+                        lease_owner='', lease_expires_at='', updated_at=?
+                    WHERE id=? AND state='running' AND lease_generation=?
+                    """,
+                    (current_text, row["id"], row["lease_generation"]),
+                )
+                self._append_queue_attempt(
+                    connection,
+                    task_id=str(row["id"]),
+                    generation=int(row["lease_generation"]),
+                    worker=normalized_worker,
+                    event="attempts_exhausted",
+                    outcome="failed",
+                    payload={
+                        "error_code": "attempt_limit_exhausted",
+                        "retryable": False,
+                        "manual_required": True,
+                    },
+                    created_at=current_text,
+                )
+            rows = connection.execute(
+                """
+                SELECT tasks.* FROM queue_tasks tasks
+                LEFT JOIN queue_tasks dependency
+                  ON dependency.id=tasks.depends_on_task_id
+                WHERE tasks.manual_required=0
+                  AND tasks.attempt_count<tasks.max_attempts
+                  AND (?='' OR tasks.repository=?)
+                  AND (
+                    (tasks.state IN ('pending', 'failed') AND tasks.available_at<=?)
+                    OR (tasks.state='running' AND tasks.lease_expires_at<=?)
+                  )
+                  AND (
+                    tasks.depends_on_task_id IS NULL
+                    OR dependency.state='completed'
+                  )
+                ORDER BY tasks.priority DESC, tasks.sequence ASC LIMIT ?
+                """,
+                (
+                    normalized_repository,
+                    normalized_repository,
+                    current_text,
+                    current_text,
+                    limit,
+                ),
+            ).fetchall()
+            for row in rows:
+                generation = int(row["lease_generation"]) + 1
+                event = "taken_over" if row["state"] == "running" else "claimed"
+                cursor = connection.execute(
+                    """
+                    UPDATE queue_tasks
+                    SET state='running', attempt_count=attempt_count+1,
+                        lease_owner=?, lease_generation=?, lease_expires_at=?,
+                        last_error_code='', updated_at=?
+                    WHERE id=? AND state=? AND lease_generation=?
+                    """,
+                    (
+                        normalized_worker,
+                        generation,
+                        expires_at,
+                        current_text,
+                        row["id"],
+                        row["state"],
+                        row["lease_generation"],
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise StoreError("queue task changed during atomic claim")
+                self._append_queue_attempt(
+                    connection,
+                    task_id=str(row["id"]),
+                    generation=generation,
+                    worker=normalized_worker,
+                    event=event,
+                    outcome="running",
+                    payload={},
+                    created_at=current_text,
+                )
+                updated = connection.execute(
+                    "SELECT * FROM queue_tasks WHERE id=?", (row["id"],)
+                ).fetchone()
+                if updated is None:
+                    raise StoreError("claimed queue task disappeared")
+                claimed.append(
+                    {
+                        **self._queue_task(updated),
+                        "lease": QueueLease(
+                            task_id=str(row["id"]),
+                            worker=normalized_worker,
+                            generation=generation,
+                            expires_at=expires_at,
+                        ),
+                    }
+                )
+        return claimed
+
+    def renew_queue_lease(
+        self,
+        lease: QueueLease,
+        *,
+        lease_seconds: int = 900,
+        now: datetime | None = None,
+    ) -> QueueLease:
+        if not 5 <= lease_seconds <= 86_400:
+            raise ValueError("queue lease_seconds must be between 5 and 86400")
+        current, current_text = self._queue_timestamp(now)
+        expires_at = (current + timedelta(seconds=lease_seconds)).isoformat(
+            timespec="microseconds"
+        )
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            cursor = connection.execute(
+                """
+                UPDATE queue_tasks SET lease_expires_at=?, updated_at=?
+                WHERE id=? AND state='running' AND lease_owner=?
+                  AND lease_generation=? AND lease_expires_at>?
+                """,
+                (
+                    expires_at,
+                    current_text,
+                    lease.task_id,
+                    lease.worker,
+                    lease.generation,
+                    current_text,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise StoreError("queue lease is stale")
+        return QueueLease(lease.task_id, lease.worker, lease.generation, expires_at)
+
+    def _finish_queue_task(
+        self,
+        lease: QueueLease,
+        *,
+        state: str,
+        event: str,
+        payload: dict[str, Any],
+        manual_required: bool | None,
+        error_code: str,
+        now: datetime | None,
+    ) -> dict[str, Any]:
+        if state not in {"completed", "failed"}:
+            raise ValueError("queue finish state must be completed or failed")
+        if error_code and not re.fullmatch(r"[a-z][a-z0-9_]{0,63}", error_code):
+            raise ValueError("queue error_code has an invalid format")
+        current, current_text = self._queue_timestamp(now)
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            row = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (lease.task_id,)
+            ).fetchone()
+            if (
+                row is None
+                or str(row["state"]) != "running"
+                or str(row["lease_owner"]) != lease.worker
+                or int(row["lease_generation"]) != lease.generation
+                or str(row["lease_expires_at"]) <= current_text
+            ):
+                raise StoreError("queue lease is stale")
+            if manual_required is None:
+                manual_required = not bool(payload.get("retryable")) or int(
+                    row["attempt_count"]
+                ) >= int(row["max_attempts"])
+                payload = {**payload, "manual_required": manual_required}
+            self._queue_payload(payload, allowed_keys=QUEUE_RESULT_KEYS)
+            available_at = current_text
+            if state == "failed" and not manual_required:
+                delay_seconds = min(
+                    300, 5 * (2 ** max(int(row["attempt_count"]) - 1, 0))
+                )
+                available_at = (current + timedelta(seconds=delay_seconds)).isoformat(
+                    timespec="microseconds"
+                )
+            connection.execute(
+                """
+                UPDATE queue_tasks
+                SET state=?, manual_required=?, last_error_code=?,
+                    lease_owner='', lease_expires_at='', available_at=?, updated_at=?
+                WHERE id=?
+                """,
+                (
+                    state,
+                    int(manual_required),
+                    error_code,
+                    available_at,
+                    current_text,
+                    lease.task_id,
+                ),
+            )
+            audit = self._append_queue_attempt(
+                connection,
+                task_id=lease.task_id,
+                generation=lease.generation,
+                worker=lease.worker,
+                event=event,
+                outcome=state,
+                payload=payload,
+                created_at=current_text,
+            )
+            updated = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (lease.task_id,)
+            ).fetchone()
+        if updated is None:
+            raise StoreError("finished queue task disappeared")
+        return {**self._queue_task(updated), "audit": audit}
+
+    def complete_queue_task(
+        self,
+        lease: QueueLease,
+        *,
+        result: dict[str, Any],
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        return self._finish_queue_task(
+            lease,
+            state="completed",
+            event="completed",
+            payload=result,
+            manual_required=False,
+            error_code="",
+            now=now,
+        )
+
+    def fail_queue_task(
+        self,
+        lease: QueueLease,
+        *,
+        error_code: str,
+        retryable: bool,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        return self._finish_queue_task(
+            lease,
+            state="failed",
+            event="failed",
+            payload={
+                "error_code": error_code,
+                "retryable": retryable,
+            },
+            manual_required=None,
+            error_code=error_code,
+            now=now,
+        )
+
+    def cancel_queue_task(
+        self,
+        task_id: str,
+        *,
+        cancelled_by: str,
+        reason_code: str = "operator_cancelled",
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        worker = self._queue_worker(cancelled_by)
+        if not re.fullmatch(r"[a-z][a-z0-9_]{0,63}", reason_code):
+            raise ValueError("queue cancellation reason has an invalid format")
+        _current, current_text = self._queue_timestamp(now)
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            row = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (task_id,)
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"queue task not found: {task_id}")
+            if str(row["state"]) == "cancelled":
+                return {**self._queue_task(row), "idempotent": True}
+            if str(row["state"]) == "completed":
+                raise StoreError("completed queue task cannot be cancelled")
+            if (
+                str(row["state"]) == "running"
+                and str(row["lease_expires_at"]) > current_text
+            ):
+                raise StoreError("active queue task cannot be cancelled")
+            connection.execute(
+                """
+                UPDATE queue_tasks
+                SET state='cancelled', manual_required=0,
+                    last_error_code=?, lease_owner='', lease_expires_at='',
+                    updated_at=? WHERE id=?
+                """,
+                (reason_code, current_text, task_id),
+            )
+            audit = self._append_queue_attempt(
+                connection,
+                task_id=task_id,
+                generation=int(row["lease_generation"]),
+                worker=worker,
+                event="cancelled",
+                outcome="cancelled",
+                payload={"error_code": reason_code},
+                created_at=current_text,
+            )
+            updated = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (task_id,)
+            ).fetchone()
+        if updated is None:
+            raise StoreError("cancelled queue task disappeared")
+        return {**self._queue_task(updated), "audit": audit, "idempotent": False}
+
+    def requeue_queue_task(
+        self,
+        task_id: str,
+        *,
+        requeued_by: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        worker = self._queue_worker(requeued_by)
+        _current, current_text = self._queue_timestamp(now)
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            row = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (task_id,)
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"queue task not found: {task_id}")
+            if str(row["state"]) == "pending" and not bool(row["manual_required"]):
+                return {**self._queue_task(row), "idempotent": True}
+            if str(row["state"]) not in {"failed", "cancelled"}:
+                raise StoreError("only failed or cancelled queue tasks can be requeued")
+            max_attempts = max(int(row["max_attempts"]), int(row["attempt_count"]) + 1)
+            connection.execute(
+                """
+                UPDATE queue_tasks
+                SET state='pending', manual_required=0, last_error_code='',
+                    max_attempts=?, available_at=?, lease_owner='',
+                    lease_expires_at='', updated_at=? WHERE id=?
+                """,
+                (max_attempts, current_text, current_text, task_id),
+            )
+            audit = self._append_queue_attempt(
+                connection,
+                task_id=task_id,
+                generation=int(row["lease_generation"]),
+                worker=worker,
+                event="requeued",
+                outcome="pending",
+                payload={},
+                created_at=current_text,
+            )
+            updated = connection.execute(
+                "SELECT * FROM queue_tasks WHERE id=?", (task_id,)
+            ).fetchone()
+        if updated is None:
+            raise StoreError("requeued task disappeared")
+        return {**self._queue_task(updated), "audit": audit, "idempotent": False}
 
     def start_run(self, repository: str, issue_number: int, stage: str) -> str:
         run_id = uuid.uuid4().hex

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,6 +348,77 @@ class CliSetupTests(unittest.TestCase):
             ],
         )
 
+    def test_queue_commands_route_bounded_control_plane_arguments(self) -> None:
+        pipeline = MagicMock()
+        pipeline.enqueue_task.return_value = {"task": {"id": "task-1"}}
+        pipeline.apply_queue.return_value = {"outcomes": [], "public_write": False}
+
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+            redirect_stdout(io.StringIO()),
+        ):
+            enqueue_code = main(
+                [
+                    "queue",
+                    "enqueue",
+                    "owner/repo",
+                    "submit",
+                    "--issue",
+                    "7",
+                    "--priority",
+                    "12",
+                    "--depends-on",
+                    "task-0",
+                    "--max-attempts",
+                    "4",
+                    "--reviewed-by",
+                    "alice",
+                    "--reopen",
+                    "19",
+                ]
+            )
+            apply_code = main(
+                [
+                    "queue",
+                    "apply",
+                    "--repo",
+                    "owner/repo",
+                    "--worker",
+                    "worker-1",
+                    "--limit",
+                    "3",
+                    "--lease-seconds",
+                    "60",
+                ]
+            )
+
+        self.assertEqual(
+            (enqueue_code, apply_code),
+            (0, 0),
+        )
+        pipeline.enqueue_task.assert_called_once_with(
+            "owner/repo",
+            action="submit",
+            issue_number=7,
+            pull_number=0,
+            run_id="",
+            work_item_id="",
+            priority=12,
+            depends_on_task_id="task-0",
+            max_attempts=4,
+            idempotency_key="",
+            reviewed_by="alice",
+            decision_id="",
+            reopen_pull_request=19,
+        )
+        pipeline.apply_queue.assert_called_once_with(
+            repository="owner/repo",
+            worker="worker-1",
+            limit=3,
+            lease_seconds=60,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from reposteward.config import RepositoryPolicy
+from reposteward.pipeline import Pipeline
+from reposteward.policy import PolicyError
+from reposteward.store import SCHEMA_VERSION, QueueLease, Store, StoreError
+
+
+class QueueStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.store = Store(Path(self.temporary.name) / "state.sqlite3")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def enqueue(self, issue_number: int, **values):
+        return self.store.enqueue_queue_task(
+            "owner/repo",
+            action="prepare",
+            enqueued_by="alice",
+            issue_number=issue_number,
+            parameters={},
+            **values,
+        )
+
+    def test_version_fifteen_database_receives_queue_migration(self) -> None:
+        path = self.store.path
+        with closing(sqlite3.connect(path)) as connection, connection:
+            connection.execute("DROP TABLE queue_attempts")
+            connection.execute("DROP TABLE queue_tasks")
+            connection.execute("PRAGMA user_version=15")
+
+        migrated = Store(path)
+        with closing(sqlite3.connect(path)) as connection, connection:
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            claim_index = connection.execute(
+                "SELECT name FROM sqlite_master WHERE name='queue_tasks_claim'"
+            ).fetchone()
+            lease_index = connection.execute(
+                """
+                SELECT name FROM sqlite_master
+                WHERE name='queue_tasks_expired_leases'
+                """
+            ).fetchone()
+            lease_plan = " ".join(
+                str(row[3])
+                for row in connection.execute(
+                    """
+                    EXPLAIN QUERY PLAN
+                    SELECT id FROM queue_tasks
+                    WHERE state='running' AND lease_expires_at<=?
+                      AND attempt_count>=max_attempts
+                    """,
+                    ("2999-01-01T00:00:00+00:00",),
+                )
+            )
+
+        self.assertEqual(migrated.schema_version(), SCHEMA_VERSION)
+        self.assertIn("queue_tasks", tables)
+        self.assertIn("queue_attempts", tables)
+        self.assertIsNotNone(claim_index)
+        self.assertIsNotNone(lease_index)
+        self.assertIn("queue_tasks_expired_leases", lease_plan)
+
+    def test_enqueue_is_idempotent_bounded_and_dependency_aware(self) -> None:
+        first = self.enqueue(1, priority=5)
+        repeated = self.enqueue(1, priority=99)
+        dependent = self.enqueue(2, depends_on_task_id=first["id"], priority=100)
+
+        claimed = self.store.claim_queue_tasks(
+            worker="worker-1", limit=10, lease_seconds=30
+        )
+
+        self.assertEqual(first["id"], repeated["id"])
+        self.assertTrue(repeated["idempotent"])
+        self.assertEqual([value["id"] for value in claimed], [first["id"]])
+        self.assertIsInstance(claimed[0]["lease"], QueueLease)
+        visible = self.store.queue_tasks(task_id=dependent["id"])[0]
+        summary = self.store.queue_task_summary(repository="owner/repo")
+        self.assertTrue(visible["blocked_by_dependency"])
+        self.assertEqual(visible["attention"], "dependency")
+        self.assertEqual(summary["counts"]["running"], 1)
+        self.assertEqual(summary["counts"]["pending"], 1)
+        self.assertEqual(summary["dependency_blocked"], 1)
+
+        completed = self.store.complete_queue_task(
+            claimed[0]["lease"], result={"status": "ready", "public_write": False}
+        )
+        next_claim = self.store.claim_queue_tasks(
+            worker="worker-1", limit=10, lease_seconds=30
+        )
+
+        self.assertEqual(completed["state"], "completed")
+        self.assertEqual([value["id"] for value in next_claim], [dependent["id"]])
+        with self.assertRaisesRegex(ValueError, "unexpected parameters"):
+            self.store.enqueue_queue_task(
+                "owner/repo",
+                action="submit",
+                enqueued_by="alice",
+                issue_number=3,
+                parameters={"reviewed_by": "alice", "token": "secret"},
+            )
+        with self.assertRaisesRegex(ValueError, "absolute paths"):
+            self.store.enqueue_queue_task(
+                "owner/repo",
+                action="submit",
+                enqueued_by="alice",
+                issue_number=3,
+                parameters={"reviewed_by": "/tmp/account"},
+            )
+
+        run_id = self.store.start_run("owner/repo", 3, "follow-up")
+        self.store.update_run(
+            run_id,
+            status="submitted",
+            details={"pr_url": "https://github.com/owner/repo/pull/44"},
+        )
+        with self.assertRaisesRegex(StoreError, "pull number does not match"):
+            self.store.enqueue_queue_task(
+                "owner/repo",
+                action="follow-up",
+                enqueued_by="alice",
+                run_id=run_id,
+                pull_number=43,
+                parameters={},
+            )
+        follow_up = self.store.enqueue_queue_task(
+            "owner/repo",
+            action="follow-up",
+            enqueued_by="alice",
+            run_id=run_id,
+            pull_number=44,
+            parameters={},
+        )
+        self.assertEqual(follow_up["issue_number"], 3)
+
+    def test_expired_claim_is_taken_over_and_old_generation_is_fenced(self) -> None:
+        task = self.enqueue(3, max_attempts=2)
+        started = datetime.now(UTC) + timedelta(seconds=1)
+        first = self.store.claim_queue_tasks(
+            worker="worker-1", limit=1, lease_seconds=5, now=started
+        )[0]
+        takeover_time = started + timedelta(seconds=6)
+        second = self.store.claim_queue_tasks(
+            worker="worker-2", limit=1, lease_seconds=5, now=takeover_time
+        )[0]
+
+        self.assertEqual(first["id"], task["id"])
+        self.assertEqual(second["lease"].generation, 2)
+        with self.assertRaisesRegex(StoreError, "lease is stale"):
+            self.store.complete_queue_task(
+                first["lease"],
+                result={"status": "ready"},
+                now=takeover_time,
+            )
+        completed = self.store.complete_queue_task(
+            second["lease"],
+            result={"status": "ready"},
+            now=takeover_time + timedelta(seconds=1),
+        )
+        events = self.store.queue_attempts(task["id"])
+
+        self.assertEqual(completed["state"], "completed")
+        self.assertEqual(
+            [value["event"] for value in events],
+            ["enqueued", "claimed", "taken_over", "completed"],
+        )
+
+    def test_retry_limit_requires_manual_requeue_and_cancel_is_audited(self) -> None:
+        task = self.enqueue(4, max_attempts=1)
+        started = datetime.now(UTC) + timedelta(seconds=1)
+        claimed = self.store.claim_queue_tasks(
+            worker="worker", lease_seconds=30, now=started
+        )[0]
+        failed = self.store.fail_queue_task(
+            claimed["lease"],
+            error_code="github_transient",
+            retryable=True,
+            now=started + timedelta(seconds=1),
+        )
+
+        self.assertTrue(failed["manual_required"])
+        self.assertEqual(
+            self.store.claim_queue_tasks(
+                worker="other", lease_seconds=30, now=started + timedelta(minutes=1)
+            ),
+            [],
+        )
+        requeued = self.store.requeue_queue_task(task["id"], requeued_by="alice")
+        first_cancel = self.store.cancel_queue_task(
+            task["id"], cancelled_by="alice", reason_code="superseded"
+        )
+        second_requeue = self.store.requeue_queue_task(task["id"], requeued_by="alice")
+        cancelled = self.store.cancel_queue_task(
+            task["id"], cancelled_by="alice", reason_code="still_superseded"
+        )
+
+        self.assertEqual(requeued["max_attempts"], 2)
+        self.assertEqual(first_cancel["state"], "cancelled")
+        self.assertEqual(second_requeue["state"], "pending")
+        self.assertEqual(cancelled["state"], "cancelled")
+        self.assertEqual(
+            [value["event"] for value in self.store.queue_attempts(task["id"])],
+            [
+                "enqueued",
+                "claimed",
+                "failed",
+                "requeued",
+                "cancelled",
+                "requeued",
+                "cancelled",
+            ],
+        )
+
+    def test_retryable_failure_backs_off_and_exhausted_crash_needs_attention(
+        self,
+    ) -> None:
+        retryable = self.enqueue(5, max_attempts=2)
+        crashed = self.enqueue(6, max_attempts=1)
+        started = datetime.now(UTC) + timedelta(seconds=1)
+        claimed = self.store.claim_queue_tasks(
+            worker="worker-1", limit=2, lease_seconds=5, now=started
+        )
+        by_id = {value["id"]: value for value in claimed}
+        failed = self.store.fail_queue_task(
+            by_id[retryable["id"]]["lease"],
+            error_code="github_transient",
+            retryable=True,
+            now=started + timedelta(seconds=1),
+        )
+
+        self.assertFalse(failed["manual_required"])
+        before_backoff = self.store.claim_queue_tasks(
+            worker="worker-2",
+            limit=2,
+            lease_seconds=5,
+            now=started + timedelta(seconds=2),
+        )
+        after_backoff = self.store.claim_queue_tasks(
+            worker="worker-2",
+            limit=2,
+            lease_seconds=5,
+            now=started + timedelta(seconds=7),
+        )
+        crashed_state = self.store.queue_tasks(task_id=crashed["id"])[0]
+
+        self.assertEqual(before_backoff, [])
+        self.assertEqual([value["id"] for value in after_backoff], [retryable["id"]])
+        self.assertEqual(crashed_state["state"], "failed")
+        self.assertTrue(crashed_state["manual_required"])
+        self.assertEqual(crashed_state["last_error_code"], "attempt_limit_exhausted")
+
+    def test_atomic_batch_claim_does_not_duplicate_tasks_between_workers(self) -> None:
+        task_ids = {self.enqueue(number)["id"] for number in range(10, 30)}
+
+        def claim(worker: str) -> set[str]:
+            return {
+                value["id"]
+                for value in self.store.claim_queue_tasks(
+                    worker=worker, limit=20, lease_seconds=30
+                )
+            }
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(claim, "worker-1")
+            second = executor.submit(claim, "worker-2")
+            claimed = first.result() | second.result()
+            overlap = first.result() & second.result()
+
+        self.assertEqual(claimed, task_ids)
+        self.assertEqual(overlap, set())
+
+    def test_queue_records_are_reported_as_protected_storage(self) -> None:
+        task = self.enqueue(30)
+        statistics = {
+            value["category"]: value
+            for value in self.store.storage_statistics(repository="owner/repo")
+        }
+
+        self.assertEqual(statistics["task_queue_control"]["records"], 1)
+        self.assertEqual(statistics["task_queue_attempt_audit"]["records"], 1)
+        self.assertEqual(task["state"], "pending")
+
+    def test_queue_readers_reject_tampered_intent_and_attempt_payloads(self) -> None:
+        task = self.store.enqueue_queue_task(
+            "owner/repo",
+            action="submit",
+            enqueued_by="alice",
+            issue_number=31,
+            parameters={"reviewed_by": "alice"},
+        )
+        with closing(sqlite3.connect(self.store.path)) as connection, connection:
+            connection.execute(
+                "UPDATE queue_tasks SET parameters=? WHERE id=?",
+                ('{"reviewed_by":"mallory"}', task["id"]),
+            )
+
+        with self.assertRaisesRegex(StoreError, "parameters were modified"):
+            self.store.queue_tasks(task_id=task["id"])
+
+        other = self.enqueue(32)
+        with closing(sqlite3.connect(self.store.path)) as connection, connection:
+            connection.execute(
+                "UPDATE queue_attempts SET payload=? WHERE task_id=?",
+                ('{"public_write":true}', other["id"]),
+            )
+
+        with self.assertRaisesRegex(StoreError, "attempt payload was modified"):
+            self.store.queue_attempts(other["id"])
+
+
+class QueuePipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        policy = RepositoryPolicy(name="owner/repo", mode="maintainer")
+        self.pipeline = object.__new__(Pipeline)
+        self.pipeline.config = SimpleNamespace(
+            repositories={"owner/repo": policy},
+            github=SimpleNamespace(login="alice"),
+        )
+        self.pipeline.store = Store(Path(self.temporary.name) / "state.sqlite3")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_apply_requires_gate_and_completes_through_existing_action(self) -> None:
+        task = self.pipeline.enqueue_task(
+            "owner/repo", action="prepare", issue_number=41
+        )["task"]
+        self.pipeline.prepare = Mock(
+            return_value={
+                "run_id": "run-result",
+                "status": "ready",
+                "stage": "review",
+                "public_write": False,
+            }
+        )
+
+        with self.assertRaisesRegex(PolicyError, "queue apply is disabled"):
+            self.pipeline.apply_queue(worker="worker")
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_QUEUE_APPLY": "1"}):
+            result = self.pipeline.apply_queue(worker="worker")
+
+        self.pipeline.prepare.assert_called_once_with("owner/repo", 41)
+        self.assertEqual(result["processed"], 1)
+        self.assertEqual(result["outcomes"][0]["status"], "completed")
+        self.assertFalse(result["public_write"])
+        inspected = self.pipeline.queue_inspect(task_id=task["id"])
+        self.assertEqual(inspected["counts"]["completed"], 1)
+        self.assertEqual(inspected["attempts"][-1]["event"], "completed")
+
+    def test_policy_failure_is_not_retried_without_manual_action(self) -> None:
+        task = self.pipeline.enqueue_task(
+            "owner/repo", action="prepare", issue_number=42
+        )["task"]
+        self.pipeline.prepare = Mock(side_effect=PolicyError("not approved"))
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_QUEUE_APPLY": "1"}):
+            result = self.pipeline.apply_queue(worker="worker")
+
+        self.assertEqual(result["outcomes"][0]["error_code"], "policy_blocked")
+        self.assertTrue(result["outcomes"][0]["manual_required"])
+        inspected = self.pipeline.queue_inspect(task_id=task["id"])
+        self.assertEqual(inspected["counts"]["failed"], 1)
+        self.assertEqual(inspected["manual_required"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -152,6 +152,8 @@ class StorageGcTests(unittest.TestCase):
         self.assertIn("merge_decision_audit", result["protected_categories"])
         self.assertIn("merge_execution_audit", result["protected_categories"])
         self.assertIn("publication_attempt_audit", result["protected_categories"])
+        self.assertIn("task_queue_control", result["protected_categories"])
+        self.assertIn("task_queue_attempt_audit", result["protected_categories"])
         self.assertIn("portfolio_dependency_audit", result["protected_categories"])
 
     def test_gc_apply_requires_switch_then_audits_and_deletes(self) -> None:


### PR DESCRIPTION
## 关联 Issue

Closes #61

## 问题与改动

RepoSteward 原有 run、checkpoint 和 lease 能恢复单个工作项，但批量待办顺序仍由调用进程或对话保存，进程退出、Harness 或账号切换后需要人工重建。

本 PR 增加本地持久任务队列：

- 使用 `pending`、`running`、`completed`、`failed`、`cancelled` 状态和追加式 attempt 审计保存调度过程。
- 支持幂等入队、优先级、依赖阻塞、指数退避、重试上限、人工处理与显式取消/重试。
- 在短 SQLite 事务内原子领取有界任务；使用 lease generation fencing 接管过期任务并拒绝旧 worker 回写。
- 队列只保存稳定 work item/run/Issue/PR 引用和有界标量参数，不保存 prompt、token、评论正文或绝对工作区路径。
- 提供 `queue enqueue|inspect|apply|cancel|retry` CLI；`apply` 仍调用现有 Pipeline，因此不会绕过 submit、attestation 或 merge 门禁。
- 补充 schema 16 迁移、架构/README 文档以及队列恢复、并发领取、数据完整性和存储保留测试。

## 验证

```text
uv run python -m unittest discover -s tests -v  # 325 tests passed
uvx ruff check .                                # passed
uvx ruff format --check .                       # 72 files already formatted
uv run reposteward --help                       # passed
uv build                                        # sdist and wheel built
uv lock --check                                 # passed
```

RepoSteward 隔离 verifier 也使用前五条命令完成验证，run `63292cbfefe14d8e9cbe4ec763c9fd08` 的审查包状态为 `ready`。

## 风险与兼容性

- 数据库从 schema 15 单向增加到 schema 16，只新增任务表和索引，不改写既有业务数据。
- 慢 Pipeline、Harness 或 GitHub 操作不持有 SQLite 写锁；heartbeat 使用短事务续租。
- 领取查询按状态、可用时间、仓库和过期租约建立索引；并发测试验证同一任务不会被重复领取。
- 队列控制面不调用 Harness，不产生额外模型 token；只有显式 `REPOSTEWARD_ENABLE_QUEUE_APPLY=1` 才执行任务，实际公开写入仍受原门禁约束。
- 队列控制与 attempt 审计属于受保护恢复状态，普通 storage GC 不会删除；载荷、查询和历史返回均有界。

## 自动化辅助

使用 Codex 协助实现和验证。提交前已人工核对完整 diff、数据迁移、并发领取、租约 fencing、公开写入边界、性能路径、敏感信息扫描以及全部验证结果。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
