### PR TITLE
feat(policy): allow trusted unlimited diff lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ opens pull requests only after repository-specific gates and local human review.
 - Every code change must start from a reviewed open Issue, use a separate branch or
   worktree, and be merged through a focused PR. Never commit or push code directly to
   `main`. Handle security emergencies through the private process in `SECURITY.md`.
+- Scope each Issue and PR around one concrete, independently verifiable capability.
+  RepoSteward does not use changed-line count to force one capability into artificial
+  slices; change size remains review evidence, not the scope boundary. Keep unrelated
+  capabilities separate and preserve every non-line safety gate.
 - Never expose GitHub credentials to a coding harness, tests, repository hooks,
   Git push, or Docker containers. An API credential may be passed only to the
   GitHub REST client; Git clone/push uses the host's SSH key.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ uv run reposteward image build
   分支或 worktree 上的 PR 合并。安全事件按 `SECURITY.md` 私下处理，不先创建公开 Issue。
 - 从最新 `main` 创建短生命周期分支，例如 `feat/context-redaction`、
   `fix/import-idempotency` 或 `perf/checkpoint-query`。
-- 每个 PR 只解决一个 Issue，避免捆绑无关重构、格式化或依赖升级。
+- 每个 Issue 和 PR 以一个具体、可独立验收的能力为边界，不按 diff 行数把同一能力拆成不可用的
+  中间切片。一个能力需要同时修改实现、测试、文档或多层接口时应完整交付；改动规模仍是 Review
+  证据，不能作为捆绑无关重构、格式化、依赖升级或其他能力的理由。
 - 提交标题使用 Conventional Commits，例如 `feat(context): import portable bundles`。
 - 提交不得包含 token、私钥、账号缓存、数据库、`.env`、运行日志或本机绝对路径。
 - 使用 Coding Harness 时，仍需由提交者检查完整 diff、测试结果和公开说明。

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -192,6 +192,19 @@ max_diff_lines = 3000
 上限。所有容量值都必须是正整数。容量门禁用于控制并行负担，不替代“一个 PR 只解决一个清晰问题”
 的范围审查。
 
+当某个仓库明确以“一个完整可验收能力”作为 Issue/PR 边界，可信用户可以只对该仓库关闭 diff
+行数门。这个例外必须写在用户配置的仓库表中；项目配置中的同名值会被忽略：
+
+```toml
+[repositories."owner/capability-scoped-repository"]
+unlimited_diff_lines = true
+```
+
+该值不使用 `0`、负数或哨兵整数，运行时把有效行数上限表示为 `None`，同时继续记录精确的新增和
+删除行数。项目配置仍可设置一个正整数 `max_diff_lines` 来收紧该例外。文件数、活动 PR 数、禁止
+路径、敏感文件、验证、Review、发布和合并门禁完全不变；关闭行数门也不意味着应把多个无关能力
+放进同一个 PR。
+
 ## 准备 Issue 草稿
 
 RepoSteward 可以在本地生成结构化 Markdown，并只读搜索相似 Issue：

--- a/reposteward.example.toml
+++ b/reposteward.example.toml
@@ -69,6 +69,10 @@ follow_up_max_tokens = 24000
 
 [repositories."owner/repository"]
 enabled = true
+# Trusted user configuration may explicitly set this for a repository whose
+# reviewed PR boundary is one complete capability. Project configuration cannot
+# enable it, and every non-line safety gate remains enforced.
+# unlimited_diff_lines = true
 auto_prepare = false
 auto_merge = false
 auto_merge_method = "squash"

--- a/src/reposteward/capacity.py
+++ b/src/reposteward/capacity.py
@@ -16,6 +16,23 @@ def effective_capacity_limit(global_limit: int, repository_limit: int | None) ->
     )
 
 
+def effective_diff_line_limit(
+    global_limit: int,
+    repository_limit: int | None,
+    *,
+    user_allows_unlimited: bool,
+) -> int | None:
+    """Resolve a changed-line limit without weakening any other capacity gate.
+
+    Unlimited mode is a user-owned repository exception. A finite repository
+    value still tightens that exception, while repositories without the trusted
+    opt-out keep the existing global-minimum behavior.
+    """
+    if user_allows_unlimited:
+        return repository_limit
+    return effective_capacity_limit(global_limit, repository_limit)
+
+
 def pull_request_capacity(
     pulls: tuple[PullRequest, ...], *, login: str, limit: int
 ) -> dict[str, Any]:

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -184,6 +184,7 @@ class RepositoryPolicy:
     max_active_pull_requests: int | None = None
     max_files_changed: int | None = None
     max_diff_lines: int | None = None
+    unlimited_diff_lines: bool = False
     merge_risk_paths: tuple[str, ...] = ()
     event_payload_retention_days: int | None = None
     owner_attestation: bool = False
@@ -333,6 +334,11 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
             safety = dict(safety)
             safety.pop("tracked_sensitive_paths", None)
             result["safety"] = safety
+        repositories = result.get("repositories")
+        if isinstance(repositories, dict):
+            for repository in repositories.values():
+                if isinstance(repository, dict):
+                    repository.pop("unlimited_diff_lines", None)
         return result
 
     # Runtime state and disposable clones belong to the user/machine trust layer.
@@ -431,6 +437,29 @@ def _merge_layers(user: dict[str, Any], project: dict[str, Any]) -> dict[str, An
         trusted_paths = user_safety.get("tracked_sensitive_paths", {})
         merged_safety["tracked_sensitive_paths"] = trusted_paths
         result["safety"] = merged_safety
+
+    # Disabling the changed-line cap is a per-user trust decision. Project
+    # configuration may retain a finite max_diff_lines value, which tightens
+    # this exception, but it cannot enable the exception itself.
+    user_repositories = user.get("repositories", {})
+    merged_repositories = result.get("repositories", {})
+    if isinstance(user_repositories, dict) and isinstance(merged_repositories, dict):
+        trusted_by_name = {
+            str(name).casefold(): value for name, value in user_repositories.items()
+        }
+        for name, repository in merged_repositories.items():
+            if not isinstance(repository, dict):
+                continue
+            trusted = trusted_by_name.get(str(name).casefold(), {})
+            trusted_unlimited = (
+                _boolean(trusted.get("unlimited_diff_lines"), False)
+                if isinstance(trusted, dict)
+                else False
+            )
+            if trusted_unlimited:
+                repository["unlimited_diff_lines"] = True
+            else:
+                repository.pop("unlimited_diff_lines", None)
     return result
 
 
@@ -850,6 +879,9 @@ def load_config(
                 int(repo_value["max_diff_lines"])
                 if "max_diff_lines" in repo_value
                 else None
+            ),
+            unlimited_diff_lines=_boolean(
+                repo_value.get("unlimited_diff_lines"), False
             ),
             merge_risk_paths=_tuple(repo_value.get("merge_risk_paths")),
             event_payload_retention_days=(

--- a/src/reposteward/context.py
+++ b/src/reposteward/context.py
@@ -58,6 +58,8 @@ def repository_policy_digest(policy: RepositoryPolicy) -> str:
         value.pop("branch_cleanup")
     if policy.max_active_pull_requests is None:
         value.pop("max_active_pull_requests")
+    if not policy.unlimited_diff_lines:
+        value.pop("unlimited_diff_lines")
     return _digest(value)
 
 

--- a/src/reposteward/merge.py
+++ b/src/reposteward/merge.py
@@ -145,7 +145,7 @@ def evaluate_merge(
     expected_base_sha: str,
     expected_policy_digest: str,
     max_files_changed: int,
-    max_diff_lines: int,
+    max_diff_lines: int | None,
     extra_risk_patterns: tuple[str, ...] = (),
 ) -> MergeDecision:
     """Evaluate a snapshot without mutating GitHub, a workspace, or the harness."""
@@ -223,7 +223,10 @@ def evaluate_merge(
             )
     if len(snapshot.files) > max_files_changed:
         block("file_limit_exceeded", "The change exceeds the configured file limit.")
-    if snapshot.additions + snapshot.deletions > max_diff_lines:
+    if (
+        max_diff_lines is not None
+        and snapshot.additions + snapshot.deletions > max_diff_lines
+    ):
         block("diff_limit_exceeded", "The change exceeds the configured diff limit.")
 
     risk_categories, risk_files = classify_merge_risk(

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -21,7 +21,11 @@ from .branch_cleanup import (
     build_branch_cleanup_plan,
     fresh_candidate_blockers,
 )
-from .capacity import effective_capacity_limit, pull_request_capacity
+from .capacity import (
+    effective_capacity_limit,
+    effective_diff_line_limit,
+    pull_request_capacity,
+)
 from .ci import (
     FAILED_CONCLUSIONS,
     MAX_COMPARISON_LOGS,
@@ -4681,8 +4685,10 @@ class Pipeline:
             max_files_changed=effective_capacity_limit(
                 self.config.safety.max_files_changed, policy.max_files_changed
             ),
-            max_diff_lines=effective_capacity_limit(
-                self.config.safety.max_diff_lines, policy.max_diff_lines
+            max_diff_lines=effective_diff_line_limit(
+                self.config.safety.max_diff_lines,
+                policy.max_diff_lines,
+                user_allows_unlimited=policy.unlimited_diff_lines,
             ),
             extra_risk_patterns=policy.merge_risk_paths,
         )

--- a/src/reposteward/policy.py
+++ b/src/reposteward/policy.py
@@ -5,7 +5,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from .capacity import effective_capacity_limit
+from .capacity import effective_capacity_limit, effective_diff_line_limit
 from .config import AppConfig, RepositoryPolicy
 from .models import VerificationResult
 
@@ -116,14 +116,16 @@ def enforce_change_policy(
     file_limit = effective_capacity_limit(
         config.safety.max_files_changed, repository.max_files_changed
     )
-    line_limit = effective_capacity_limit(
-        config.safety.max_diff_lines, repository.max_diff_lines
+    line_limit = effective_diff_line_limit(
+        config.safety.max_diff_lines,
+        repository.max_diff_lines,
+        user_allows_unlimited=repository.unlimited_diff_lines,
     )
     if len(summary.files) > file_limit:
         raise PolicyError(
             f"change touches {len(summary.files)} files; policy limit is {file_limit}"
         )
-    if summary.total_lines > line_limit:
+    if line_limit is not None and summary.total_lines > line_limit:
         raise PolicyError(
             f"change has {summary.total_lines} changed lines; policy limit is {line_limit}"
         )

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import unittest
 
-from reposteward.capacity import effective_capacity_limit, pull_request_capacity
+from reposteward.capacity import (
+    effective_capacity_limit,
+    effective_diff_line_limit,
+    pull_request_capacity,
+)
 from reposteward.github import PullRequest
 
 
@@ -66,6 +70,21 @@ class PullRequestCapacityTests(unittest.TestCase):
         )
         self.assertEqual(capacity["active_count"], 5)
         self.assertTrue(capacity["allows_new_pull_request"])
+
+    def test_trusted_unlimited_diff_mode_retains_finite_repository_tightening(
+        self,
+    ) -> None:
+        self.assertIsNone(
+            effective_diff_line_limit(2_000, None, user_allows_unlimited=True)
+        )
+        self.assertEqual(
+            effective_diff_line_limit(2_000, 3_000, user_allows_unlimited=True),
+            3_000,
+        )
+        self.assertEqual(
+            effective_diff_line_limit(2_000, 3_000, user_allows_unlimited=False),
+            2_000,
+        )
 
     def test_capacity_details_are_bounded_without_losing_the_total(self) -> None:
         capacity = pull_request_capacity(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -388,6 +388,78 @@ max_diff_lines = 2500
         self.assertEqual(policy.max_files_changed, 50)
         self.assertEqual(policy.max_diff_lines, 2_500)
 
+    def test_only_user_configuration_can_enable_unlimited_diff_lines(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+unlimited_diff_lines = true
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[repositories."owner/repo"]
+enabled = true
+""",
+                encoding="utf-8",
+            )
+
+            trusted = load_config(project, user_path=user)
+
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+unlimited_diff_lines = true
+""",
+                encoding="utf-8",
+            )
+            untrusted = load_config(project, user_path=user)
+            project_only = load_config(project)
+
+        self.assertTrue(trusted.repositories["owner/repo"].unlimited_diff_lines)
+        self.assertFalse(untrusted.repositories["owner/repo"].unlimited_diff_lines)
+        self.assertFalse(project_only.repositories["owner/repo"].unlimited_diff_lines)
+
+    def test_unlimited_diff_lines_requires_a_boolean(self) -> None:
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            project = root / "project.toml"
+            user.write_text(
+                """config_version = 1
+[github]
+login = "alice"
+[repositories."owner/repo"]
+unlimited_diff_lines = "unlimited"
+""",
+                encoding="utf-8",
+            )
+            project.write_text(
+                """config_version = 1
+[repositories."owner/repo"]
+enabled = true
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigError, "expected a boolean"):
+                load_config(project, user_path=user)
+
     def test_capacity_limits_must_be_positive(self) -> None:
         with TemporaryDirectory() as directory:
             path = Path(directory) / "config.toml"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -59,6 +59,7 @@ class RepositoryPolicyDigestTests(unittest.TestCase):
         legacy.pop("owner_attestation")
         legacy.pop("max_active_pull_requests")
         legacy.pop("branch_cleanup")
+        legacy.pop("unlimited_diff_lines")
         encoded = json.dumps(
             legacy, ensure_ascii=False, sort_keys=True, separators=(",", ":")
         ).encode()
@@ -76,6 +77,10 @@ class RepositoryPolicyDigestTests(unittest.TestCase):
         )
         self.assertNotEqual(
             repository_policy_digest(replace(policy, branch_cleanup=True)),
+            repository_policy_digest(policy),
+        )
+        self.assertNotEqual(
+            repository_policy_digest(replace(policy, unlimited_diff_lines=True)),
             repository_policy_digest(policy),
         )
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -33,7 +33,7 @@ class MergeDecisionTests(unittest.TestCase):
             expected_base_sha="b" * 40,
             expected_policy_digest="c" * 64,
             max_files_changed=18,
-            max_diff_lines=700,
+            max_diff_lines=kwargs.pop("max_diff_lines", 700),
             **kwargs,
         )
 
@@ -196,4 +196,17 @@ class MergeDecisionTests(unittest.TestCase):
                 "file_limit_exceeded",
                 "diff_limit_exceeded",
             },
+        )
+
+    def test_unlimited_diff_mode_keeps_exact_counts_without_blocking_merge(
+        self,
+    ) -> None:
+        result = self.evaluate(
+            replace(self.snapshot, additions=100_000, deletions=100_000),
+            max_diff_lines=None,
+        )
+
+        self.assertTrue(result.eligible)
+        self.assertNotIn(
+            "diff_limit_exceeded", [reason.code for reason in result.reasons]
         )

--- a/tests/test_merge_pipeline.py
+++ b/tests/test_merge_pipeline.py
@@ -172,6 +172,8 @@ class StubGitHub:
         self.can_admin = True
         self.owner_login = "owner"
         self.files = ["src/example.py"]
+        self.additions = 10
+        self.deletions = 2
         self.optional_check_pending = False
 
     def pull_request_activity(
@@ -215,8 +217,8 @@ class StubGitHub:
             "unresolved_conversations": 0,
             "conversation_digest": self.conversation_marker,
             "files": self.files,
-            "additions": 10,
-            "deletions": 2,
+            "additions": self.additions,
+            "deletions": self.deletions,
             "checks": [
                 {
                     "name": "quality",
@@ -305,12 +307,14 @@ class MergePipelineTests(unittest.TestCase):
         auto_merge: bool = False,
         owner_attestation: bool = False,
         branch_cleanup: bool = False,
+        unlimited_diff_lines: bool = False,
     ) -> Pipeline:
         policy = RepositoryPolicy(
             name="owner/repo",
             auto_merge=auto_merge,
             owner_attestation=owner_attestation,
             branch_cleanup=branch_cleanup,
+            unlimited_diff_lines=unlimited_diff_lines,
             mode="maintainer",
             submission_strategy="same-repository",
         )
@@ -324,6 +328,19 @@ class MergePipelineTests(unittest.TestCase):
         pipeline.store = StubStore(policy)
         pipeline.github = StubGitHub()
         return pipeline
+
+    def test_trusted_unlimited_diff_policy_reaches_merge_evaluation(self) -> None:
+        pipeline = self.pipeline(unlimited_diff_lines=True)
+        pipeline.github.additions = 100_000
+        pipeline.github.deletions = 100_000
+
+        decision = pipeline.merge_decision("run-1")
+
+        self.assertTrue(decision["eligible"])
+        self.assertEqual(
+            pipeline.store.audits[0]["decision"]["snapshot"]["additions"],
+            100_000,
+        )
 
     def test_decision_reads_current_snapshot_and_appends_every_audit(self) -> None:
         policy = RepositoryPolicy(name="owner/repo")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -125,6 +125,27 @@ class PolicyTests(unittest.TestCase):
         ):
             enforce_change_policy(Path("."), verification, repository, self.config)
 
+    def test_trusted_repository_can_disable_only_the_changed_line_limit(self) -> None:
+        repository = RepositoryPolicy(
+            name="owner/repo",
+            unlimited_diff_lines=True,
+        )
+        verification = VerificationResult(passed=True, commands=())
+        successful_diff_check = Mock(returncode=0, stdout="")
+        summary = DiffSummary(("file",), 100_000, 100_000)
+
+        with (
+            patch(
+                "reposteward.policy.subprocess.run", return_value=successful_diff_check
+            ),
+            patch("reposteward.policy.summarize_diff", return_value=summary),
+        ):
+            accepted = enforce_change_policy(
+                Path("."), verification, repository, self.config
+            )
+
+        self.assertEqual(accepted, summary)
+
     def test_pull_request_body_contains_review_attestation(self) -> None:
         body = Pipeline._pull_request_body(
             5112,


### PR DESCRIPTION
Closes #80

Allow a trusted user to disable only the changed-line capacity gate for one repository while preserving every other safety and review gate.

---

Adds an explicit repository policy flag, trust-layer enforcement, optional effective line limits in preparation and merge evaluation, exact diff accounting, compatibility-safe policy digests, operator documentation, and regression coverage.

Verified with `uv run python -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
