### PR TITLE
fix(verifier): allow safe tracked environment templates

### DIFF
--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -42,6 +42,19 @@ UNTRACKED_SANDBOX_EXCLUDED_NAMES = frozenset(
     }
 )
 SENSITIVE_SANDBOX_NAMES = frozenset({"credentials", "secrets"})
+SUPPORTED_ENV_TEMPLATE_NAMES = frozenset(
+    {".env.example", ".env.sample", ".env.template"}
+)
+MAX_ENV_TEMPLATE_BYTES = 64 * 1024
+ENV_ASSIGNMENT = re.compile(
+    r"(?:export\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*)"
+)
+SENSITIVE_ENV_NAME = re.compile(
+    r"(?:^|_)(?:ACCESS_KEY|API_KEY|AUTH|CREDENTIALS?|PASS(?:WORD|WD)?|"
+    r"PRIVATE_KEY|SECRET|TOKEN)(?:_|$)",
+    re.IGNORECASE,
+)
+EMPTY_ENV_VALUE = re.compile(r"(?:|''|\"\")(?:\s+#.*)?")
 
 
 class VerificationError(RuntimeError):
@@ -179,6 +192,47 @@ class DockerVerifier:
         )
 
     @classmethod
+    def _is_supported_env_template(cls, relative: Path) -> bool:
+        return relative.name.casefold() in SUPPORTED_ENV_TEMPLATE_NAMES and not any(
+            part.casefold() in SENSITIVE_SANDBOX_NAMES for part in relative.parent.parts
+        )
+
+    @staticmethod
+    def _validate_env_template(source: Path, relative: Path) -> None:
+        if source.is_symlink() or not source.is_file():
+            raise VerificationError(
+                f"tracked environment template must be a regular file: {relative}"
+            )
+        if source.stat().st_size > MAX_ENV_TEMPLATE_BYTES:
+            raise VerificationError(
+                f"tracked environment template exceeds {MAX_ENV_TEMPLATE_BYTES} bytes: "
+                f"{relative}"
+            )
+        try:
+            content = source.read_text(encoding="utf-8")
+        except UnicodeDecodeError as error:
+            raise VerificationError(
+                f"tracked environment template must be UTF-8: {relative}"
+            ) from error
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            assignment = ENV_ASSIGNMENT.fullmatch(stripped)
+            if assignment is None:
+                raise VerificationError(
+                    "tracked environment template contains an unsupported line "
+                    f"at {relative}:{line_number}"
+                )
+            if SENSITIVE_ENV_NAME.search(
+                assignment.group("name")
+            ) and not EMPTY_ENV_VALUE.fullmatch(assignment.group("value")):
+                raise VerificationError(
+                    "tracked environment template contains a non-empty sensitive "
+                    f"field at {relative}:{line_number}"
+                )
+
+    @classmethod
     def _copy_workspace(cls, worktree: Path, target: Path) -> int:
         """Copy tracked and non-ignored untracked files without scanning caches."""
         tracked = cls._git_file_list(worktree, "--cached")
@@ -193,11 +247,14 @@ class DockerVerifier:
             if relative.is_absolute() or ".." in relative.parts:
                 raise VerificationError("Git returned an unsafe workspace path")
             if cls._sensitive_path(relative):
-                if is_tracked:
+                if is_tracked and cls._is_supported_env_template(relative):
+                    cls._validate_env_template(worktree / relative, relative)
+                elif is_tracked:
                     raise VerificationError(
                         f"tracked sensitive path cannot enter verification: {relative}"
                     )
-                continue
+                else:
+                    continue
             if not is_tracked and any(
                 part in UNTRACKED_SANDBOX_EXCLUDED_NAMES for part in relative.parts
             ):

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -171,6 +171,109 @@ class VerificationSandboxTests(unittest.TestCase):
             ):
                 DockerVerifier._copy_workspace(worktree, root / "snapshot")
 
+    def test_tracked_empty_environment_templates_are_copied(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            names = (".env.example", ".env.sample", ".env.template")
+            for name in names:
+                (worktree / name).write_text(
+                    "# Safe defaults for local development\nAPI_KEY=\nLOG_LEVEL=info\n",
+                    encoding="utf-8",
+                )
+            subprocess.run(["git", "add", *names], cwd=worktree, check=True)
+
+            DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+            for name in names:
+                with self.subTest(name=name):
+                    self.assertEqual(
+                        (root / "snapshot" / name).read_text(encoding="utf-8"),
+                        (worktree / name).read_text(encoding="utf-8"),
+                    )
+
+    def test_untracked_environment_template_is_excluded(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / ".env.example").write_text("API_KEY=\n", encoding="utf-8")
+
+            DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+            self.assertFalse((root / "snapshot" / ".env.example").exists())
+
+    def test_tracked_environment_template_with_secret_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / ".env.example").write_text(
+                "API_KEY=real-value\n", encoding="utf-8"
+            )
+            subprocess.run(["git", "add", ".env.example"], cwd=worktree, check=True)
+
+            with self.assertRaisesRegex(VerificationError, "non-empty sensitive field"):
+                DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_tracked_environment_template_symlink_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / "template-source").write_text("API_KEY=\n", encoding="utf-8")
+            (worktree / ".env.example").symlink_to("template-source")
+            subprocess.run(["git", "add", ".env.example"], cwd=worktree, check=True)
+
+            with self.assertRaisesRegex(VerificationError, "must be a regular file"):
+                DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_tracked_environment_template_in_sensitive_directory_fails_closed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            template = worktree / "secrets" / ".env.example"
+            template.parent.mkdir()
+            template.write_text("API_KEY=\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "secrets/.env.example"], cwd=worktree, check=True
+            )
+
+            with self.assertRaisesRegex(
+                VerificationError, "tracked sensitive path cannot enter verification"
+            ):
+                DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_environment_template_must_be_bounded_utf8(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name, content, message in (
+                ("oversized", b"#" * (64 * 1024 + 1), "exceeds 65536 bytes"),
+                ("non-utf8", b"API_KEY=\xff\n", "must be UTF-8"),
+            ):
+                with self.subTest(name=name):
+                    worktree = root / name
+                    worktree.mkdir()
+                    _repository(worktree)
+                    (worktree / ".env.example").write_bytes(content)
+                    subprocess.run(
+                        ["git", "add", ".env.example"], cwd=worktree, check=True
+                    )
+
+                    with self.assertRaisesRegex(VerificationError, message):
+                        DockerVerifier._copy_workspace(
+                            worktree, root / f"{name}-snapshot"
+                        )
+
     def test_container_receives_shared_cache_and_read_only_git_mounts(self) -> None:
         verifier = self._verifier()
         completed = subprocess.CompletedProcess(


### PR DESCRIPTION
Closes #66

允许经过严格验证的已跟踪环境模板进入 verifier sandbox，同时维持真实 dotenv 和异常内容的失败关闭。

---

只接受 .env.example、.env.sample、.env.template；要求普通文件、最多 64 KiB、UTF-8、可审计赋值语法且敏感字段为空。未跟踪模板仍排除，并新增允许与拒绝路径测试。

Verified with `uv run python -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
