### PR TITLE
feat(batch): orchestrate recoverable merge trains

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,40 @@ REPOSTEWARD_ENABLE_QUEUE_APPLY=1 \
 动作白名单和有界标量参数，不保存 prompt、token、评论正文或绝对工作区路径；attempt 审计不参与
 普通 GC。
 
+多个已提交 PR 可以先生成只读 merge-train 计划。计划复用同一次 Portfolio/Dependency 快照，输出
+权威依赖顺序、非权威重叠分组、可并行预检集合、WIP 状态、逐 PR blocker 和稳定 batch digest；
+Draft、缺失本地 submitted run、外部 head 变化及不完整事实都会失败关闭：
+
+```bash
+uv run reposteward batch plan owner/repository --max-parallel 6 --format text
+```
+
+审核该输出后，apply 必须带回精确 digest，并且只把计划写成串行 `batch-advance` 队列任务，不会立即
+修改 workspace 或 GitHub。仓库级写入刻意串行，避免一个 PR 合并后其他 PR 继续消费旧 base：
+
+```bash
+REPOSTEWARD_ENABLE_BATCH_APPLY=1 \
+  uv run reposteward batch apply owner/repository \
+  --expected-digest BATCH_DIGEST --reviewed-by your-github-login
+```
+
+执行这些任务仍需显式开启队列和原有公开写入边界：
+
+```bash
+REPOSTEWARD_ENABLE_BATCH_APPLY=1 \
+REPOSTEWARD_ENABLE_QUEUE_APPLY=1 \
+REPOSTEWARD_ENABLE_SUBMIT=1 \
+REPOSTEWARD_ENABLE_OWNER_ATTESTATION=1 \
+REPOSTEWARD_ENABLE_MERGE=1 \
+  uv run reposteward queue apply --repo owner/repository --limit 20
+```
+
+每个任务都会重新读取当前 PR。base 未变化时直接复用 owner attestation、merge decision 和 merge
+executor；base 变化时在原 clean worktree 上执行确定性 Git replay，并用原验证命令重新进入
+`adopt`/`submit`，不会调用 Harness。CI 尚未结束会进入有界退避，rebase 冲突会先 abort 恢复已验证
+HEAD，再标记 `manual_required`，不会自动解决冲突或覆盖维护者改动。文件重叠只影响预检分组，不能
+凭自身制造依赖；公开 push 和 merge 仍有各自的身份、租约、SHA 与 intent/result 审计。
+
 检查贡献门禁并准备修复：
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,24 @@ GitHub，Merge Decision 只在当前 PR 存在直接依赖时读取目标 PR，�
 的两次 freshness 检查。RepoSteward 不能阻止维护者绕过它直接在 GitHub 点击 Ready，但所有由
 RepoSteward 产生的 Ready 判断和 merge 决策都会失败关闭。
 
+Batch Orchestrator 是 Portfolio 与持久队列之间的确定性协调层。它在一次 open-PR listing 上复用
+Portfolio Snapshot 和 Dependency Plan，将本地最新 submitted run 与精确 PR branch/head 关联，
+然后生成带 batch digest 的计划。显式依赖决定拓扑顺序；文件重叠通过倒排索引结果形成连通分组，
+并用于把预检候选拆成互不重叠的有界 parallel set，但不升级为依赖。Draft、缺失或歧义 run、外部
+head/branch 变化、循环和不完整分页事实进入明确 blocker。WIP 超限被展示而不阻止减少现有 WIP。
+
+Batch apply 必须重读全部线上事实并匹配维护者审阅过的 digest，随后只写 `batch-advance` 队列意图。
+即使计划展示可并行预检集合，仓库级 merge train 仍使用 task dependency 串行化公开写入，因为任何
+一次 merge 都会改变其余 PR 的 base。任务只携带 root run、PR、计划摘要及计划时 head/base；切换
+进程、账号或 Harness 不需要重建顺序，也不会把 prompt 或 workspace 路径复制进队列。
+
+执行者在每一步重新读取 PR：当前 verified head/base 可直接进入原 owner attestation、merge decision
+和 merge executor；base 已前进时，对 clean worktree 使用 `git rebase --onto` 重放原提交，并用原
+verification commands 创建 successor run。该路径不调用 Harness。重放通过后仍复用 adopt 的隔离
+Runner 和 submit 的 force-with-lease/intent-result 边界；CI pending 作为有界可重试等待，冲突则
+执行 `rebase --abort` 恢复原 HEAD 并进入人工状态。每个独立公开动作的环境开关和身份门禁继续有效，
+batch 与 queue 开关不能代替它们。
+
 ## 持久数据模型
 
 SQLite 使用显式 `PRAGMA user_version` 迁移。现有用户的未版本化数据库会原地升级；高于当前

--- a/src/reposteward/batch.py
+++ b/src/reposteward/batch.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import re
+from collections import defaultdict
+from typing import Any
+
+BATCH_SCHEMA_VERSION = 1
+MAX_TEXT_PULLS = 50
+MAX_PARALLEL = 32
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _pull_number(run: dict[str, Any]) -> int:
+    details = run.get("details")
+    if not isinstance(details, dict):
+        return 0
+    locator = str(details.get("pr_url") or run.get("submission_pr_url") or "")
+    match = re.search(r"/pull/([1-9][0-9]*)/?$", locator)
+    return int(match.group(1)) if match else 0
+
+
+def _overlap_groups(
+    pull_numbers: set[int], overlaps: list[dict[str, Any]]
+) -> tuple[list[list[int]], dict[int, int]]:
+    parent = {number: number for number in pull_numbers}
+
+    def find(number: int) -> int:
+        root = number
+        while parent[root] != root:
+            root = parent[root]
+        while parent[number] != number:
+            next_number = parent[number]
+            parent[number] = root
+            number = next_number
+        return root
+
+    for value in overlaps:
+        left = int(value["left"])
+        right = int(value["right"])
+        if left not in parent or right not in parent:
+            continue
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[max(left_root, right_root)] = min(left_root, right_root)
+    grouped: dict[int, list[int]] = defaultdict(list)
+    for number in sorted(pull_numbers):
+        grouped[find(number)].append(number)
+    groups = [values for values in grouped.values() if len(values) > 1]
+    groups.sort(key=lambda values: values)
+    membership = {
+        number: index
+        for index, values in enumerate(groups, start=1)
+        for number in values
+    }
+    return groups, membership
+
+
+def _parallel_sets(
+    order: list[int],
+    prerequisites: dict[int, set[int]],
+    conflicts: dict[int, set[int]],
+    *,
+    max_parallel: int,
+) -> list[list[int]]:
+    index = {number: offset for offset, number in enumerate(order)}
+    nodes = set(order)
+    remaining_dependencies = {
+        number: set(prerequisites.get(number, ())) & nodes for number in order
+    }
+    dependents: dict[int, set[int]] = defaultdict(set)
+    for source, dependencies in remaining_dependencies.items():
+        for dependency in dependencies:
+            dependents[dependency].add(source)
+    ready = [
+        (index[number], number)
+        for number in order
+        if not remaining_dependencies[number]
+    ]
+    heapq.heapify(ready)
+    result: list[list[int]] = []
+    completed: set[int] = set()
+    while ready:
+        wave: list[int] = []
+        deferred: list[tuple[int, int]] = []
+        wave_members: set[int] = set()
+        while ready and len(wave) < max_parallel:
+            item = heapq.heappop(ready)
+            number = item[1]
+            if conflicts.get(number, set()) & wave_members:
+                deferred.append(item)
+                continue
+            wave.append(number)
+            wave_members.add(number)
+        for item in deferred:
+            heapq.heappush(ready, item)
+        if not wave:
+            # The dependency planner already rejects cycles. This keeps the batch
+            # planner fail-closed if a malformed caller bypasses that invariant.
+            break
+        result.append(wave)
+        completed.update(wave)
+        for number in wave:
+            for dependent in dependents.get(number, ()):
+                remaining_dependencies[dependent].discard(number)
+                if not remaining_dependencies[dependent]:
+                    heapq.heappush(ready, (index[dependent], dependent))
+    if completed != nodes:
+        return []
+    return result
+
+
+def build_batch_plan(
+    portfolio_snapshot: dict[str, Any],
+    dependency_plan: dict[str, Any],
+    runs: list[dict[str, Any]],
+    *,
+    wip_limit: int,
+    max_parallel: int,
+) -> dict[str, Any]:
+    """Combine online PR facts and local runs into one deterministic train plan."""
+    if not 1 <= max_parallel <= MAX_PARALLEL:
+        raise ValueError(f"max_parallel must be between 1 and {MAX_PARALLEL}")
+    if wip_limit < 1:
+        raise ValueError("wip_limit must be positive")
+    repository = str(portfolio_snapshot["repository"]).casefold()
+    if str(dependency_plan["repository"]).casefold() != repository:
+        raise ValueError("batch dependency plan belongs to another repository")
+    if str(dependency_plan.get("portfolio_snapshot_digest") or "") != str(
+        portfolio_snapshot.get("snapshot_digest") or ""
+    ):
+        raise ValueError("batch inputs were built from different portfolio snapshots")
+
+    pulls = {
+        int(value["number"]): value
+        for value in portfolio_snapshot.get("pull_requests", ())
+    }
+    runs_by_pull: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for run in runs:
+        number = _pull_number(run)
+        if number in pulls:
+            runs_by_pull[number].append(run)
+    overlaps = list(portfolio_snapshot.get("overlaps", ()))
+    overlap_groups, membership = _overlap_groups(set(pulls), overlaps)
+    hard_dependency_blockers = {
+        int(number): [
+            str(value)
+            for value in values
+            if not str(value).startswith("dependency_open:")
+        ]
+        for number, values in dependency_plan.get("ready_blockers", {}).items()
+    }
+
+    entries: list[dict[str, Any]] = []
+    runnable: set[int] = set()
+    for number, pull in sorted(pulls.items()):
+        blockers = list(hard_dependency_blockers.get(number, ()))
+        matching_runs = runs_by_pull.get(number, [])
+        run = matching_runs[0] if len(matching_runs) == 1 else None
+        if not portfolio_snapshot.get("complete"):
+            blockers.append("portfolio_snapshot_incomplete")
+        if not bool(pull.get("facts_complete")):
+            blockers.append("pull_facts_incomplete")
+        if bool(pull.get("draft")):
+            blockers.append("pull_is_draft")
+        if len(matching_runs) > 1:
+            blockers.append("ambiguous_local_run")
+        elif run is None:
+            blockers.append("local_run_missing")
+        details = run.get("details", {}) if run is not None else {}
+        if not isinstance(details, dict):
+            details = {}
+        run_status = str(run.get("status") or "") if run is not None else ""
+        if run is not None and run_status != "submitted":
+            blockers.append(f"local_run_not_submitted:{run_status or 'unknown'}")
+        if run is not None and str(details.get("branch") or "") != str(
+            pull.get("head_branch") or ""
+        ):
+            blockers.append("tracked_branch_changed")
+        expected_head = str(details.get("commit_sha") or "")
+        online_head = str(pull.get("head_sha") or "")
+        online_base = str(pull.get("base_sha") or "")
+        if not re.fullmatch(r"[a-f0-9]{40}", online_head) or not re.fullmatch(
+            r"[a-f0-9]{40}", online_base
+        ):
+            blockers.append("pull_identity_incomplete")
+        if run is not None and not re.fullmatch(r"[a-f0-9]{40}", expected_head):
+            blockers.append("verified_head_missing")
+        if run_status == "submitted" and expected_head and expected_head != online_head:
+            blockers.append("pull_head_changed")
+        if run is not None and str(details.get("base_branch") or "") != str(
+            pull.get("base_branch") or ""
+        ):
+            blockers.append("base_branch_changed")
+        verified_base = str(details.get("base_commit") or "")
+        if run is not None and not re.fullmatch(r"[a-f0-9]{40}", verified_base):
+            blockers.append("verified_base_missing")
+        replay_required = bool(
+            run_status == "submitted" and verified_base and verified_base != online_base
+        )
+        if replay_required:
+            if not bool(run.get("batch_worktree_available", True)):
+                blockers.append("replay_worktree_missing")
+            agent = details.get("agent_result")
+            raw_commands = (
+                agent.get("verification_commands", ())
+                if isinstance(agent, dict)
+                else ()
+            )
+            if not isinstance(raw_commands, (list, tuple)) or not raw_commands:
+                blockers.append("replay_verification_missing")
+        blockers = sorted(set(blockers))
+        if not blockers:
+            runnable.add(number)
+        entries.append(
+            {
+                "pull_number": number,
+                "run_id": str(run.get("id") or "") if run is not None else "",
+                "issue_number": int(run.get("issue_number") or 0)
+                if run is not None
+                else 0,
+                "run_status": run_status,
+                "head_sha": str(pull.get("head_sha") or ""),
+                "base_sha": str(pull.get("base_sha") or ""),
+                "verified_head_sha": expected_head,
+                "verified_base_sha": verified_base,
+                "replay_required": replay_required,
+                "overlap_group": membership.get(number, 0),
+                "blockers": blockers,
+            }
+        )
+
+    entries_by_number = {int(value["pull_number"]): value for value in entries}
+    batch_dependents: dict[int, set[int]] = defaultdict(set)
+    for edge in dependency_plan.get("authoritative_edges", ()):
+        if str(edge.get("status") or "") == "open":
+            batch_dependents[int(edge["dependency_number"])].add(
+                int(edge["pull_number"])
+            )
+    blocked_queue = [number for number in pulls if number not in runnable]
+    heapq.heapify(blocked_queue)
+    while blocked_queue:
+        dependency = heapq.heappop(blocked_queue)
+        for dependent in batch_dependents.get(dependency, ()):
+            if dependent not in runnable:
+                continue
+            runnable.remove(dependent)
+            entry = entries_by_number[dependent]
+            entry["blockers"] = sorted(
+                {
+                    *entry["blockers"],
+                    f"dependency_prerequisite_not_runnable:#{dependency}",
+                }
+            )
+            heapq.heappush(blocked_queue, dependent)
+
+    dependency_order = [
+        int(value) for value in dependency_plan.get("suggested_merge_order", ())
+    ]
+    queue_order = [number for number in dependency_order if number in runnable]
+    prerequisites: dict[int, set[int]] = defaultdict(set)
+    for edge in dependency_plan.get("authoritative_edges", ()):
+        source = int(edge["pull_number"])
+        target = int(edge["dependency_number"])
+        if str(edge.get("status") or "") == "open" and target in runnable:
+            prerequisites[source].add(target)
+    conflicts: dict[int, set[int]] = defaultdict(set)
+    for value in overlaps:
+        left, right = int(value["left"]), int(value["right"])
+        if left in runnable and right in runnable:
+            conflicts[left].add(right)
+            conflicts[right].add(left)
+    parallel_sets = _parallel_sets(
+        queue_order, prerequisites, conflicts, max_parallel=max_parallel
+    )
+    complete = bool(portfolio_snapshot.get("complete")) and bool(
+        dependency_plan.get("complete")
+    )
+    material = {
+        "schema_version": BATCH_SCHEMA_VERSION,
+        "repository": repository,
+        "portfolio_snapshot_digest": str(
+            portfolio_snapshot.get("snapshot_digest") or ""
+        ),
+        "dependency_plan_digest": str(dependency_plan.get("plan_digest") or ""),
+        "complete": complete,
+        "max_parallel": max_parallel,
+        "wip": {
+            "active": len(pulls),
+            "limit": wip_limit,
+            "over_limit": len(pulls) > wip_limit,
+        },
+        "queue_order": queue_order,
+        "parallel_sets": parallel_sets,
+        "overlap_groups": overlap_groups,
+        "pull_requests": entries,
+        "blocked_pull_requests": {
+            str(value["pull_number"]): value["blockers"]
+            for value in entries
+            if value["blockers"]
+        },
+        "serialization": "repository_merge_train",
+        "overlap_is_authoritative": False,
+    }
+    return {**material, "batch_digest": _digest(material)}
+
+
+def render_batch_plan_text(result: dict[str, Any]) -> str:
+    plan = result["plan"]
+    lines = [
+        f"Batch plan: {plan['repository']}",
+        f"Batch: {result['batch_digest']}",
+        f"Complete: {'yes' if plan['complete'] else 'no'}",
+        "Queue order: "
+        + (" -> ".join(f"#{value}" for value in plan["queue_order"]) or "none"),
+        (
+            f"WIP: {plan['wip']['active']}/{plan['wip']['limit']}"
+            + (" (over limit)" if plan["wip"]["over_limit"] else "")
+        ),
+    ]
+    expected = result.get("expected_digest")
+    if expected:
+        lines.append(
+            "Expected batch: "
+            + ("current" if result.get("matches_expected_digest") else "stale")
+        )
+    for wave, values in enumerate(plan["parallel_sets"], start=1):
+        lines.append(
+            f"Parallel set {wave}: " + ", ".join(f"#{value}" for value in values)
+        )
+    blocked = list(plan["blocked_pull_requests"].items())
+    for number, blockers in blocked[:MAX_TEXT_PULLS]:
+        lines.append(f"Blocked #{number}: {', '.join(blockers)}")
+    if len(blocked) > MAX_TEXT_PULLS:
+        lines.append(f"... {len(blocked) - MAX_TEXT_PULLS} blocked PRs omitted")
+    return "\n".join(lines)

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from .batch import render_batch_plan_text
 from .config import ConfigError, load_config
 from .dependencies import render_dependency_plan_text
 from .discovery import DiscoveryService
@@ -284,6 +285,26 @@ def _parser() -> argparse.ArgumentParser:
     dependency_list.add_argument("repository")
     dependency_list.add_argument("--pull-number", type=int, default=0)
     dependency_list.add_argument("--limit", type=int, default=100)
+
+    batch = subparsers.add_parser(
+        "batch", help="plan and enqueue a reviewed pull request merge train"
+    )
+    batch_commands = batch.add_subparsers(dest="batch_command", required=True)
+    batch_plan = batch_commands.add_parser(
+        "plan", help="build a read-only dependency and overlap aware plan"
+    )
+    batch_plan.add_argument("repository")
+    batch_plan.add_argument("--expected-digest", default="")
+    batch_plan.add_argument("--max-parallel", type=int, default=4)
+    batch_plan.add_argument("--format", choices=("json", "text"), default="json")
+    batch_apply = batch_commands.add_parser(
+        "apply", help="persist tasks from one exact reviewed batch plan"
+    )
+    batch_apply.add_argument("repository")
+    batch_apply.add_argument("--expected-digest", required=True)
+    batch_apply.add_argument("--reviewed-by", required=True)
+    batch_apply.add_argument("--max-parallel", type=int, default=4)
+    batch_apply.add_argument("--priority", type=int, default=100)
 
     inbox = subparsers.add_parser(
         "inbox", help="aggregate maintainer attention without invoking a Harness"
@@ -674,6 +695,30 @@ def main(argv: list[str] | None = None) -> int:
             raise AssertionError(
                 f"unhandled portfolio command: {args.portfolio_command}"
             )
+        if args.command == "batch":
+            if args.batch_command == "plan":
+                result = pipeline.batch_plan(
+                    args.repository,
+                    expected_digest=args.expected_digest,
+                    max_parallel=args.max_parallel,
+                )
+                if args.format == "text":
+                    print(render_batch_plan_text(result))
+                else:
+                    _json(result)
+                return 0
+            if args.batch_command == "apply":
+                _json(
+                    pipeline.batch_apply(
+                        args.repository,
+                        expected_digest=args.expected_digest,
+                        reviewed_by=args.reviewed_by,
+                        max_parallel=args.max_parallel,
+                        priority=args.priority,
+                    )
+                )
+                return 0
+            raise AssertionError(f"unhandled batch command: {args.batch_command}")
         if args.command == "follow-up":
             _json(pipeline.follow_up(args.run_id))
             return 0

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -15,6 +15,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from .batch import build_batch_plan
 from .capacity import effective_capacity_limit, pull_request_capacity
 from .ci import (
     FAILED_CONCLUSIONS,
@@ -76,7 +77,7 @@ from .usage import (
     session_resume_outcome,
 )
 from .verifier import DockerVerifier
-from .workspace import WorkspaceError, WorkspaceManager
+from .workspace import WorkspaceError, WorkspaceManager, sanitized_environment
 from .workspace_storage import (
     WORKSPACE_KIND,
     delete_workspace,
@@ -127,6 +128,18 @@ def _repair_feedback(
             if isinstance(value, dict):
                 actionable.append({"kind": "failed_check", **value})
     return tuple(actionable), tuple(suggestions)
+
+
+class BatchDeferred(RuntimeError):
+    """A batch step made progress but must wait for fresh online facts."""
+
+    def __init__(self, reason: str, *, public_write: bool = False) -> None:
+        super().__init__(reason)
+        self.public_write = public_write
+
+
+class BatchConflictError(PolicyError):
+    """A deterministic replay conflicted and requires bounded human repair."""
 
 
 class Pipeline:
@@ -736,6 +749,19 @@ class Pipeline:
                 "expected dependency plan digest must be 64 lowercase hex chars"
             )
         pulls = self.github.open_pull_requests(policy.name)
+        _portfolio, result = self._portfolio_dependency_plan_from_pulls(policy, pulls)
+        digest = str(result["plan_digest"])
+        return {
+            **result,
+            "expected_digest": expected_digest,
+            "matches_expected_digest": (
+                digest == expected_digest if expected_digest else None
+            ),
+        }
+
+    def _portfolio_dependency_plan_from_pulls(
+        self, policy: RepositoryPolicy, pulls: tuple[PullRequest, ...]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         portfolio = self._portfolio_snapshot_from_pulls(policy, pulls)
         snapshot = {
             **portfolio["snapshot"],
@@ -775,12 +801,8 @@ class Pipeline:
             snapshot, declarations, attestations, target_states
         )
         digest = str(plan.pop("plan_digest"))
-        return {
+        return portfolio, {
             "plan_digest": digest,
-            "expected_digest": expected_digest,
-            "matches_expected_digest": (
-                digest == expected_digest if expected_digest else None
-            ),
             "plan": plan,
             "harness_invoked": False,
             "workspace_modified": False,
@@ -892,6 +914,435 @@ class Pipeline:
             ],
             "public_write": False,
         }
+
+    def batch_plan(
+        self,
+        repository: str,
+        *,
+        expected_digest: str = "",
+        max_parallel: int = 4,
+    ) -> dict[str, Any]:
+        """Build a stable merge-train plan without writes or Harness calls."""
+        policy = self.policy(repository)
+        if expected_digest and not re.fullmatch(r"[a-f0-9]{64}", expected_digest):
+            raise ValueError("expected batch digest must be 64 lowercase hex chars")
+        pulls = self.github.open_pull_requests(policy.name)
+        portfolio, dependency = self._portfolio_dependency_plan_from_pulls(
+            policy, pulls
+        )
+        snapshot = {
+            **portfolio["snapshot"],
+            "snapshot_digest": portfolio["snapshot_digest"],
+        }
+        dependency_plan = {
+            **dependency["plan"],
+            "plan_digest": dependency["plan_digest"],
+        }
+        runs = self.store.latest_runs_for_repository(policy.name)
+        for run in runs:
+            details = run.get("details")
+            worktree = (
+                Path(str(details.get("worktree") or "")).expanduser()
+                if isinstance(details, dict)
+                else Path()
+            )
+            run["batch_worktree_available"] = bool(
+                isinstance(details, dict)
+                and details.get("worktree")
+                and (worktree / ".git").exists()
+            )
+        plan = build_batch_plan(
+            snapshot,
+            dependency_plan,
+            runs,
+            wip_limit=effective_capacity_limit(
+                self.config.safety.max_active_pull_requests,
+                policy.max_active_pull_requests,
+            ),
+            max_parallel=max_parallel,
+        )
+        digest = str(plan.pop("batch_digest"))
+        return {
+            "batch_digest": digest,
+            "expected_digest": expected_digest,
+            "matches_expected_digest": (
+                digest == expected_digest if expected_digest else None
+            ),
+            "plan": plan,
+            "harness_invoked": False,
+            "workspace_modified": False,
+            "local_write": False,
+            "public_write": False,
+        }
+
+    def batch_apply(
+        self,
+        repository: str,
+        *,
+        expected_digest: str,
+        reviewed_by: str,
+        max_parallel: int = 4,
+        priority: int = 100,
+    ) -> dict[str, Any]:
+        """Revalidate one reviewed plan and persist its serialized train tasks."""
+        if os.environ.get("REPOSTEWARD_ENABLE_BATCH_APPLY") != "1":
+            raise PolicyError(
+                "batch apply is disabled; set REPOSTEWARD_ENABLE_BATCH_APPLY=1"
+            )
+        actor = reviewed_by.strip()
+        if actor.casefold() != self.config.github.login.casefold():
+            raise PolicyError("--reviewed-by must match the configured GitHub login")
+        if not expected_digest:
+            raise ValueError("batch apply requires a reviewed --expected-digest")
+        result = self.batch_plan(
+            repository,
+            expected_digest=expected_digest,
+            max_parallel=max_parallel,
+        )
+        if not result["matches_expected_digest"]:
+            raise PolicyError("batch plan is stale; inspect and review the latest plan")
+        plan = result["plan"]
+        if not plan["complete"]:
+            raise PolicyError("batch facts are incomplete; no tasks were enqueued")
+        entries = {int(value["pull_number"]): value for value in plan["pull_requests"]}
+        tasks = []
+        dependency_task_id = ""
+        order = list(plan["queue_order"])
+        for offset, pull_number in enumerate(order):
+            entry = entries[int(pull_number)]
+            task = self.enqueue_task(
+                repository,
+                action="batch-advance",
+                issue_number=int(entry["issue_number"]),
+                pull_number=int(entry["pull_number"]),
+                run_id=str(entry["run_id"]),
+                priority=max(-1_000, min(1_000, priority - offset)),
+                depends_on_task_id=dependency_task_id,
+                max_attempts=20,
+                idempotency_key=f"batch:{expected_digest}:{pull_number}",
+                reviewed_by=actor,
+                batch_plan_digest=expected_digest,
+                batch_head_sha=str(entry["head_sha"]),
+                batch_base_sha=str(entry["base_sha"]),
+                batch_verified_base_sha=str(entry["verified_base_sha"]),
+            )["task"]
+            dependency_task_id = str(task["id"])
+            tasks.append(
+                {
+                    key: task[key]
+                    for key in (
+                        "id",
+                        "action",
+                        "pull_number",
+                        "state",
+                        "depends_on_task_id",
+                        "idempotent",
+                    )
+                }
+            )
+        return {
+            "repository": plan["repository"],
+            "batch_digest": expected_digest,
+            "queue_order": order,
+            "tasks": tasks,
+            "blocked_pull_requests": plan["blocked_pull_requests"],
+            "local_write": bool(tasks),
+            "public_write": False,
+            "next_action": "review queue state, then explicitly run queue apply",
+        }
+
+    @staticmethod
+    def _batch_git(
+        worktree: Path, arguments: list[str], *, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=worktree,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=sanitized_environment(keep_codex_credentials=False),
+        )
+        if check and result.returncode:
+            message = result.stderr.strip() or result.stdout.strip()
+            raise WorkspaceError(f"git {' '.join(arguments[:2])} failed: {message}")
+        return result
+
+    def _batch_replay(
+        self,
+        source_run: dict[str, Any],
+        *,
+        pull_number: int,
+        reviewed_by: str,
+        batch_plan_digest: str,
+        root_run_id: str,
+        planned_base_sha: str,
+    ) -> dict[str, Any]:
+        repository = str(source_run["repository"])
+        issue_number = int(source_run["issue_number"])
+        with self._mutation_lease(repository, issue_number) as lease:
+            current = self.store.latest_run(repository, issue_number)
+            if current is None or str(current["id"]) != str(source_run["id"]):
+                raise PolicyError("batch source run changed before replay")
+            if str(current["status"]) != "submitted":
+                raise PolicyError("batch replay requires a submitted run")
+            details = current.get("details", {})
+            if not isinstance(details, dict):
+                raise PolicyError("batch source run details are unavailable")
+            snapshot = self.github.pull_request_merge_snapshot(repository, pull_number)
+            if str(snapshot.get("state") or "").casefold() != "open":
+                raise PolicyError("batch pull request is no longer open")
+            if str(snapshot.get("head_sha") or "") != str(
+                details.get("commit_sha") or ""
+            ):
+                raise PolicyError("batch pull request head changed before replay")
+            if str(snapshot.get("base_branch") or "") != str(
+                details.get("base_branch") or ""
+            ):
+                raise PolicyError("batch pull request base branch changed")
+            old_base = str(details.get("base_commit") or "")
+            new_base = str(snapshot.get("base_sha") or "")
+            if old_base == new_base:
+                raise BatchDeferred("base already current; re-read merge facts")
+            worktree = Path(str(details.get("worktree") or "")).expanduser().resolve()
+            if not (worktree / ".git").exists():
+                raise PolicyError("batch replay worktree is unavailable")
+            if self._batch_git(worktree, ["status", "--porcelain"]).stdout.strip():
+                raise PolicyError("batch replay worktree has uncommitted changes")
+            head = self._revision(worktree)
+            if head != str(details.get("commit_sha") or ""):
+                raise PolicyError("batch replay worktree head changed")
+            base_branch = str(details["base_branch"])
+            self._batch_git(
+                worktree,
+                [
+                    "fetch",
+                    "--no-tags",
+                    "origin",
+                    f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}",
+                ],
+            )
+            if self._revision(worktree, f"origin/{base_branch}") != new_base:
+                raise PolicyError("fetched base differs from reviewed GitHub facts")
+            if (
+                self._batch_git(
+                    worktree,
+                    ["merge-base", "--is-ancestor", planned_base_sha, new_base],
+                    check=False,
+                ).returncode
+                != 0
+            ):
+                raise PolicyError("base history was rewritten after batch planning")
+            ancestry = self._batch_git(
+                worktree,
+                ["merge-base", "--is-ancestor", old_base, head],
+                check=False,
+            )
+            if ancestry.returncode:
+                raise PolicyError("verified base is not an ancestor of the batch head")
+            if self._batch_git(
+                worktree, ["rev-list", "--merges", f"{old_base}..{head}"]
+            ).stdout.strip():
+                raise PolicyError("batch replay does not rewrite merge commits")
+            if (
+                self._batch_git(
+                    worktree,
+                    ["merge-base", "--is-ancestor", new_base, head],
+                    check=False,
+                ).returncode
+                != 0
+            ):
+                signing = "true" if self.config.github.sign_commits else "false"
+                replay = self._batch_git(
+                    worktree,
+                    [
+                        "-c",
+                        f"commit.gpgsign={signing}",
+                        "rebase",
+                        "--onto",
+                        new_base,
+                        old_base,
+                    ],
+                    check=False,
+                )
+                if replay.returncode:
+                    aborted = self._batch_git(
+                        worktree, ["rebase", "--abort"], check=False
+                    )
+                    if aborted.returncode:
+                        raise WorkspaceError(
+                            "batch replay conflicted and git rebase --abort failed"
+                        )
+                    raise BatchConflictError(
+                        "batch replay conflicted; worktree was restored for manual repair"
+                    )
+            agent = details.get("agent_result", {})
+            if not isinstance(agent, dict):
+                raise PolicyError("batch source verification commands are unavailable")
+            raw_commands = agent.get("verification_commands", ())
+            commands = (
+                tuple(str(value) for value in raw_commands)
+                if isinstance(raw_commands, (list, tuple))
+                else ()
+            )
+            if not commands:
+                raise PolicyError("batch replay cannot reproduce source verification")
+            packet = self._adopt_leased(
+                repository,
+                issue_number,
+                worktree=worktree,
+                summary_text=str(
+                    agent.get("summary") or "Replayed onto the latest base."
+                ),
+                implementation_notes=(
+                    "Deterministic Git replay onto the reviewed base; reused the exact "
+                    "source verification commands without invoking a Harness."
+                ),
+                verification_commands=commands,
+            )
+            successor = self.store.latest_run(repository, issue_number)
+            if successor is None or str(successor["id"]) != str(packet["run_id"]):
+                raise StoreError("batch replay successor run was not persisted")
+            successor_details = dict(successor["details"])
+            successor_details["batch_replay"] = {
+                "root_run_id": root_run_id,
+                "source_run_id": str(source_run["id"]),
+                "batch_plan_digest": batch_plan_digest,
+                "source_head_sha": head,
+                "base_sha": new_base,
+            }
+            self.store.update_run(
+                str(successor["id"]),
+                status="ready",
+                details=successor_details,
+                lease=lease,
+            )
+            return self._submit_leased(
+                repository,
+                issue_number,
+                reviewed_by=reviewed_by,
+                mutation_lease=lease,
+            )
+
+    def batch_advance(
+        self,
+        run_id: str,
+        *,
+        pull_number: int,
+        reviewed_by: str,
+        batch_plan_digest: str,
+        planned_head_sha: str,
+        planned_base_sha: str,
+        planned_verified_base_sha: str,
+    ) -> dict[str, Any]:
+        """Advance one queued PR through replay, verification and existing gates."""
+        if os.environ.get("REPOSTEWARD_ENABLE_BATCH_APPLY") != "1":
+            raise PolicyError(
+                "batch execution is disabled; set REPOSTEWARD_ENABLE_BATCH_APPLY=1"
+            )
+        if reviewed_by.casefold() != self.config.github.login.casefold():
+            raise PolicyError("batch reviewed identity no longer matches configuration")
+        root = self.store.run(run_id)
+        if root is None:
+            raise KeyError(f"batch root run not found: {run_id}")
+        repository = str(root["repository"])
+        issue_number = int(root["issue_number"])
+        latest = self.store.latest_run(repository, issue_number)
+        if latest is None:
+            raise PolicyError("batch tracked run is unavailable")
+        latest_details = latest.get("details", {})
+        if not isinstance(latest_details, dict):
+            raise PolicyError("batch tracked run details are unavailable")
+        if str(latest["id"]) != run_id:
+            replay = latest_details.get("batch_replay")
+            if not isinstance(replay, dict) or (
+                str(replay.get("root_run_id") or "") != run_id
+                or str(replay.get("batch_plan_digest") or "") != batch_plan_digest
+            ):
+                raise PolicyError("batch run was superseded outside the reviewed train")
+
+        pull = self.github.pull_request(repository, pull_number)
+        if pull.merged:
+            return {
+                "run_id": str(latest["id"]),
+                "pr_number": pull_number,
+                "status": "merged",
+                "merged": True,
+                "idempotent": True,
+                "public_write": False,
+            }
+        if pull.state.casefold() != "open":
+            raise PolicyError("batch pull request is not open")
+        if str(latest["id"]) == run_id:
+            if pull.head_sha != planned_head_sha:
+                raise PolicyError("batch pull request head changed after planning")
+            if (
+                str(latest_details.get("base_commit") or "")
+                != planned_verified_base_sha
+            ):
+                raise PolicyError("batch verified base changed after planning")
+        if str(latest_details.get("branch") or "") != pull.head_branch:
+            raise PolicyError("batch tracked branch changed")
+
+        if str(latest["status"]) == "ready":
+            submitted = self.submit(repository, issue_number, reviewed_by=reviewed_by)
+            raise BatchDeferred(
+                "batch submitted a newly verified head; wait for current CI",
+                public_write=bool(submitted.get("public_write")),
+            )
+        if str(latest["status"]) != "submitted":
+            raise PolicyError("batch latest run is not ready or submitted")
+        if pull.head_sha != str(latest_details.get("commit_sha") or ""):
+            raise PolicyError("batch pull request head differs from the verified run")
+        if pull.base_sha != str(latest_details.get("base_commit") or ""):
+            submitted = self._batch_replay(
+                latest,
+                pull_number=pull_number,
+                reviewed_by=reviewed_by,
+                batch_plan_digest=batch_plan_digest,
+                root_run_id=run_id,
+                planned_base_sha=planned_base_sha,
+            )
+            raise BatchDeferred(
+                "batch replayed and submitted the head; wait for current CI",
+                public_write=bool(submitted.get("public_write")),
+            )
+
+        (
+            _run,
+            _details,
+            policy,
+            _number,
+            snapshot,
+            decision,
+            _raw,
+            _activity,
+        ) = self._current_merge_evaluation(str(latest["id"]))
+        reason_codes = {value.code for value in decision.reasons}
+        if (
+            reason_codes & {"base_changed", "dependency_blocked"}
+            or "required_check_pending" in reason_codes
+            or (
+                "pull_not_mergeable" in reason_codes
+                and snapshot.mergeable.casefold() in {"", "unknown"}
+            )
+        ):
+            raise BatchDeferred("batch is waiting for fresh GitHub merge facts")
+        if reason_codes == {"review_not_approved"} and policy.owner_attestation:
+            self.attest_owner_review(str(latest["id"]), reviewed_by=reviewed_by)
+        elif reason_codes:
+            raise PolicyError(
+                "batch merge gates require manual attention: "
+                + ", ".join(sorted(reason_codes))
+            )
+        evaluated = self.merge_decision(str(latest["id"]))
+        if not evaluated["eligible"]:
+            raise PolicyError("batch merge decision changed before execution")
+        return self.execute_merge(
+            str(latest["id"]),
+            decision_id=str(evaluated["audit"]["id"]),
+            reviewed_by=reviewed_by,
+        )
 
     def _publication_target(
         self, client: GitHubClient, policy: RepositoryPolicy
@@ -2365,16 +2816,29 @@ class Pipeline:
         reviewed_by: str = "",
         decision_id: str = "",
         reopen_pull_request: int = 0,
+        batch_plan_digest: str = "",
+        batch_head_sha: str = "",
+        batch_base_sha: str = "",
+        batch_verified_base_sha: str = "",
     ) -> dict[str, Any]:
         """Persist one bounded control-plane task without executing it."""
         policy = self.policy(repository)
         parameters: dict[str, Any] = {}
-        if action in {"submit", "merge-attest", "merge"}:
+        if action in {"submit", "merge-attest", "merge", "batch-advance"}:
             parameters["reviewed_by"] = reviewed_by
         if action == "merge":
             parameters["decision_id"] = decision_id
         if action == "submit" and reopen_pull_request:
             parameters["reopen_pull_request"] = reopen_pull_request
+        if action == "batch-advance":
+            parameters.update(
+                {
+                    "batch_plan_digest": batch_plan_digest,
+                    "batch_head_sha": batch_head_sha,
+                    "batch_base_sha": batch_base_sha,
+                    "batch_verified_base_sha": batch_verified_base_sha,
+                }
+            )
         task = self.store.enqueue_queue_task(
             policy.name,
             action=action,
@@ -2466,6 +2930,10 @@ class Pipeline:
 
     @staticmethod
     def _queue_failure(exc: Exception) -> tuple[str, bool]:
+        if isinstance(exc, BatchDeferred):
+            return "batch_waiting", True
+        if isinstance(exc, BatchConflictError):
+            return "batch_conflict", False
         if isinstance(exc, GitHubError):
             transient = exc.status_code in {408, 425, 429} or (
                 exc.status_code is not None and exc.status_code >= 500
@@ -2510,6 +2978,16 @@ class Pipeline:
                 run_id,
                 decision_id=str(parameters["decision_id"]),
                 reviewed_by=str(parameters["reviewed_by"]),
+            )
+        if action == "batch-advance":
+            return self.batch_advance(
+                run_id,
+                pull_number=int(task["pull_number"]),
+                reviewed_by=str(parameters["reviewed_by"]),
+                batch_plan_digest=str(parameters["batch_plan_digest"]),
+                planned_head_sha=str(parameters["batch_head_sha"]),
+                planned_base_sha=str(parameters["batch_base_sha"]),
+                planned_verified_base_sha=str(parameters["batch_verified_base_sha"]),
             )
         raise PolicyError(f"unsupported queued action: {action!r}")
 
@@ -2610,6 +3088,8 @@ class Pipeline:
                 failed = self.store.fail_queue_task(
                     lease, error_code=error_code, retryable=retryable
                 )
+                public_write = bool(isinstance(exc, BatchDeferred) and exc.public_write)
+                any_public_write = any_public_write or public_write
                 outcomes.append(
                     {
                         "task_id": task["id"],
@@ -2618,6 +3098,7 @@ class Pipeline:
                         "error_code": error_code,
                         "retryable": retryable,
                         "manual_required": bool(failed["manual_required"]),
+                        "public_write": public_write,
                     }
                 )
                 continue

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -675,10 +675,21 @@ QUEUE_ACTIONS = frozenset(
         "merge-decision",
         "merge-attest",
         "merge",
+        "batch-advance",
     }
 )
 QUEUE_STATES = frozenset({"pending", "running", "completed", "failed", "cancelled"})
-QUEUE_PARAMETER_KEYS = frozenset({"reviewed_by", "decision_id", "reopen_pull_request"})
+QUEUE_PARAMETER_KEYS = frozenset(
+    {
+        "reviewed_by",
+        "decision_id",
+        "reopen_pull_request",
+        "batch_plan_digest",
+        "batch_head_sha",
+        "batch_base_sha",
+        "batch_verified_base_sha",
+    }
+)
 QUEUE_RESULT_KEYS = frozenset(
     {
         "run_id",
@@ -3167,6 +3178,15 @@ class Store:
             "submit": frozenset({"reviewed_by"}),
             "merge-attest": frozenset({"reviewed_by"}),
             "merge": frozenset({"reviewed_by", "decision_id"}),
+            "batch-advance": frozenset(
+                {
+                    "reviewed_by",
+                    "batch_plan_digest",
+                    "batch_head_sha",
+                    "batch_base_sha",
+                    "batch_verified_base_sha",
+                }
+            ),
         }
         required_keys = required[action]
         missing = required_keys - set(parameters)
@@ -3195,6 +3215,19 @@ class Store:
             not isinstance(decision_id, str) or not _is_lower_hex(decision_id, 32)
         ):
             raise ValueError("queue decision_id must be 32 lowercase hex characters")
+        for key, length in (
+            ("batch_plan_digest", 64),
+            ("batch_head_sha", 40),
+            ("batch_base_sha", 40),
+            ("batch_verified_base_sha", 40),
+        ):
+            value = parameters.get(key)
+            if value is not None and (
+                not isinstance(value, str) or not _is_lower_hex(value, length)
+            ):
+                raise ValueError(
+                    f"queue {key} must be {length} lowercase hex characters"
+                )
         reopen = parameters.get("reopen_pull_request")
         if reopen is not None and (
             isinstance(reopen, bool) or not isinstance(reopen, int) or reopen < 0

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,646 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from reposteward.batch import build_batch_plan, render_batch_plan_text
+from reposteward.github import PullRequest
+from reposteward.pipeline import BatchConflictError, BatchDeferred, Pipeline
+from reposteward.policy import PolicyError
+
+
+def _pull(number: int, files: list[str], *, draft: bool = False) -> dict:
+    return {
+        "number": number,
+        "draft": draft,
+        "head_branch": f"tiammomo/change-{number}",
+        "head_sha": str(number) * 40,
+        "base_branch": "main",
+        "base_sha": "b" * 40,
+        "files": files,
+        "facts_complete": True,
+    }
+
+
+def _run(number: int, *, status: str = "submitted") -> dict:
+    return {
+        "id": f"run-{number}",
+        "repository": "owner/repo",
+        "issue_number": number,
+        "status": status,
+        "submission_pr_url": f"https://github.com/owner/repo/pull/{number}",
+        "details": {
+            "branch": f"tiammomo/change-{number}",
+            "base_branch": "main",
+            "base_commit": "b" * 40,
+            "commit_sha": str(number) * 40,
+        },
+    }
+
+
+class BatchPlanTests(unittest.TestCase):
+    def inputs(self):
+        snapshot = {
+            "repository": "owner/repo",
+            "snapshot_digest": "s" * 64,
+            "complete": True,
+            "pull_requests": [
+                _pull(3, ["three.py"]),
+                _pull(1, ["shared.py"]),
+                _pull(4, ["four.py"], draft=True),
+                _pull(2, ["shared.py"]),
+            ],
+            "overlaps": [
+                {"left": 1, "right": 2, "file_count": 1, "files": ["shared.py"]}
+            ],
+        }
+        dependency = {
+            "repository": "owner/repo",
+            "portfolio_snapshot_digest": "s" * 64,
+            "plan_digest": "d" * 64,
+            "complete": True,
+            "suggested_merge_order": [1, 2, 3, 4],
+            "ready_blockers": {"3": ["dependency_open:#1"]},
+            "authoritative_edges": [
+                {
+                    "pull_number": 3,
+                    "dependency_number": 1,
+                    "status": "open",
+                }
+            ],
+        }
+        return snapshot, dependency
+
+    def test_plan_is_stable_and_overlap_does_not_become_a_dependency(self) -> None:
+        snapshot, dependency = self.inputs()
+
+        first = build_batch_plan(
+            snapshot,
+            dependency,
+            [_run(4), _run(2), _run(1), _run(3)],
+            wip_limit=3,
+            max_parallel=2,
+        )
+        second = build_batch_plan(
+            {**snapshot, "pull_requests": list(reversed(snapshot["pull_requests"]))},
+            dependency,
+            [_run(3), _run(1), _run(2), _run(4)],
+            wip_limit=3,
+            max_parallel=2,
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["queue_order"], [1, 2, 3])
+        self.assertEqual(first["parallel_sets"], [[1], [2, 3]])
+        self.assertEqual(first["overlap_groups"], [[1, 2]])
+        self.assertFalse(first["overlap_is_authoritative"])
+        self.assertEqual(first["blocked_pull_requests"], {"4": ["pull_is_draft"]})
+        self.assertTrue(first["wip"]["over_limit"])
+        text = render_batch_plan_text(
+            {"batch_digest": first.pop("batch_digest"), "plan": first}
+        )
+        self.assertIn("Queue order: #1 -> #2 -> #3", text)
+
+    def test_incomplete_or_ambiguous_facts_fail_closed_per_pull(self) -> None:
+        snapshot, dependency = self.inputs()
+        snapshot["complete"] = False
+        runs = [_run(1), _run(1), _run(2), _run(3), _run(4)]
+
+        plan = build_batch_plan(snapshot, dependency, runs, wip_limit=8, max_parallel=4)
+
+        self.assertFalse(plan["complete"])
+        self.assertEqual(plan["queue_order"], [])
+        self.assertIn("ambiguous_local_run", plan["blocked_pull_requests"]["1"])
+        self.assertTrue(
+            all(
+                "portfolio_snapshot_incomplete" in blockers
+                for blockers in plan["blocked_pull_requests"].values()
+            )
+        )
+
+    def test_local_blocker_propagates_to_dependent_pull_requests(self) -> None:
+        snapshot, dependency = self.inputs()
+        dependency["authoritative_edges"] = [
+            {"pull_number": 3, "dependency_number": 1, "status": "open"}
+        ]
+
+        plan = build_batch_plan(
+            snapshot,
+            dependency,
+            [_run(2), _run(3), _run(4)],
+            wip_limit=8,
+            max_parallel=4,
+        )
+
+        self.assertEqual(plan["queue_order"], [2])
+        self.assertEqual(plan["blocked_pull_requests"]["1"], ["local_run_missing"])
+        self.assertIn(
+            "dependency_prerequisite_not_runnable:#1",
+            plan["blocked_pull_requests"]["3"],
+        )
+
+    def test_replay_requires_recoverable_worktree_and_verification_commands(
+        self,
+    ) -> None:
+        snapshot, dependency = self.inputs()
+        snapshot["pull_requests"] = [_pull(1, ["one.py"])]
+        snapshot["pull_requests"][0]["base_sha"] = "c" * 40
+        snapshot["overlaps"] = []
+        dependency["suggested_merge_order"] = [1]
+        dependency["ready_blockers"] = {}
+        dependency["authoritative_edges"] = []
+        run = _run(1)
+        run["details"]["agent_result"] = {
+            "verification_commands": ["python -m unittest"]
+        }
+        run["batch_worktree_available"] = False
+
+        blocked = build_batch_plan(
+            snapshot, dependency, [run], wip_limit=8, max_parallel=4
+        )
+        run["batch_worktree_available"] = True
+        ready = build_batch_plan(
+            snapshot, dependency, [run], wip_limit=8, max_parallel=4
+        )
+
+        self.assertEqual(
+            blocked["blocked_pull_requests"]["1"], ["replay_worktree_missing"]
+        )
+        self.assertEqual(ready["queue_order"], [1])
+        self.assertTrue(ready["pull_requests"][0]["replay_required"])
+
+    def test_mismatched_snapshot_digest_is_rejected(self) -> None:
+        snapshot, dependency = self.inputs()
+        dependency["portfolio_snapshot_digest"] = "x" * 64
+
+        with self.assertRaisesRegex(ValueError, "different portfolio snapshots"):
+            build_batch_plan(snapshot, dependency, [], wip_limit=4, max_parallel=1)
+
+    def test_long_dependency_chain_uses_iterative_ready_sets(self) -> None:
+        count = 1_000
+        pulls = []
+        runs = []
+        for number in range(1, count + 1):
+            sha = f"{number:040x}"
+            pull = _pull(number, [f"src/{number}.py"])
+            pull["head_sha"] = sha
+            run = _run(number)
+            run["details"]["commit_sha"] = sha
+            pulls.append(pull)
+            runs.append(run)
+        snapshot = {
+            "repository": "owner/repo",
+            "snapshot_digest": "s" * 64,
+            "complete": True,
+            "pull_requests": pulls,
+            "overlaps": [],
+        }
+        dependency = {
+            "repository": "owner/repo",
+            "portfolio_snapshot_digest": "s" * 64,
+            "plan_digest": "d" * 64,
+            "complete": True,
+            "suggested_merge_order": list(range(1, count + 1)),
+            "ready_blockers": {
+                str(number): [f"dependency_open:#{number - 1}"]
+                for number in range(2, count + 1)
+            },
+            "authoritative_edges": [
+                {
+                    "pull_number": number,
+                    "dependency_number": number - 1,
+                    "status": "open",
+                }
+                for number in range(2, count + 1)
+            ],
+        }
+
+        plan = build_batch_plan(
+            snapshot, dependency, runs, wip_limit=2_000, max_parallel=32
+        )
+
+        self.assertEqual(len(plan["parallel_sets"]), count)
+        self.assertEqual(plan["parallel_sets"][0], [1])
+        self.assertEqual(plan["parallel_sets"][-1], [count])
+
+
+class BatchApplyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pipeline = object.__new__(Pipeline)
+        self.pipeline.config = SimpleNamespace(github=SimpleNamespace(login="alice"))
+        self.pipeline.enqueue_task = Mock()
+
+    @staticmethod
+    def plan(digest: str, *, matches: bool = True) -> dict:
+        return {
+            "batch_digest": digest,
+            "matches_expected_digest": matches,
+            "plan": {
+                "repository": "owner/repo",
+                "complete": True,
+                "queue_order": [1, 2, 3],
+                "blocked_pull_requests": {},
+                "pull_requests": [
+                    {
+                        "pull_number": number,
+                        "run_id": f"run-{number}",
+                        "issue_number": number,
+                        "head_sha": str(number) * 40,
+                        "base_sha": "b" * 40,
+                        "verified_base_sha": "b" * 40,
+                    }
+                    for number in (1, 2, 3)
+                ],
+            },
+        }
+
+    def test_apply_rechecks_digest_and_serializes_repository_writes(self) -> None:
+        digest = "d" * 64
+        self.pipeline.batch_plan = Mock(return_value=self.plan(digest))
+        self.pipeline.enqueue_task.side_effect = [
+            {
+                "task": {
+                    "id": f"task-{number}",
+                    "action": "batch-advance",
+                    "pull_number": number,
+                    "state": "pending",
+                    "depends_on_task_id": "" if number == 1 else f"task-{number - 1}",
+                    "idempotent": False,
+                }
+            }
+            for number in (1, 2, 3)
+        ]
+
+        with unittest.mock.patch.dict(
+            os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+        ):
+            result = self.pipeline.batch_apply(
+                "owner/repo", expected_digest=digest, reviewed_by="alice"
+            )
+
+        self.assertEqual(result["queue_order"], [1, 2, 3])
+        self.assertEqual(
+            [
+                call.kwargs["depends_on_task_id"]
+                for call in self.pipeline.enqueue_task.call_args_list
+            ],
+            ["", "task-1", "task-2"],
+        )
+        self.assertTrue(
+            all(
+                call.kwargs["max_attempts"] == 20
+                for call in self.pipeline.enqueue_task.call_args_list
+            )
+        )
+        self.assertFalse(result["public_write"])
+
+    def test_apply_rejects_stale_plan_before_enqueue(self) -> None:
+        self.pipeline.batch_plan = Mock(return_value=self.plan("d" * 64, matches=False))
+
+        with (
+            unittest.mock.patch.dict(
+                os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+            ),
+            self.assertRaisesRegex(PolicyError, "stale"),
+        ):
+            self.pipeline.batch_apply(
+                "owner/repo", expected_digest="d" * 64, reviewed_by="alice"
+            )
+
+        self.pipeline.enqueue_task.assert_not_called()
+
+
+class BatchAdvanceTests(unittest.TestCase):
+    def pipeline(self, reason_codes: tuple[str, ...]):
+        run = {
+            "id": "root-run",
+            "repository": "owner/repo",
+            "issue_number": 7,
+            "status": "submitted",
+            "details": {
+                "branch": "tiammomo/change",
+                "base_branch": "main",
+                "base_commit": "b" * 40,
+                "commit_sha": "a" * 40,
+            },
+        }
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(github=SimpleNamespace(login="alice"))
+        pipeline.store = SimpleNamespace(
+            run=Mock(return_value=run), latest_run=Mock(return_value=run)
+        )
+        pipeline.github = SimpleNamespace(
+            pull_request=Mock(
+                return_value=PullRequest(
+                    number=7,
+                    url="https://github.com/owner/repo/pull/7",
+                    state="open",
+                    draft=False,
+                    head_branch="tiammomo/change",
+                    head_sha="a" * 40,
+                    base_branch="main",
+                    base_sha="b" * 40,
+                )
+            )
+        )
+        snapshot = SimpleNamespace(mergeable="MERGEABLE")
+        decision = SimpleNamespace(
+            reasons=tuple(SimpleNamespace(code=value) for value in reason_codes)
+        )
+        policy = SimpleNamespace(owner_attestation=True)
+        pipeline._current_merge_evaluation = Mock(
+            return_value=(run, run["details"], policy, 7, snapshot, decision, {}, {})
+        )
+        pipeline.attest_owner_review = Mock(return_value={})
+        pipeline.merge_decision = Mock(
+            return_value={"eligible": True, "audit": {"id": "e" * 32}}
+        )
+        pipeline.execute_merge = Mock(
+            return_value={
+                "run_id": "root-run",
+                "merged": True,
+                "merge_commit_sha": "c" * 40,
+                "public_write": True,
+            }
+        )
+        return pipeline
+
+    def advance(self, pipeline: Pipeline):
+        return pipeline.batch_advance(
+            "root-run",
+            pull_number=7,
+            reviewed_by="alice",
+            batch_plan_digest="d" * 64,
+            planned_head_sha="a" * 40,
+            planned_base_sha="b" * 40,
+            planned_verified_base_sha="b" * 40,
+        )
+
+    def test_pending_checks_defer_without_attesting_or_merging(self) -> None:
+        pipeline = self.pipeline(("required_check_pending", "review_not_approved"))
+
+        with (
+            unittest.mock.patch.dict(
+                os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+            ),
+            self.assertRaises(BatchDeferred),
+        ):
+            self.advance(pipeline)
+
+        pipeline.attest_owner_review.assert_not_called()
+        pipeline.execute_merge.assert_not_called()
+
+    def test_owner_review_and_merge_reuse_existing_exact_gates(self) -> None:
+        pipeline = self.pipeline(("review_not_approved",))
+
+        with unittest.mock.patch.dict(
+            os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+        ):
+            result = self.advance(pipeline)
+
+        self.assertTrue(result["merged"])
+        pipeline.attest_owner_review.assert_called_once_with(
+            "root-run", reviewed_by="alice"
+        )
+        pipeline.merge_decision.assert_called_once_with("root-run")
+        pipeline.execute_merge.assert_called_once_with(
+            "root-run", decision_id="e" * 32, reviewed_by="alice"
+        )
+
+    def test_external_head_change_fails_closed_before_merge_reads(self) -> None:
+        pipeline = self.pipeline(())
+        pipeline.github.pull_request.return_value = PullRequest(
+            number=7,
+            url="https://github.com/owner/repo/pull/7",
+            state="open",
+            draft=False,
+            head_branch="tiammomo/change",
+            head_sha="f" * 40,
+            base_branch="main",
+            base_sha="b" * 40,
+        )
+
+        with (
+            unittest.mock.patch.dict(
+                os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+            ),
+            self.assertRaisesRegex(PolicyError, "head changed after planning"),
+        ):
+            self.advance(pipeline)
+
+        pipeline._current_merge_evaluation.assert_not_called()
+
+    def test_new_online_base_uses_the_separately_bound_verified_base(self) -> None:
+        pipeline = self.pipeline(())
+        pipeline.github.pull_request.return_value = PullRequest(
+            number=7,
+            url="https://github.com/owner/repo/pull/7",
+            state="open",
+            draft=False,
+            head_branch="tiammomo/change",
+            head_sha="a" * 40,
+            base_branch="main",
+            base_sha="c" * 40,
+        )
+        pipeline._batch_replay = Mock(return_value={"public_write": True})
+
+        with (
+            unittest.mock.patch.dict(
+                os.environ, {"REPOSTEWARD_ENABLE_BATCH_APPLY": "1"}
+            ),
+            self.assertRaises(BatchDeferred),
+        ):
+            pipeline.batch_advance(
+                "root-run",
+                pull_number=7,
+                reviewed_by="alice",
+                batch_plan_digest="d" * 64,
+                planned_head_sha="a" * 40,
+                planned_base_sha="c" * 40,
+                planned_verified_base_sha="b" * 40,
+            )
+
+        pipeline._batch_replay.assert_called_once()
+
+
+class _ReplayStore:
+    def __init__(self, source: dict) -> None:
+        self.current = source
+
+    def latest_run(self, _repository: str, _issue_number: int):
+        return self.current
+
+    def update_run(self, run_id: str, **values) -> None:
+        self.current = {**self.current, "id": run_id, **values}
+
+
+class _ReplayGitHub:
+    def __init__(self, head: str, base: str) -> None:
+        self.head = head
+        self.base = base
+
+    def pull_request_merge_snapshot(self, _repository: str, _number: int) -> dict:
+        return {
+            "state": "OPEN",
+            "head_sha": self.head,
+            "base_branch": "main",
+            "base_sha": self.base,
+        }
+
+
+class BatchReplayTests(unittest.TestCase):
+    def git(self, worktree: Path, *arguments: str) -> str:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def repository(self, root: Path, *, conflict: bool) -> tuple[Path, str, str, str]:
+        remote = root / "remote.git"
+        seed = root / "seed"
+        worktree = root / "worktree"
+        subprocess.run(
+            ["git", "init", "--bare", remote], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "init", "-b", "main", seed], check=True, capture_output=True
+        )
+        self.git(seed, "config", "user.name", "Test")
+        self.git(seed, "config", "user.email", "test@example.com")
+        (seed / "shared.txt").write_text("base\n")
+        self.git(seed, "add", "shared.txt")
+        self.git(seed, "commit", "-m", "base")
+        old_base = self.git(seed, "rev-parse", "HEAD")
+        self.git(seed, "remote", "add", "origin", str(remote))
+        self.git(seed, "push", "-u", "origin", "main")
+        subprocess.run(
+            ["git", "clone", "--branch", "main", str(remote), worktree],
+            check=True,
+            capture_output=True,
+        )
+        self.git(worktree, "config", "user.name", "Test")
+        self.git(worktree, "config", "user.email", "test@example.com")
+        self.git(worktree, "switch", "-c", "tiammomo/change")
+        target = worktree / ("shared.txt" if conflict else "feature.txt")
+        target.write_text("feature\n")
+        self.git(worktree, "add", target.name)
+        self.git(worktree, "commit", "-s", "-m", "feat: change")
+        head = self.git(worktree, "rev-parse", "HEAD")
+        if conflict:
+            (seed / "shared.txt").write_text("main\n")
+        else:
+            (seed / "main.txt").write_text("main\n")
+        self.git(seed, "add", ".")
+        self.git(seed, "commit", "-m", "advance main")
+        new_base = self.git(seed, "rev-parse", "HEAD")
+        self.git(seed, "push", "origin", "main")
+        return worktree, old_base, head, new_base
+
+    def pipeline(self, worktree: Path, old_base: str, head: str, new_base: str):
+        source = {
+            "id": "root-run",
+            "repository": "owner/repo",
+            "issue_number": 7,
+            "status": "submitted",
+            "details": {
+                "worktree": str(worktree),
+                "base_branch": "main",
+                "base_commit": old_base,
+                "branch": "tiammomo/change",
+                "commit_sha": head,
+                "agent_result": {
+                    "summary": "change",
+                    "verification_commands": ["python -m unittest"],
+                },
+            },
+        }
+        pipeline = object.__new__(Pipeline)
+        pipeline.config = SimpleNamespace(github=SimpleNamespace(sign_commits=False))
+        pipeline.store = _ReplayStore(source)
+        pipeline.github = _ReplayGitHub(head, new_base)
+
+        @contextmanager
+        def lease(_repository: str, _issue_number: int):
+            yield SimpleNamespace(generation=1)
+
+        pipeline._mutation_lease = lease
+
+        def adopt(_repository, _issue, **_values):
+            successor = {
+                **source,
+                "id": "successor-run",
+                "status": "ready",
+                "details": {
+                    **source["details"],
+                    "base_commit": new_base,
+                    "commit_sha": pipeline._revision(worktree),
+                },
+            }
+            pipeline.store.current = successor
+            return {"run_id": "successor-run"}
+
+        pipeline._adopt_leased = Mock(side_effect=adopt)
+        pipeline._submit_leased = Mock(return_value={"public_write": True})
+        return pipeline, source
+
+    def test_clean_replay_reuses_verification_without_harness(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, old_base, head, new_base = self.repository(
+                Path(directory), conflict=False
+            )
+            pipeline, source = self.pipeline(worktree, old_base, head, new_base)
+
+            result = pipeline._batch_replay(
+                source,
+                pull_number=7,
+                reviewed_by="tiammomo",
+                batch_plan_digest="d" * 64,
+                root_run_id="root-run",
+                planned_base_sha=old_base,
+            )
+
+            self.assertTrue(result["public_write"])
+            self.assertEqual(self.git(worktree, "status", "--porcelain"), "")
+            self.assertEqual(
+                self.git(worktree, "merge-base", "--is-ancestor", new_base, "HEAD"),
+                "",
+            )
+            pipeline._adopt_leased.assert_called_once()
+            self.assertEqual(
+                pipeline._adopt_leased.call_args.kwargs["verification_commands"],
+                ("python -m unittest",),
+            )
+
+    def test_conflict_aborts_and_restores_the_verified_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            worktree, old_base, head, new_base = self.repository(
+                Path(directory), conflict=True
+            )
+            pipeline, source = self.pipeline(worktree, old_base, head, new_base)
+
+            with self.assertRaises(BatchConflictError):
+                pipeline._batch_replay(
+                    source,
+                    pull_number=7,
+                    reviewed_by="tiammomo",
+                    batch_plan_digest="d" * 64,
+                    root_run_id="root-run",
+                    planned_base_sha=old_base,
+                )
+
+            self.assertEqual(self.git(worktree, "rev-parse", "HEAD"), head)
+            self.assertEqual(self.git(worktree, "status", "--porcelain"), "")
+            pipeline._adopt_leased.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,6 +419,52 @@ class CliSetupTests(unittest.TestCase):
             lease_seconds=60,
         )
 
+    def test_batch_commands_separate_read_only_plan_from_reviewed_apply(self) -> None:
+        pipeline = MagicMock()
+        pipeline.batch_plan.return_value = {
+            "batch_digest": "d" * 64,
+            "plan": {"repository": "owner/repo", "queue_order": []},
+        }
+        pipeline.batch_apply.return_value = {
+            "batch_digest": "d" * 64,
+            "tasks": [],
+            "public_write": False,
+        }
+
+        with (
+            patch("reposteward.cli.load_config", return_value=object()),
+            patch("reposteward.cli.Pipeline", return_value=pipeline),
+            redirect_stdout(io.StringIO()),
+        ):
+            plan_code = main(["batch", "plan", "owner/repo", "--max-parallel", "6"])
+            apply_code = main(
+                [
+                    "batch",
+                    "apply",
+                    "owner/repo",
+                    "--expected-digest",
+                    "d" * 64,
+                    "--reviewed-by",
+                    "alice",
+                    "--max-parallel",
+                    "6",
+                    "--priority",
+                    "80",
+                ]
+            )
+
+        self.assertEqual((plan_code, apply_code), (0, 0))
+        pipeline.batch_plan.assert_called_once_with(
+            "owner/repo", expected_digest="", max_parallel=6
+        )
+        pipeline.batch_apply.assert_called_once_with(
+            "owner/repo",
+            expected_digest="d" * 64,
+            reviewed_by="alice",
+            max_parallel=6,
+            priority=80,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from reposteward.config import RepositoryPolicy
-from reposteward.pipeline import Pipeline
+from reposteward.pipeline import BatchConflictError, BatchDeferred, Pipeline
 from reposteward.policy import PolicyError
 from reposteward.store import SCHEMA_VERSION, QueueLease, Store, StoreError
 
@@ -150,6 +150,21 @@ class QueueStoreTests(unittest.TestCase):
             parameters={},
         )
         self.assertEqual(follow_up["issue_number"], 3)
+
+    def test_batch_parameters_are_exact_bounded_hashes(self) -> None:
+        parameters = {
+            "reviewed_by": "alice",
+            "batch_plan_digest": "d" * 64,
+            "batch_head_sha": "a" * 40,
+            "batch_base_sha": "b" * 40,
+            "batch_verified_base_sha": "b" * 40,
+        }
+
+        Store._validate_queue_parameters("batch-advance", parameters)
+        with self.assertRaisesRegex(ValueError, "batch_head_sha"):
+            Store._validate_queue_parameters(
+                "batch-advance", {**parameters, "batch_head_sha": "not-a-sha"}
+            )
 
     def test_expired_claim_is_taken_over_and_old_generation_is_fenced(self) -> None:
         task = self.enqueue(3, max_attempts=2)
@@ -380,6 +395,43 @@ class QueuePipelineTests(unittest.TestCase):
         inspected = self.pipeline.queue_inspect(task_id=task["id"])
         self.assertEqual(inspected["counts"]["failed"], 1)
         self.assertEqual(inspected["manual_required"], 1)
+
+    def test_batch_wait_is_retryable_and_reports_prior_public_progress(self) -> None:
+        run_id = self.pipeline.store.start_run("owner/repo", 43, "pull_request")
+        self.pipeline.store.update_run(
+            run_id,
+            status="submitted",
+            details={"pr_url": "https://github.com/owner/repo/pull/43"},
+        )
+        task = self.pipeline.enqueue_task(
+            "owner/repo",
+            action="batch-advance",
+            run_id=run_id,
+            pull_number=43,
+            max_attempts=2,
+            reviewed_by="alice",
+            batch_plan_digest="d" * 64,
+            batch_head_sha="a" * 40,
+            batch_base_sha="b" * 40,
+            batch_verified_base_sha="b" * 40,
+        )["task"]
+        self.pipeline.batch_advance = Mock(
+            side_effect=BatchDeferred("wait for CI", public_write=True)
+        )
+
+        with patch.dict(os.environ, {"REPOSTEWARD_ENABLE_QUEUE_APPLY": "1"}):
+            result = self.pipeline.apply_queue(worker="worker")
+
+        self.assertEqual(result["outcomes"][0]["error_code"], "batch_waiting")
+        self.assertTrue(result["outcomes"][0]["retryable"])
+        self.assertFalse(result["outcomes"][0]["manual_required"])
+        self.assertTrue(result["public_write"])
+        inspected = self.pipeline.queue_inspect(task_id=task["id"])
+        self.assertEqual(inspected["counts"]["failed"], 1)
+        self.assertEqual(
+            self.pipeline._queue_failure(BatchConflictError("conflict")),
+            ("batch_conflict", False),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 关联 Issue

Closes #62

## 问题与改动

RepoSteward 已有 Portfolio、依赖规划、持久队列和单 PR 合并门禁，但维护者仍需在每次 main 变化后手工重排、重放、复验和合并多个 PR。

本 PR 增加确定性 merge-train 协调器：

- batch plan 在同一次 open-PR listing 上复用 Portfolio/Dependency facts，输出稳定 digest、依赖顺序、非权威重叠分组、可并行预检集合、WIP 和逐 PR blocker。
- 只接受与线上 PR 精确关联的本地 submitted run；Draft、缺失/歧义 run、外部 head/branch 变化、不完整事实和不可恢复 replay 输入均失败关闭。
- batch apply 必须回传审阅过的 digest，重新读取线上事实后只创建幂等 batch-advance 队列任务；仓库公开写入通过 task dependency 串行化。
- 每个任务重新读取当前 PR。base 未变时复用 owner attestation、merge decision 和 merge executor；base 前进时对 clean worktree 执行 Git replay，并通过原验证命令重新 adopt/submit，不调用 Harness。
- 计划时线上 base 与本地 verified base 分别绑定；后续 base 必须是计划 base 的后代，force-push/rewrite 失败关闭。
- CI pending、base/依赖的正常竞态采用有界退避；rebase 冲突先 abort 恢复已验证 HEAD，再进入 manual_required，不会自动覆盖维护者改动。
- README 和架构文档补充完整操作流程与安全边界。

## 验证

~~~text
uv run python -m unittest discover -s tests -v  # 342 tests passed
uvx ruff check .                                # passed
uvx ruff format --check .                       # 74 files already formatted
uv run reposteward --help                       # passed
uv build                                        # sdist and wheel built
uv lock --check                                 # passed
~~~

RepoSteward 隔离 verifier 也使用前五条命令完成验证，run d26566f160c5451db70a77c1c58ab70b 的审查包状态为 ready。

新增测试覆盖 digest stale、重叠不升级为依赖、本地 blocker 传播、串行队列、公开写入后的可恢复等待、owner gate 复用、外部 head 变化、真实 Git clean replay、冲突 abort，以及 1,000 节点长依赖链。

## 风险与兼容性

- 不新增数据库迁移；只扩展 schema 16 队列动作/有界参数白名单，旧任务保持兼容。
- batch plan 和 batch apply 均不调用 Harness；只有 replay 的既有 verification commands 进入隔离 Runner，因此控制面不增加模型 token。
- ready-heap、依赖反向邻接与 overlap 邻接按 O((V+E) log V) 规划；1,000 节点长链测试避免递归和全量重复扫描。
- 线上 freshness 读取次数增加是刻意的安全成本；慢 GitHub、Runner 和 Git 操作期间不持有 SQLite 写锁。
- batch、queue、submit、owner attestation 和 merge 各自的环境开关与身份/SHA/租约门禁仍独立生效，协调器不会代为开启。
- merge commit、base 历史重写、真实冲突、失败 CI、高风险路径和不完整事实需要人工处理。

## 自动化辅助

使用 Codex 协助实现和验证。提交前已复核完整 diff、队列与运行租约边界、Git replay 恢复、公开写入审计、依赖传播、最坏复杂度、敏感信息扫描及全部验证结果。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。
