### PR TITLE
fix(runner): add ModelPort toolchains

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -1,10 +1,25 @@
-FROM ghcr.io/astral-sh/uv:0.11.32 AS uv
-FROM node:22.23.2-bookworm-slim AS node
-FROM python:3.12-bookworm
+FROM ghcr.io/astral-sh/uv:0.11.32@sha256:df4cae8f3a96d175e2e5f992e597550000edbe78fdc2594d5cd8de1a217f504c AS uv
+FROM node:24.16.0-bookworm-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 AS node
+FROM rust:1.96.0-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS rust
+
+RUN set -eux; \
+    installed=; \
+    for attempt in 1 2 3; do \
+        if RUSTUP_MAX_RETRIES=5 timeout 900 rustup component add clippy rustfmt; then \
+            installed=1; \
+            break; \
+        fi; \
+        sleep 5; \
+    done; \
+    test "$installed" = "1"
+
+FROM python:3.12-bookworm@sha256:80f5d259a5969c86f6c92145d572de4a68c68e0edd28d4367dec0fb411b42af3
 
 COPY --from=uv /uv /uvx /bin/
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=rust /usr/local/cargo /usr/local/cargo
+COPY --from=rust /usr/local/rustup /usr/local/rustup
 
 ARG TEMURIN_8_URL=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jdk_x64_linux_hotspot_8u502b07.tar.gz
 ARG TEMURIN_8_SHA256=b8f5440f64f50193c01f67dacba55c9660caffe13b908baf6bd1955f4dd4c3ea
@@ -14,36 +29,71 @@ ARG PROTOC_VERSION=3.6.1
 ARG PROTOC_SHA256=6003de742ea3fcf703cfec1cd4a3380fd143081a2eb0e559065563496af27807
 ARG HELM_VERSION=3.21.0
 ARG HELM_SHA256=0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36
+ARG DOWNLOAD_CURL_FLAGS="--fail --location --silent --show-error --retry 5 --retry-all-errors --retry-max-time 1800 --connect-timeout 30 --max-time 900"
 
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' \
+        /etc/apt/sources.list.d/debian.sources \
+    && apt-get -o Acquire::Retries=5 -o Acquire::https::Timeout=60 update \
     && apt-get install -y --no-install-recommends \
         aspell aspell-en build-essential ca-certificates curl git git-lfs unzip \
         libasound2 libatk-bridge2.0-0 libatk1.0-0 libcups2 libdbus-1-3 \
         libgbm1 libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxdamage1 \
-        libxfixes3 libxkbcommon0 libxrandr2 \
-    && curl --fail --location --silent --show-error "$TEMURIN_8_URL" --output /tmp/temurin.tar.gz \
-    && echo "$TEMURIN_8_SHA256  /tmp/temurin.tar.gz" | sha256sum --check - \
-    && curl --fail --location --silent --show-error \
+        libxfixes3 libxkbcommon0 libxrandr2 shellcheck=0.9.0-1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,id=reposteward-runner-downloads,target=/downloads,sharing=locked \
+    set -eux; \
+    download() { \
+        source_url="$1"; \
+        output_path="$2"; \
+        if [ ! -f "$output_path" ]; then \
+            curl $DOWNLOAD_CURL_FLAGS --continue-at - "$source_url" \
+                --output "$output_path.part"; \
+            mv "$output_path.part" "$output_path"; \
+        fi; \
+    }; \
+    verify_sha256() { \
+        expected_sum="$1"; \
+        output_path="$2"; \
+        if ! printf '%s  %s\n' "$expected_sum" "$output_path" | sha256sum --check -; then \
+            rm -f "$output_path"; \
+            return 1; \
+        fi; \
+    }; \
+    verify_sha512() { \
+        expected_sum="$1"; \
+        output_path="$2"; \
+        if ! printf '%s  %s\n' "$expected_sum" "$output_path" | sha512sum --check -; then \
+            rm -f "$output_path"; \
+            return 1; \
+        fi; \
+    }; \
+    download "$TEMURIN_8_URL" /downloads/temurin.tar.gz; \
+    verify_sha256 "$TEMURIN_8_SHA256" /downloads/temurin.tar.gz; \
+    download \
         "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" \
-        --output /tmp/maven.tar.gz \
-    && echo "$MAVEN_SHA512  /tmp/maven.tar.gz" | sha512sum --check - \
-    && curl --fail --location --silent --show-error \
+        /downloads/maven.tar.gz; \
+    verify_sha512 "$MAVEN_SHA512" /downloads/maven.tar.gz; \
+    download \
         "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip" \
-        --output /tmp/protoc.zip \
-    && echo "$PROTOC_SHA256  /tmp/protoc.zip" | sha256sum --check - \
-    && curl --fail --location --silent --show-error \
+        /downloads/protoc.zip; \
+    verify_sha256 "$PROTOC_SHA256" /downloads/protoc.zip; \
+    download \
         "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz" \
-        --output /tmp/helm.tar.gz \
-    && echo "$HELM_SHA256  /tmp/helm.tar.gz" | sha256sum --check - \
-    && mkdir -p /opt/java/temurin-8u502-b07 /opt/maven/apache-maven-$MAVEN_VERSION \
+        /downloads/helm.tar.gz; \
+    verify_sha256 "$HELM_SHA256" /downloads/helm.tar.gz; \
+    mkdir -p /opt/java/temurin-8u502-b07 /opt/maven/apache-maven-$MAVEN_VERSION \
         /opt/protobuf/protoc-$PROTOC_VERSION \
-    && tar -xzf /tmp/temurin.tar.gz --strip-components=1 -C /opt/java/temurin-8u502-b07 \
-    && tar -xzf /tmp/maven.tar.gz --strip-components=1 -C /opt/maven/apache-maven-$MAVEN_VERSION \
-    && unzip -q /tmp/protoc.zip -d /opt/protobuf/protoc-$PROTOC_VERSION \
-    && tar -xzf /tmp/helm.tar.gz -C /tmp \
+    && tar -xzf /downloads/temurin.tar.gz --strip-components=1 -C /opt/java/temurin-8u502-b07 \
+    && tar -xzf /downloads/maven.tar.gz --strip-components=1 -C /opt/maven/apache-maven-$MAVEN_VERSION \
+    && unzip -q /downloads/protoc.zip -d /opt/protobuf/protoc-$PROTOC_VERSION \
+    && tar -xzf /downloads/helm.tar.gz -C /tmp \
     && install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm \
     && chmod -R a+rX /opt/protobuf/protoc-$PROTOC_VERSION \
-    && ln -s /opt/java/temurin-8u502-b07 /opt/java/current \
+    && chmod -R a+rX,a-w /usr/local/cargo /usr/local/rustup \
+    && rm -rf /tmp/linux-amd64
+
+RUN ln -s /opt/java/temurin-8u502-b07 /opt/java/current \
     && ln -s /opt/maven/apache-maven-$MAVEN_VERSION /opt/maven/current \
     && ln -s /opt/protobuf/protoc-$PROTOC_VERSION /opt/protobuf/current \
     && ln -s /opt/java/current/bin/java /usr/local/bin/java \
@@ -56,9 +106,10 @@ RUN apt-get update \
     && ln -s /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack \
     && npm install --global --no-audit --no-fund pnpm@10.33.2 \
     && git lfs install --system \
-    && rm -f /tmp/temurin.tar.gz /tmp/maven.tar.gz /tmp/protoc.zip /tmp/helm.tar.gz \
-    && rm -rf /tmp/linux-amd64 \
-    && rm -rf /var/lib/apt/lists/*
+    && printf '%s\n' \
+        'export PATH="/usr/local/cargo/bin:/opt/protobuf/current/bin:/opt/maven/current/bin:/opt/java/current/bin:$PATH"' \
+        > /etc/profile.d/reposteward-toolchains.sh \
+    && chmod 0444 /etc/profile.d/reposteward-toolchains.sh
 
 RUN groupadd --gid 1000 reposteward \
     && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash reposteward
@@ -66,9 +117,29 @@ RUN groupadd --gid 1000 reposteward \
 ENV JAVA_HOME=/opt/java/current \
     MAVEN_HOME=/opt/maven/current \
     PROTOBUF_HOME=/opt/protobuf/current \
-    PATH=/opt/protobuf/current/bin:/opt/maven/current/bin:/opt/java/current/bin:$PATH \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:/opt/protobuf/current/bin:/opt/maven/current/bin:/opt/java/current/bin:$PATH \
     UV_LINK_MODE=copy \
     UV_NO_PROGRESS=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
+
+USER reposteward:reposteward
+
+RUN bash -lc "set -eux; \
+    test \"\$(id -u)\" = \"1000\"; \
+    test \"\$(id -g)\" = \"1000\"; \
+    python --version | grep -Fx 'Python 3.12.14'; \
+    node --version | grep -Fx 'v24.16.0'; \
+    npm --version; \
+    pnpm --version | grep -Fx '10.33.2'; \
+    rustc --version | grep -E '^rustc 1\.96\.0 '; \
+    cargo --version | grep -E '^cargo 1\.96\.0 '; \
+    cargo clippy --version; \
+    cargo fmt --version; \
+    shellcheck --version | grep -Fx 'version: 0.9.0'; \
+    java -version 2>&1 | grep -F 'openjdk version \"1.8.0_502\"'; \
+    mvn --version | grep -F 'Apache Maven 3.9.16'; \
+    protoc --version | grep -Fx 'libprotoc 3.6.1'; \
+    helm version --short | grep -E '^v3\.21\.0([+].*)?$'"
 
 WORKDIR /workspace

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -257,6 +257,11 @@ uv run reposteward image build
 uv run reposteward doctor
 ```
 
+Runner 镜像从固定摘要的官方基础镜像构建，并自检 Python 3.12.14、Node.js 24.16.0、
+Rust 1.96.0（含 rustfmt 与 Clippy）、ShellCheck 0.9.0、Java 8、Maven、Protobuf、Helm
+和 pnpm。最终镜像默认以 UID/GID 1000 的 `reposteward` 用户运行；目标仓库的 bootstrap
+只安装锁定依赖，不挂载或复用宿主机工具链。
+
 发现和查看候选：
 
 ```bash

--- a/tests/test_runner_image.py
+++ b/tests/test_runner_image.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+RUNNER_DOCKERFILE = Path(__file__).resolve().parents[1] / "docker" / "Dockerfile.runner"
+
+
+class RunnerImageContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dockerfile = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+
+    def test_modelport_toolchains_are_pinned(self) -> None:
+        self.assertIn(
+            "FROM ghcr.io/astral-sh/uv:0.11.32@sha256:"
+            "df4cae8f3a96d175e2e5f992e597550000edbe78fdc2594d5cd8de1a217f504c AS uv",
+            self.dockerfile,
+        )
+        self.assertIn(
+            "FROM node:24.16.0-bookworm-slim@sha256:"
+            "2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203 AS node",
+            self.dockerfile,
+        )
+        self.assertIn(
+            "FROM rust:1.96.0-bookworm@sha256:"
+            "5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS rust",
+            self.dockerfile,
+        )
+        self.assertIn(
+            "FROM python:3.12-bookworm@sha256:"
+            "80f5d259a5969c86f6c92145d572de4a68c68e0edd28d4367dec0fb411b42af3",
+            self.dockerfile,
+        )
+        self.assertIn("rustup component add clippy rustfmt", self.dockerfile)
+        self.assertIn("RUSTUP_MAX_RETRIES=5 timeout 900", self.dockerfile)
+        self.assertIn("for attempt in 1 2 3", self.dockerfile)
+        self.assertIn("shellcheck=0.9.0-1", self.dockerfile)
+        self.assertIn(
+            "sed -i 's|http://deb.debian.org|https://deb.debian.org|g'",
+            self.dockerfile,
+        )
+        self.assertIn(
+            "apt-get -o Acquire::Retries=5 -o Acquire::https::Timeout=60 update",
+            self.dockerfile,
+        )
+        self.assertIn(
+            'ARG DOWNLOAD_CURL_FLAGS="--fail --location --silent --show-error '
+            "--retry 5 --retry-all-errors --retry-max-time 1800 "
+            '--connect-timeout 30 --max-time 900"',
+            self.dockerfile,
+        )
+        self.assertIn(
+            "RUN --mount=type=cache,id=reposteward-runner-downloads,"
+            "target=/downloads,sharing=locked",
+            self.dockerfile,
+        )
+        self.assertIn("curl $DOWNLOAD_CURL_FLAGS --continue-at -", self.dockerfile)
+        for artifact in (
+            "temurin.tar.gz",
+            "maven.tar.gz",
+            "protoc.zip",
+            "helm.tar.gz",
+        ):
+            with self.subTest(artifact=artifact):
+                self.assertIn(f"/downloads/{artifact}", self.dockerfile)
+        self.assertIn('mv "$output_path.part" "$output_path"', self.dockerfile)
+
+    def test_rust_toolchain_is_available_but_not_writable(self) -> None:
+        self.assertIn(
+            "COPY --from=rust /usr/local/cargo /usr/local/cargo", self.dockerfile
+        )
+        self.assertIn(
+            "COPY --from=rust /usr/local/rustup /usr/local/rustup", self.dockerfile
+        )
+        self.assertIn(
+            "chmod -R a+rX,a-w /usr/local/cargo /usr/local/rustup",
+            self.dockerfile,
+        )
+        self.assertIn("RUSTUP_HOME=/usr/local/rustup", self.dockerfile)
+        self.assertIn("PATH=/usr/local/cargo/bin:", self.dockerfile)
+        self.assertIn("> /etc/profile.d/reposteward-toolchains.sh", self.dockerfile)
+        self.assertIn(
+            'export PATH="/usr/local/cargo/bin:/opt/protobuf/current/bin:',
+            self.dockerfile,
+        )
+        self.assertNotIn("CARGO_HOME=/usr/local/cargo", self.dockerfile)
+
+    def test_build_checks_tools_and_preserves_non_root_default(self) -> None:
+        for command in (
+            "python --version | grep -Fx 'Python 3.12.14'",
+            "node --version | grep -Fx 'v24.16.0'",
+            "pnpm --version | grep -Fx '10.33.2'",
+            "rustc --version | grep -E '^rustc 1\\.96\\.0 '",
+            "cargo --version | grep -E '^cargo 1\\.96\\.0 '",
+            "cargo clippy --version",
+            "cargo fmt --version",
+            "shellcheck --version | grep -Fx 'version: 0.9.0'",
+            "java -version 2>&1 | grep -F 'openjdk version",
+            "mvn --version | grep -F 'Apache Maven 3.9.16'",
+            "protoc --version | grep -Fx 'libprotoc 3.6.1'",
+            "helm version --short | grep -E '^v3\\.21\\.0([+].*)?$'",
+        ):
+            with self.subTest(command=command):
+                self.assertIn(command, self.dockerfile)
+        self.assertIn(r"test \"\$(id -u)\" = \"1000\"", self.dockerfile)
+        self.assertIn(r"test \"\$(id -g)\" = \"1000\"", self.dockerfile)
+        self.assertIn('RUN bash -lc "set -eux;', self.dockerfile)
+        self.assertIn("USER reposteward:reposteward", self.dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #71

为硬化 Runner 增加固定官方 Rust 1.96、Node 24 与 ShellCheck 工具链，并保持非 root 与凭据隔离边界。

---

固定官方基础镜像摘要；安装 rustfmt、Clippy 与 ShellCheck；为公开归档增加校验、重试、断点续传缓存；修复 verifier 的登录 shell PATH；新增 Dockerfile 契约测试并完成真实镜像构建和非 root 运行验证。

Verified with `uv run python -m unittest discover -s tests -v`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run reposteward --help`, `uv build --no-build-isolation`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
