### PR TITLE
fix(verifier): allow trusted tracked sensitive paths

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -153,6 +153,18 @@ API 验证当前身份确实拥有 push 权限，并继续禁止直接使用默�
 旧配置显式指定 `state_dir` 时保持原有工作区布局。项目层不能覆盖用户层的运行目录、GitHub 身份、Agent executable 或 Runner
 image；项目安全设置只能收紧用户限额和默认禁止路径，不能静默放宽它们。
 
+少数仓库会把普通源码放在名为 `secrets` 或 `credentials` 的目录中。验证器默认仍拒绝复制这些
+路径；可信的用户配置可以按仓库放行一个至少包含两级目录的规范化相对路径前缀：
+
+```toml
+[safety.tracked_sensitive_paths]
+"makecindy/cindy" = ["apps/desktop/src/main/secrets/"]
+```
+
+该表只从用户配置读取，仓库项目配置中的同名表会被忽略。授权只适用于前缀下的已跟踪普通文件；
+未跟踪文件、符号链接、`.env` 文件、仓库根级 `secrets`/`credentials` 前缀和包含通配符或父目录
+跳转的路径仍会失败关闭。每个授权前缀都会写入验证沙箱清单，便于 Review 时核对。
+
 ### 并发与变更规模
 
 默认情况下，每个仓库最多同时保留 4 个由当前 GitHub 账号创建的 open PR；Draft 和 Ready 都计入，

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -31,6 +31,11 @@ max_diff_lines = 2000
 require_verification = true
 draft_pull_requests = true
 
+# Only the trusted per-user configuration may allow tracked source files under
+# a sensitive directory name. Repository-local configuration cannot add entries.
+[safety.tracked_sensitive_paths]
+"makecindy/cindy" = ["apps/desktop/src/main/secrets/"]
+
 [agent]
 harness = "codex-cli"
 executable = "codex"

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 CONFIG_VERSION = 1
 PROJECT_CONFIG_NAMES = (".reposteward.toml", "reposteward.toml", "starfix.toml")
+REPOSITORY_NAME = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+SENSITIVE_PATH_NAMES = frozenset({"credentials", "secrets"})
 
 
 class ConfigError(ValueError):
@@ -89,6 +91,14 @@ class SafetyConfig:
         "credentials",
         "secrets",
     )
+    tracked_sensitive_paths: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    def tracked_sensitive_paths_for(self, repository: str) -> tuple[str, ...]:
+        normalized = repository.casefold()
+        for configured_repository, paths in self.tracked_sensitive_paths:
+            if configured_repository == normalized:
+                return paths
+        return ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -317,6 +327,11 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
     """Merge layers while keeping identity and execution trust user-owned."""
     result = _merge(user, project)
     if not user:
+        safety = result.get("safety")
+        if isinstance(safety, dict):
+            safety = dict(safety)
+            safety.pop("tracked_sensitive_paths", None)
+            result["safety"] = safety
         return result
 
     # Runtime state and disposable clones belong to the user/machine trust layer.
@@ -412,8 +427,82 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
             if isinstance(values, list):
                 forbidden.extend(str(value) for value in values)
         merged_safety["forbidden_paths"] = list(dict.fromkeys(forbidden))
+        trusted_paths = user_safety.get("tracked_sensitive_paths", {})
+        merged_safety["tracked_sensitive_paths"] = trusted_paths
         result["safety"] = merged_safety
     return result
+
+
+def _tracked_sensitive_paths(
+    value: object,
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, dict):
+        raise ConfigError("safety.tracked_sensitive_paths must be a table")
+    configured: dict[str, tuple[str, ...]] = {}
+    for raw_repository, raw_paths in value.items():
+        if not isinstance(raw_repository, str):
+            raise ConfigError(
+                "safety.tracked_sensitive_paths repository names must be strings"
+            )
+        repository = raw_repository.strip()
+        normalized_repository = repository.casefold()
+        if REPOSITORY_NAME.fullmatch(repository) is None:
+            raise ConfigError(
+                "safety.tracked_sensitive_paths repository must use owner/name form: "
+                f"{raw_repository!r}"
+            )
+        if normalized_repository in configured:
+            raise ConfigError(
+                "safety.tracked_sensitive_paths contains a duplicate repository: "
+                f"{repository}"
+            )
+        if not isinstance(raw_paths, list) or not raw_paths:
+            raise ConfigError(
+                "safety.tracked_sensitive_paths entries must be non-empty arrays"
+            )
+        paths: list[str] = []
+        for raw_path in raw_paths:
+            if not isinstance(raw_path, str):
+                raise ConfigError(
+                    "safety.tracked_sensitive_paths values must be strings"
+                )
+            candidate = raw_path.strip().rstrip("/")
+            parts = candidate.split("/")
+            if (
+                not candidate
+                or candidate.startswith("/")
+                or "\\" in candidate
+                or ":" in candidate
+                or any(not part or part in {".", ".."} for part in parts)
+                or any(any(marker in part for marker in "*?[]") for part in parts)
+            ):
+                raise ConfigError(
+                    "safety.tracked_sensitive_paths requires normalized relative "
+                    f"paths: {raw_path!r}"
+                )
+            if len(parts) < 2:
+                raise ConfigError(
+                    "safety.tracked_sensitive_paths refuses a repository-root "
+                    f"sensitive prefix: {raw_path!r}"
+                )
+            folded_parts = tuple(part.casefold() for part in parts)
+            if not any(part in SENSITIVE_PATH_NAMES for part in folded_parts):
+                raise ConfigError(
+                    "safety.tracked_sensitive_paths prefixes must contain a "
+                    f"credentials or secrets component: {raw_path!r}"
+                )
+            if any(part == ".env" or part.startswith(".env.") for part in folded_parts):
+                raise ConfigError(
+                    "safety.tracked_sensitive_paths cannot allow environment files: "
+                    f"{raw_path!r}"
+                )
+            canonical = "/".join(parts)
+            if canonical not in paths:
+                paths.append(canonical)
+        configured[normalized_repository] = tuple(paths)
+    return tuple(sorted(configured.items()))
 
 
 def load_config(
@@ -579,6 +668,9 @@ def load_config(
         draft_pull_requests=_boolean(safety_raw.get("draft_pull_requests"), True),
         forbidden_paths=tuple(
             dict.fromkeys(safety_defaults.forbidden_paths + configured_forbidden)
+        ),
+        tracked_sensitive_paths=_tracked_sensitive_paths(
+            safety_raw.get("tracked_sensitive_paths")
         ),
     )
 

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -86,6 +86,11 @@ max_diff_lines = 2000
 require_verification = true
 draft_pull_requests = true
 
+# Only configure this table in the trusted per-user file. Entries must name a
+# repository and a nested sensitive directory; project config cannot add them.
+# [safety.tracked_sensitive_paths]
+# "owner/repository" = ["src/secrets/"]
+
 [agent]
 harness = "codex-cli"
 executable = "codex"

--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -122,7 +122,9 @@ class DockerVerifier:
 
         verification_dir = run_dir / "verification" if run_dir is not None else None
         results: list[CommandResult] = []
-        with self._verification_sandbox(worktree, verification_dir) as sandbox:
+        with self._verification_sandbox(
+            worktree, verification_dir, policy=policy
+        ) as sandbox:
             sandbox_worktree, environment_dir, git_dir = sandbox
             if policy.bootstrap_commands:
                 bootstrap = " && ".join(policy.bootstrap_commands)
@@ -185,13 +187,46 @@ class DockerVerifier:
         return tuple(Path(os.fsdecode(raw)) for raw in listing.split(b"\0") if raw)
 
     @staticmethod
-    def _sensitive_path(relative: Path) -> bool:
+    def _environment_path(relative: Path) -> bool:
         return any(
-            part.casefold() in SENSITIVE_SANDBOX_NAMES
-            or part.casefold() == ".env"
-            or part.casefold().startswith(".env.")
+            part.casefold() == ".env" or part.casefold().startswith(".env.")
             for part in relative.parts
         )
+
+    @classmethod
+    def _sensitive_path(cls, relative: Path) -> bool:
+        return any(
+            part.casefold() in SENSITIVE_SANDBOX_NAMES for part in relative.parts
+        ) or cls._environment_path(relative)
+
+    @staticmethod
+    def _is_allowlisted_tracked_sensitive_path(
+        relative: Path, trusted_sensitive_paths: tuple[str, ...]
+    ) -> bool:
+        relative_parts = tuple(part.casefold() for part in relative.parts)
+        return any(
+            relative_parts[: len(prefix_parts)] == prefix_parts
+            for configured in trusted_sensitive_paths
+            if (
+                prefix_parts := tuple(
+                    part.casefold() for part in configured.split("/") if part
+                )
+            )
+        )
+
+    @staticmethod
+    def _validate_allowlisted_sensitive_source(source: Path, relative: Path) -> None:
+        current = source
+        for _part in relative.parts:
+            if current.is_symlink():
+                raise VerificationError(
+                    f"allowlisted tracked sensitive path must be a regular file: {relative}"
+                )
+            current = current.parent
+        if not source.is_file():
+            raise VerificationError(
+                f"allowlisted tracked sensitive path must be a regular file: {relative}"
+            )
 
     @classmethod
     def _is_supported_env_template(cls, relative: Path) -> bool:
@@ -243,7 +278,13 @@ class DockerVerifier:
                 )
 
     @classmethod
-    def _copy_workspace(cls, worktree: Path, target: Path) -> int:
+    def _copy_workspace(
+        cls,
+        worktree: Path,
+        target: Path,
+        *,
+        trusted_sensitive_paths: tuple[str, ...] = (),
+    ) -> int:
         """Copy tracked and non-ignored untracked files without scanning caches."""
         tracked = cls._git_file_list(worktree, "--cached")
         untracked = cls._git_file_list(worktree, "--others", "--exclude-standard")
@@ -259,6 +300,16 @@ class DockerVerifier:
             if cls._sensitive_path(relative):
                 if is_tracked and cls._is_supported_env_template(relative):
                     cls._validate_env_template(worktree / relative, relative)
+                elif (
+                    is_tracked
+                    and not cls._environment_path(relative)
+                    and cls._is_allowlisted_tracked_sensitive_path(
+                        relative, trusted_sensitive_paths
+                    )
+                ):
+                    cls._validate_allowlisted_sensitive_source(
+                        worktree / relative, relative
+                    )
                 elif is_tracked:
                     raise VerificationError(
                         f"tracked sensitive path cannot enter verification: {relative}"
@@ -326,7 +377,11 @@ class DockerVerifier:
 
     @contextmanager
     def _verification_sandbox(
-        self, worktree: Path, verification_dir: Path | None
+        self,
+        worktree: Path,
+        verification_dir: Path | None,
+        *,
+        policy: RepositoryPolicy,
     ) -> Iterator[tuple[Path, Path, Path]]:
         temporary = None
         if verification_dir is None:
@@ -342,7 +397,14 @@ class DockerVerifier:
         common_git_dir: Path | None = None
         try:
             common_git_dir, container_git_dir = self._git_paths(worktree)
-            copied_files = self._copy_workspace(worktree, sandbox_worktree)
+            trusted_sensitive_paths = self.config.safety.tracked_sensitive_paths_for(
+                policy.name
+            )
+            copied_files = self._copy_workspace(
+                worktree,
+                sandbox_worktree,
+                trusted_sensitive_paths=trusted_sensitive_paths,
+            )
             environment_dir.mkdir(parents=True)
             (sandbox_worktree / ".git").write_text(
                 f"gitdir: {container_git_dir}\n", encoding="utf-8"
@@ -355,6 +417,9 @@ class DockerVerifier:
                             "sandbox": "ephemeral_copy",
                             "excluded_untracked_names": sorted(
                                 UNTRACKED_SANDBOX_EXCLUDED_NAMES
+                            ),
+                            "trusted_tracked_sensitive_paths": list(
+                                trusted_sensitive_paths
                             ),
                             "host_workspace_writable": False,
                             "shared_dependency_environment": True,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,6 +209,111 @@ event_payload_retention_days = 45
             config.repositories["owner/repo"].event_payload_retention_days, 45
         )
 
+    def test_tracked_sensitive_paths_are_user_owned_and_repository_scoped(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[safety.tracked_sensitive_paths]
+"Owner/Repo" = ["src/secrets/", "packages/credentials/generated"]
+"other/repo" = ["lib/secrets"]
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[safety.tracked_sensitive_paths]
+"owner/repo" = ["src/secrets/wider"]
+"mallory/repo" = ["src/secrets"]
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project, user_path=user)
+
+        self.assertEqual(
+            config.safety.tracked_sensitive_paths,
+            (
+                (
+                    "other/repo",
+                    ("lib/secrets",),
+                ),
+                (
+                    "owner/repo",
+                    ("src/secrets", "packages/credentials/generated"),
+                ),
+            ),
+        )
+        self.assertEqual(
+            config.safety.tracked_sensitive_paths_for("OWNER/REPO"),
+            ("src/secrets", "packages/credentials/generated"),
+        )
+        self.assertEqual(config.safety.tracked_sensitive_paths_for("mallory/repo"), ())
+
+    def test_project_only_config_cannot_allow_tracked_sensitive_paths(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[safety.tracked_sensitive_paths]
+"owner/repo" = ["src/secrets"]
+""",
+                encoding="utf-8",
+            )
+
+            config = load_config(project, user_path=user)
+
+        self.assertEqual(config.safety.tracked_sensitive_paths, ())
+
+    def test_tracked_sensitive_paths_reject_unsafe_values(self) -> None:
+        invalid_tables = (
+            ('"owner" = ["src/secrets"]', "owner/name form"),
+            ('"owner/repo" = "src/secrets"', "non-empty arrays"),
+            ('"owner/repo" = []', "non-empty arrays"),
+            ('"owner/repo" = [""]', "normalized relative paths"),
+            ('"owner/repo" = ["/src/secrets"]', "normalized relative paths"),
+            ('"owner/repo" = ["src/./secrets"]', "normalized relative paths"),
+            ('"owner/repo" = ["src/../secrets"]', "normalized relative paths"),
+            ('"owner/repo" = ["src\\\\secrets"]', "normalized relative paths"),
+            ('"owner/repo" = ["secrets"]', "repository-root sensitive prefix"),
+            ('"owner/repo" = ["src/cache"]', "credentials or secrets component"),
+            ('"owner/repo" = ["src/secrets/*"]', "normalized relative paths"),
+            ('"owner/repo" = ["src/secrets/.env"]', "environment files"),
+        )
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project.toml"
+            project.write_text("config_version = 1\n", encoding="utf-8")
+            for index, (table, message) in enumerate(invalid_tables):
+                with self.subTest(table=table):
+                    user = root / f"user-{index}.toml"
+                    user.write_text(
+                        "config_version = 1\n"
+                        "[github]\n"
+                        'login = "alice"\n'
+                        "[safety.tracked_sensitive_paths]\n"
+                        f"{table}\n",
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaisesRegex(ConfigError, message):
+                        load_config(project, user_path=user)
+
     def test_event_payload_retention_must_be_explicit_and_positive(self) -> None:
         with TemporaryDirectory() as directory:
             path = Path(directory) / "config.toml"

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -8,7 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from reposteward.config import RepositoryPolicy, RunnerConfig
+from reposteward.config import RepositoryPolicy, RunnerConfig, SafetyConfig
 from reposteward.models import AgentResult, CommandResult
 from reposteward.verifier import DockerVerifier, VerificationError
 
@@ -25,11 +26,11 @@ def _repository(root: Path) -> None:
 
 
 class VerificationSandboxTests(unittest.TestCase):
-    def _verifier(self) -> DockerVerifier:
+    def _verifier(self, safety: SafetyConfig | None = None) -> DockerVerifier:
         verifier = DockerVerifier(
             SimpleNamespace(
                 runner=RunnerConfig(),
-                safety=SimpleNamespace(require_verification=True),
+                safety=safety or SafetyConfig(),
             )
         )
         verifier.image_available = lambda: True  # type: ignore[method-assign]
@@ -97,6 +98,7 @@ class VerificationSandboxTests(unittest.TestCase):
         self.assertEqual(host_marker, "host")
         self.assertTrue(manifest["cleaned"])
         self.assertFalse(manifest["host_workspace_writable"])
+        self.assertEqual(manifest["trusted_tracked_sensitive_paths"], [])
 
     def test_failed_bootstrap_still_removes_the_sandbox(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -170,6 +172,167 @@ class VerificationSandboxTests(unittest.TestCase):
                 VerificationError, "tracked sensitive path cannot enter verification"
             ):
                 DockerVerifier._copy_workspace(worktree, root / "snapshot")
+
+    def test_allowlisted_tracked_sensitive_source_is_copied(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            source = worktree / "apps" / "desktop" / "src" / "secrets" / "api.ts"
+            source.parent.mkdir(parents=True)
+            source.write_text("export const safe = true;\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "apps/desktop/src/secrets/api.ts"],
+                cwd=worktree,
+                check=True,
+            )
+
+            DockerVerifier._copy_workspace(
+                worktree,
+                root / "snapshot",
+                trusted_sensitive_paths=("apps/desktop/src/secrets",),
+            )
+
+            self.assertEqual(
+                (root / "snapshot" / "apps/desktop/src/secrets/api.ts").read_text(
+                    encoding="utf-8"
+                ),
+                source.read_text(encoding="utf-8"),
+            )
+
+    def test_sensitive_path_allowlist_uses_component_boundaries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            source = worktree / "src" / "secrets" / "allowed-extra" / "api.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("SAFE = True\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "src/secrets/allowed-extra/api.py"],
+                cwd=worktree,
+                check=True,
+            )
+
+            with self.assertRaisesRegex(
+                VerificationError, "tracked sensitive path cannot enter verification"
+            ):
+                DockerVerifier._copy_workspace(
+                    worktree,
+                    root / "snapshot",
+                    trusted_sensitive_paths=("src/secrets/allowed",),
+                )
+
+    def test_allowlisted_sensitive_path_excludes_untracked_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            source = worktree / "src" / "secrets" / "local.txt"
+            source.parent.mkdir(parents=True)
+            source.write_text("local only\n", encoding="utf-8")
+
+            DockerVerifier._copy_workspace(
+                worktree,
+                root / "snapshot",
+                trusted_sensitive_paths=("src/secrets",),
+            )
+
+            self.assertFalse((root / "snapshot" / "src/secrets/local.txt").exists())
+
+    def test_allowlisted_sensitive_path_symlink_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            (worktree / "source.ts").write_text("safe\n", encoding="utf-8")
+            link = worktree / "src" / "secrets" / "source.ts"
+            link.parent.mkdir(parents=True)
+            link.symlink_to("../../../source.ts")
+            subprocess.run(
+                ["git", "add", "src/secrets/source.ts"], cwd=worktree, check=True
+            )
+
+            with self.assertRaisesRegex(VerificationError, "must be a regular file"):
+                DockerVerifier._copy_workspace(
+                    worktree,
+                    root / "snapshot",
+                    trusted_sensitive_paths=("src/secrets",),
+                )
+
+    def test_allowlisted_sensitive_path_symlinked_parent_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            source = worktree / "src" / "secrets" / "source.ts"
+            source.parent.mkdir(parents=True)
+            source.write_text("safe\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "src/secrets/source.ts"], cwd=worktree, check=True
+            )
+            shutil.rmtree(source.parent)
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "source.ts").write_text("outside\n", encoding="utf-8")
+            source.parent.symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(VerificationError, "must be a regular file"):
+                DockerVerifier._copy_workspace(
+                    worktree,
+                    root / "snapshot",
+                    trusted_sensitive_paths=("src/secrets",),
+                )
+
+    def test_sensitive_path_allowlist_is_scoped_to_policy_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            _repository(worktree)
+            source = worktree / "src" / "secrets" / "source.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("SAFE = True\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "src/secrets/source.py"], cwd=worktree, check=True
+            )
+            verifier = self._verifier(
+                SafetyConfig(
+                    tracked_sensitive_paths=(("owner/allowed", ("src/secrets",)),)
+                )
+            )
+            verifier._run_container = lambda *_args, **_kwargs: CommandResult(
+                "uv run test", 0, "", 0.01
+            )  # type: ignore[method-assign]
+            result = AgentResult(
+                "summary", "fix(repo): test", "notes", ("uv run test",)
+            )
+
+            with self.assertRaisesRegex(
+                VerificationError, "tracked sensitive path cannot enter verification"
+            ):
+                verifier.verify(
+                    worktree,
+                    RepositoryPolicy(
+                        name="owner/other", verification_prefixes=("uv run ",)
+                    ),
+                    result,
+                )
+
+            verification = verifier.verify(
+                worktree,
+                RepositoryPolicy(
+                    name="owner/allowed", verification_prefixes=("uv run ",)
+                ),
+                result,
+            )
+
+        self.assertTrue(verification.passed)
 
     def test_tracked_empty_environment_templates_are_copied(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -331,7 +494,11 @@ class VerificationSandboxTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 VerificationError, "tracked sensitive path cannot enter verification"
             ):
-                DockerVerifier._copy_workspace(worktree, root / "snapshot")
+                DockerVerifier._copy_workspace(
+                    worktree,
+                    root / "snapshot",
+                    trusted_sensitive_paths=("src/secrets",),
+                )
 
     def test_environment_template_must_be_bounded_utf8(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Closes #73

Allow trusted per-user repository-scoped paths for tracked source directories named secrets or credentials while preserving fail-closed defaults.

---

Adds strict path validation, project-layer isolation, regular-file and symlink checks, sandbox manifest evidence, documentation, and regression tests. Closes #73.

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
