### PR TITLE
fix(verifier): allow explicit credential placeholders

### DIFF
--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -46,15 +46,17 @@ SUPPORTED_ENV_TEMPLATE_NAMES = frozenset(
     {".env.example", ".env.sample", ".env.template"}
 )
 MAX_ENV_TEMPLATE_BYTES = 64 * 1024
+MAX_ENV_PLACEHOLDER_CHARS = 128
 ENV_ASSIGNMENT = re.compile(
     r"(?:export\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*)"
 )
 SENSITIVE_ENV_NAME = re.compile(
-    r"(?:^|_)(?:ACCESS_KEY|API_KEY|AUTH|CREDENTIALS?|PASS(?:WORD|WD)?|"
-    r"PRIVATE_KEY|SECRET|TOKEN)(?:_|$)",
+    r"(?:^|_)(?:ACCESS_KEY(?:_ID)?|API_KEY|AUTH|CREDENTIALS?|PASS(?:WORD|WD)?|"
+    r"PRIVATE_KEY|SECRET(?:_KEY)?|TOKEN)(?:_(?:HASH|VALUE))?$",
     re.IGNORECASE,
 )
 EMPTY_ENV_VALUE = re.compile(r"(?:|''|\"\")(?:\s+#.*)?")
+SAFE_ENV_PLACEHOLDER = re.compile(r"replace-with-[a-z0-9]+(?:-[a-z0-9]+)*")
 
 
 class VerificationError(RuntimeError):
@@ -224,9 +226,17 @@ class DockerVerifier:
                     "tracked environment template contains an unsupported line "
                     f"at {relative}:{line_number}"
                 )
-            if SENSITIVE_ENV_NAME.search(
-                assignment.group("name")
-            ) and not EMPTY_ENV_VALUE.fullmatch(assignment.group("value")):
+            sensitive_value = assignment.group("value")
+            safe_placeholder = len(
+                sensitive_value
+            ) <= MAX_ENV_PLACEHOLDER_CHARS and SAFE_ENV_PLACEHOLDER.fullmatch(
+                sensitive_value
+            )
+            if (
+                SENSITIVE_ENV_NAME.search(assignment.group("name"))
+                and not EMPTY_ENV_VALUE.fullmatch(sensitive_value)
+                and not safe_placeholder
+            ):
                 raise VerificationError(
                     "tracked environment template contains a non-empty sensitive "
                     f"field at {relative}:{line_number}"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -194,6 +194,27 @@ class VerificationSandboxTests(unittest.TestCase):
                         (worktree / name).read_text(encoding="utf-8"),
                     )
 
+    def test_tracked_environment_template_accepts_explicit_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            template = worktree / ".env.example"
+            template.write_text(
+                "AUTH_TOKEN=replace-with-a-local-token\n"
+                "RATE_LIMIT_API_KEY_PER_MINUTE=600\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", ".env.example"], cwd=worktree, check=True)
+
+            DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+            self.assertEqual(
+                (root / "snapshot" / ".env.example").read_text(encoding="utf-8"),
+                template.read_text(encoding="utf-8"),
+            )
+
     def test_untracked_environment_template_is_excluded(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -219,6 +240,65 @@ class VerificationSandboxTests(unittest.TestCase):
 
             with self.assertRaisesRegex(VerificationError, "non-empty sensitive field"):
                 DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_environment_template_rejects_invalid_sensitive_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, value in enumerate(
+                (
+                    "replace-with-",
+                    "replace-with-UPPER",
+                    "replace-with-token.value",
+                    '"replace-with-a-token"',
+                    "replace-with-" + "a" * 129,
+                )
+            ):
+                with self.subTest(value=value):
+                    worktree = root / f"invalid-placeholder-{index}"
+                    worktree.mkdir()
+                    _repository(worktree)
+                    (worktree / ".env.example").write_text(
+                        f"API_KEY={value}\n", encoding="utf-8"
+                    )
+                    subprocess.run(
+                        ["git", "add", ".env.example"], cwd=worktree, check=True
+                    )
+
+                    with self.assertRaisesRegex(
+                        VerificationError, "non-empty sensitive field"
+                    ):
+                        DockerVerifier._copy_workspace(
+                            worktree, root / f"invalid-placeholder-snapshot-{index}"
+                        )
+
+    def test_terminal_sensitive_field_variants_still_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, name in enumerate(
+                (
+                    "AUTH_TOKEN",
+                    "CLIENT_SECRET",
+                    "AWS_SECRET_ACCESS_KEY",
+                    "PASSWORD_HASH",
+                )
+            ):
+                with self.subTest(name=name):
+                    worktree = root / f"sensitive-name-{index}"
+                    worktree.mkdir()
+                    _repository(worktree)
+                    (worktree / ".env.example").write_text(
+                        f"{name}=real-value\n", encoding="utf-8"
+                    )
+                    subprocess.run(
+                        ["git", "add", ".env.example"], cwd=worktree, check=True
+                    )
+
+                    with self.assertRaisesRegex(
+                        VerificationError, "non-empty sensitive field"
+                    ):
+                        DockerVerifier._copy_workspace(
+                            worktree, root / f"sensitive-name-snapshot-{index}"
+                        )
 
     def test_tracked_environment_template_symlink_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Closes #68

Allow strict credential placeholders in tracked environment templates without treating rate-limit settings as secrets.

---

Keeps the tracked-template filename, size, UTF-8, symlink, directory, and sensitive-value gates fail-closed. Accepts only unquoted lowercase replace-with-* placeholders up to 128 characters. The first isolated replay passed tests, lint, formatting, and the CLI smoke test; its final isolated uv build retried PyPI and failed DNS. This replay uses the hatchling version installed by the repository bootstrap via uv build --no-build-isolation.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
