### PR TITLE
feat(benchmark): add RepoStewardBench v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,17 @@ uv run reposteward portfolio plan owner/repository --format text
 uv run reposteward batch plan owner/repository --format text
 uv run reposteward usage report owner/repository
 uv run reposteward storage stats --repo owner/repository
+uv run reposteward benchmark run --output .artifacts/benchmark.json
 ```
 
 The persistent queue and batch planner store bounded control-plane intent. They do not
 turn on submit, owner-attestation, or merge permissions.
+
+`benchmark run` executes RepoStewardBench v0 entirely offline. Its versioned fixtures
+cover safety gates, context bounds, maintainer attention, recovery, and scale. Every
+scenario is repeated to detect nondeterminism, critical safety and recovery scenarios
+form a hard gate, and machine-specific duration is reported only as informational data.
+Use `--baseline PREVIOUS.json` to compare semantic metric deltas between commits.
 
 ## Trust boundaries
 
@@ -238,6 +245,7 @@ uv run python -m unittest discover -s tests -v
 uvx ruff check .
 uvx ruff format --check .
 uv run reposteward --help
+uv run reposteward benchmark run
 uv build
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,10 +136,15 @@ uv run reposteward portfolio plan owner/repository --format text
 uv run reposteward batch plan owner/repository --format text
 uv run reposteward usage report owner/repository
 uv run reposteward storage stats --repo owner/repository
+uv run reposteward benchmark run --output .artifacts/benchmark.json
 ```
 
 持久队列和 Batch Planner 只保存有界的控制面意图。它们不能自行开启 submit、Owner Attestation
 或 merge 权限。
+
+`benchmark run` 完全离线运行 RepoStewardBench v0。版本化 fixtures 覆盖安全门槛、上下文边界、
+维护者注意力、故障恢复和规模；每个场景会重复执行以检测非确定性，关键安全与恢复场景组成硬门槛，
+机器相关耗时只作为观察数据。使用 `--baseline PREVIOUS.json` 可以比较不同 commit 的语义指标变化。
 
 ## 信任边界
 
@@ -211,6 +216,7 @@ uv run python -m unittest discover -s tests -v
 uvx ruff check .
 uvx ruff format --check .
 uv run reposteward --help
+uv run reposteward benchmark run
 uv build
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,11 @@ local draft ── explicit stage ──► Project Draft Issue
 - Runner 只安装依赖并执行已允许的验证命令，不接触宿主凭据。
 - 人类审阅者决定是否发布，并对最终提交负责。
 
+RepoStewardBench 位于这些运行时边界之外，只调用确定性的控制面纯函数和临时 SQLite fixture。
+版本化 manifest 把安全硬门槛与 context、management、recovery、scale 指标分开；场景重复执行得到
+稳定结果摘要，机器相关耗时只作为观察值。评测器不加载仓库账号配置、不联网、不调用 Harness，
+也不拥有公开写入能力，因此 benchmark 本身不能扩大运行时权限。
+
 Runner 不把宿主工作区直接以读写方式交给容器。每次验证先创建一份临时快照，
 Bootstrap 和后续无网络命令共享该快照及专用 HOME/工具缓存，因此依赖只安装一次，
 但宿主 `.venv`、`node_modules` 和其他本地环境不会被替换。Git 元数据单独只读挂载；

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -40,6 +40,7 @@ RepoSteward 把一次代码维护任务拆成八个可审计步骤：
 | --- | --- |
 | 第一次试用 | [安装](#安装) → [添加项目](#添加项目) → [基本工作流](#基本工作流) |
 | 评估产品边界 | [产品边界](#产品边界) → [架构文档](architecture.md) |
+| 运行指标评测 | [RepoStewardBench 指标评测](#repostewardbench-指标评测) |
 | 切换 Harness、账号或机器 | [上下文与跨 Harness 交接](#上下文与跨-harness-交接) |
 | 参与开发 | [贡献指南](../CONTRIBUTING.md) → [安全报告说明](../SECURITY.md) |
 
@@ -476,6 +477,44 @@ output_per_million = "4.00"
 缺少适用价格或必要 token 指标时，该次成本保持 `unknown`。如果配置推理输出单价，它会替代输出
 token 中推理部分的普通输出单价。一次查询超过 10,000 条运行时会要求缩小过滤范围。成功的 merge
 结果也会携带对应 PR 的 `usage_summary`，方便把实际交付与生命周期成本关联起来。
+
+## RepoStewardBench 指标评测
+
+RepoStewardBench v0 把已有安全、上下文、项目管理、恢复和规模不变量组织为独立的离线评测套件。
+它不读取项目配置、不访问网络、不调用 Harness，也不修改 workspace 或 GitHub。完整运行并原子写入
+机器可读报告：
+
+```bash
+uv run reposteward benchmark run --output .artifacts/benchmark.json
+```
+
+报告使用 `benchmark-report-v1` schema，包含 suite/benchmark 版本、git SHA、Python 与平台环境、
+逐场景确定性摘要、语义指标、耗时和分类汇总。默认每个场景执行两次；结果摘要变化会令场景失败。
+标记为 critical 的安全与恢复场景组成 `hard_gate_pass`，任何场景失败都会令命令返回非零。耗时受
+机器影响，只用于观察，不参与通过门槛。
+
+可以缩小范围，或与先前保存的报告比较：
+
+```bash
+uv run reposteward benchmark run --category safety --category recovery
+uv run reposteward benchmark run \
+  --scenario context.events_10000_bounded \
+  --repeat 3
+uv run reposteward benchmark run \
+  --baseline .artifacts/previous.json \
+  --output .artifacts/current.json
+```
+
+基线比较报告新增失败、结果摘要变化及共同数值指标的 delta，但不会比较耗时。CI 应将报告作为构建
+产物保存；仓库只提交稳定 fixture、schema 和语义门槛，不提交某台机器的绝对 timing 基线。
+
+五类 v0 指标分别回答：
+
+- `safety`：必要安全事实是否保留，不可信文本是否被误当成授权，以及只读路径是否越界；
+- `context`：大事件流是否保持有界，以及 UTF-8 保守估算是否稳定；
+- `management`：Inbox 对 gold attention set 的 precision/recall、Top-K blocker 召回和依赖顺序；
+- `recovery`：中断 intent 是否只对账一次，旧 lease 是否无法继续写入；
+- `scale`：1,000 个 PR 或依赖节点下的结果规模与完整性。
 
 ## 上下文与跨 Harness 交接
 

--- a/src/reposteward/benchmark.py
+++ b/src/reposteward/benchmark.py
@@ -1,0 +1,946 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.resources
+import json
+import platform
+import statistics
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from .context_budget import (
+    ContextBudgetError,
+    build_follow_up_context,
+    estimate_tokens,
+)
+from .dependencies import (
+    build_dependency_plan,
+    parse_dependency_declarations,
+)
+from .inbox import build_maintainer_inbox, render_inbox_text
+from .store import Store, StoreError
+
+BENCHMARK_REPORT_SCHEMA_VERSION = 1
+BENCHMARK_CATEGORIES = ("safety", "context", "management", "recovery", "scale")
+MIN_REPEATS = 2
+MAX_REPEATS = 20
+
+ScenarioResult = dict[str, dict[str, Any]]
+Scenario = Callable[[], ScenarioResult]
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _resource_json(*parts: str) -> dict[str, Any]:
+    resource = importlib.resources.files("reposteward").joinpath(*parts)
+    value = json.loads(resource.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError(f"benchmark resource must be an object: {'/'.join(parts)}")
+    return value
+
+
+def benchmark_manifest() -> dict[str, Any]:
+    manifest = _resource_json("data", "benchmark-scenarios-v1.json")
+    scenarios = manifest.get("scenarios")
+    categories = manifest.get("categories")
+    if (
+        manifest.get("schema_version") != 1
+        or not isinstance(scenarios, list)
+        or not isinstance(categories, list)
+    ):
+        raise ValueError("benchmark manifest has an unsupported shape")
+    if tuple(categories) != BENCHMARK_CATEGORIES:
+        raise ValueError("benchmark manifest categories differ from the CLI contract")
+    identifiers = [str(value.get("id") or "") for value in scenarios]
+    if not all(identifiers) or len(identifiers) != len(set(identifiers)):
+        raise ValueError("benchmark scenario identifiers must be unique and non-empty")
+    if set(identifiers) != set(_SCENARIOS):
+        raise ValueError("benchmark manifest and scenario implementations differ")
+    if any(value.get("category") not in categories for value in scenarios):
+        raise ValueError("benchmark manifest contains an unknown category")
+    for scenario in scenarios:
+        assertions = scenario.get("assertions")
+        if not isinstance(assertions, list) or not assertions:
+            raise ValueError("every benchmark scenario must declare metric assertions")
+        for assertion in assertions:
+            if (
+                not isinstance(assertion, dict)
+                or not str(assertion.get("metric") or "")
+                or assertion.get("operator") not in {"eq", "ge", "gt", "le", "lt"}
+                or not isinstance(assertion.get("value"), (int, float))
+                or isinstance(assertion.get("value"), bool)
+            ):
+                raise ValueError("benchmark manifest contains an invalid assertion")
+    return manifest
+
+
+def benchmark_report_schema() -> dict[str, Any]:
+    return _resource_json("schemas", "benchmark-report-v1.schema.json")
+
+
+def validate_benchmark_report(report: dict[str, Any]) -> None:
+    schema = benchmark_report_schema()
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(report),
+        key=lambda error: tuple(str(value) for value in error.absolute_path),
+    )
+    if errors:
+        first = errors[0]
+        location = ".".join(str(value) for value in first.absolute_path) or "report"
+        raise ValueError(f"invalid benchmark report at {location}: {first.message}")
+    for row in report["scenarios"]:
+        expected = _digest({"metrics": row["metrics"], "facts": row["facts"]})
+        if row["passed"] and row["result_digest"] != expected:
+            raise ValueError(
+                f"benchmark result digest does not match scenario {row['id']!r}"
+            )
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _apply_metric_assertions(metadata: dict[str, Any], result: ScenarioResult) -> None:
+    metrics = result.get("metrics")
+    if not isinstance(metrics, dict):
+        raise TypeError("benchmark scenario metrics must be an object")
+    operators: dict[str, Callable[[int | float, int | float], bool]] = {
+        "eq": lambda actual, expected: actual == expected,
+        "ge": lambda actual, expected: actual >= expected,
+        "gt": lambda actual, expected: actual > expected,
+        "le": lambda actual, expected: actual <= expected,
+        "lt": lambda actual, expected: actual < expected,
+    }
+    for assertion in metadata["assertions"]:
+        name = str(assertion["metric"])
+        actual = metrics.get(name)
+        expected = assertion["value"]
+        if not isinstance(actual, (int, float)) or isinstance(actual, bool):
+            raise TypeError(f"metric {name!r} is missing or not numeric")
+        if not operators[str(assertion["operator"])](actual, expected):
+            raise AssertionError(
+                f"metric {name!r} is {actual}; expected "
+                f"{assertion['operator']} {expected}"
+            )
+
+
+def _activity(*, checks: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "pull_request": {
+            "number": 12,
+            "url": "https://example.test/pull/12",
+            "state": "open",
+            "draft": True,
+            "head_sha": "a" * 40,
+            "base_branch": "main",
+            "base_sha": "b" * 40,
+            "merged": False,
+        },
+        "comments": [],
+        "reviews": [],
+        "review_comments": [],
+        "checks": checks or [],
+    }
+
+
+def _event(
+    sequence: int,
+    *,
+    event_id: int | None = None,
+    kind: str = "review_comment",
+    body: str = "Handle this case.",
+) -> dict[str, Any]:
+    identifier = sequence if event_id is None else event_id
+    return {
+        "sequence": sequence,
+        "event_type": kind,
+        "external_id": str(identifier),
+        "version_digest": f"{sequence:064x}",
+        "payload": {
+            "id": identifier,
+            "author": "reviewer",
+            "association": "MEMBER",
+            "path": "src/example.py",
+            "line": 10,
+            "body": body,
+        },
+    }
+
+
+def _scenario_context_mandatory_facts() -> ScenarioResult:
+    checks = [
+        {
+            "id": 9,
+            "name": "quality",
+            "status": "completed",
+            "conclusion": "failure",
+        }
+    ]
+    events = [
+        _event(index, body=f"feedback-{index}-" + "x" * 2_000) for index in range(1, 30)
+    ]
+    plan = build_follow_up_context(
+        activity=_activity(checks=checks),
+        events=events,
+        budget_tokens=5_000,
+        safety_blockers=("head_changed",),
+    )
+    mandatory = plan["mandatory"]
+    _require(mandatory["safety_blockers"] == ["head_changed"], "lost blocker")
+    _require(mandatory["failed_checks"][0]["name"] == "quality", "lost check")
+    _require(plan["estimated_tokens"] <= 5_000, "context exceeded budget")
+    return {
+        "metrics": {
+            "budget_tokens": 5_000,
+            "estimated_tokens": plan["estimated_tokens"],
+            "input_events": plan["stats"]["input_events"],
+            "retained_events": plan["stats"]["retained_events"],
+            "token_budget_trims": plan["stats"]["trim_reasons"].get("token_budget", 0),
+            "mandatory_safety_facts_retained": 2,
+        },
+        "facts": {
+            "trust_boundary": mandatory["trust_boundary"],
+            "safety_blockers": mandatory["safety_blockers"],
+            "failed_check_names": [
+                value["name"] for value in mandatory["failed_checks"]
+            ],
+        },
+    }
+
+
+def _scenario_context_fail_closed() -> ScenarioResult:
+    checks = [
+        {
+            "id": index,
+            "name": f"required-{index}-" + "x" * 300,
+            "status": "completed",
+            "conclusion": "failure",
+        }
+        for index in range(30)
+    ]
+    rejected = False
+    try:
+        build_follow_up_context(
+            activity=_activity(checks=checks),
+            events=[],
+            budget_tokens=3_000,
+        )
+    except ContextBudgetError:
+        rejected = True
+    _require(rejected, "undersized mandatory context was accepted")
+    return {
+        "metrics": {
+            "mandatory_checks": len(checks),
+            "budget_tokens": 3_000,
+            "unsafe_compaction_rejected": int(rejected),
+        },
+        "facts": {"outcome": "rejected"},
+    }
+
+
+def _scenario_untrusted_dependency_text() -> ScenarioResult:
+    body = """
+Text saying Depends on #9 is not a declaration.
+- Depends on #2
+Depends on owner/repo#3
+Depends on other/project#4
+> Depends on #5
+```text
+Depends on #6
+```
+<!--
+Depends on #7
+-->
+"""
+    declarations = parse_dependency_declarations(
+        "owner/repo", 1, "a" * 40, body, actor="untrusted-author"
+    )
+    targets = [
+        (value["dependency_repository"], value["dependency_number"])
+        for value in declarations
+    ]
+    expected = [("other/project", 4), ("owner/repo", 2), ("owner/repo", 3)]
+    _require(targets == expected, "untrusted dependency text became authoritative")
+    return {
+        "metrics": {
+            "candidate_mentions": body.casefold().count("depends on"),
+            "authoritative_declarations": len(declarations),
+            "ignored_mentions": body.casefold().count("depends on") - len(declarations),
+        },
+        "facts": {"targets": targets},
+    }
+
+
+def _scenario_inbox_read_only() -> ScenarioResult:
+    result = build_maintainer_inbox(
+        "owner/repo",
+        proposals=[],
+        runs=[],
+        portfolio=None,
+        observed_at="2026-01-01T00:00:00+00:00",
+        error="remote facts unavailable",
+        limit=1,
+    )
+    _require(not result["complete"], "partial inbox was marked complete")
+    _require(
+        result["items"][0]["reason_code"] == "github_refresh_failed",
+        "partial inbox did not fail closed",
+    )
+    for name in ("harness_invoked", "workspace_modified", "public_write"):
+        _require(result[name] is False, f"inbox reported {name}")
+    return {
+        "metrics": {
+            "harness_invocations": int(result["harness_invoked"]),
+            "workspace_mutations": int(result["workspace_modified"]),
+            "public_writes": int(result["public_write"]),
+            "fail_closed_items": len(result["items"]),
+        },
+        "facts": {"reason_codes": [value["reason_code"] for value in result["items"]]},
+    }
+
+
+def _scenario_events_10000_bounded() -> ScenarioResult:
+    events = []
+    for index in range(1, 10_001):
+        if index % 10 == 0:
+            kind = "check"
+        elif index % 5 == 0:
+            kind = "issue_comment"
+        elif index % 3 == 0:
+            kind = "review"
+        else:
+            kind = "review_comment"
+        body = (
+            "repeated feedback"
+            if index % 7 == 0
+            else f"feedback-{index}-" + "x" * 4_000
+        )
+        events.append(_event(index, kind=kind, body=body))
+    plan = build_follow_up_context(
+        activity=_activity(), events=events, budget_tokens=5_000
+    )
+    stats = plan["stats"]
+    _require(stats["input_events"] == 10_000, "input event count changed")
+    _require(plan["estimated_tokens"] <= 5_000, "context exceeded budget")
+    _require(stats["retained_events"] < 10_000, "events were not bounded")
+    return {
+        "metrics": {
+            "budget_tokens": 5_000,
+            "estimated_tokens": plan["estimated_tokens"],
+            "input_events": stats["input_events"],
+            "retained_events": stats["retained_events"],
+            "retention_basis_points": round(
+                stats["retained_events"] * 10_000 / stats["input_events"]
+            ),
+            "trimmed_duplicate_events": stats["trim_reasons"].get(
+                "duplicate_event_content", 0
+            ),
+        },
+        "facts": {
+            "actionable": plan["actionable"],
+            "trim_reasons": stats["trim_reasons"],
+        },
+    }
+
+
+def _scenario_utf8_estimate() -> ScenarioResult:
+    text = "管理" * 1_000
+    estimated = estimate_tokens(text)
+    encoded_bytes = len(text.encode("utf-8"))
+    _require(estimated == encoded_bytes, "UTF-8 estimate stopped being conservative")
+    return {
+        "metrics": {
+            "characters": len(text),
+            "utf8_bytes": encoded_bytes,
+            "estimated_tokens": estimated,
+        },
+        "facts": {"estimate_basis": "utf8_bytes"},
+    }
+
+
+def _pull(
+    number: int,
+    *,
+    checks: list[dict[str, Any]] | None = None,
+    review: str = "APPROVED",
+    unresolved: int = 0,
+    complete: bool = True,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "updated_at": "2026-01-01T00:00:00Z",
+        "facts_complete": complete,
+        "checks": checks or [],
+        "review_decision": review,
+        "unresolved_conversations": unresolved,
+    }
+
+
+def _run(
+    run_id: str, status: str, *, issue: int, pull_number: int = 0
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "issue_number": issue,
+        "status": status,
+        "updated_at": "2026-01-01T00:00:00Z",
+        "details": {
+            "pr_url": (
+                f"https://github.com/owner/repo/pull/{pull_number}"
+                if pull_number
+                else ""
+            )
+        },
+        "submission_pr_url": "",
+    }
+
+
+def _scenario_inbox_gold_set() -> ScenarioResult:
+    failed_check = [{"name": "quality", "required": True, "conclusion": "failure"}]
+    portfolio = {
+        "snapshot": {
+            "complete": True,
+            "pull_requests": [
+                _pull(10, checks=failed_check),
+                _pull(11, unresolved=1),
+                _pull(12),
+                _pull(99),
+            ],
+        }
+    }
+    result = build_maintainer_inbox(
+        "owner/repo",
+        proposals=[
+            {
+                "project_item_id": "proposal-1",
+                "updated_at": "2025-12-31T00:00:00Z",
+            }
+        ],
+        runs=[
+            _run("failed", "failed", issue=1),
+            _run("ready", "ready", issue=2),
+            _run("ci", "submitted", issue=3, pull_number=10),
+            _run("review", "submitted", issue=4, pull_number=11),
+            _run("merge", "submitted", issue=5, pull_number=12),
+            _run("noise", "running", issue=6),
+        ],
+        portfolio=portfolio,
+        observed_at="2026-01-01T01:00:00+00:00",
+    )
+    actual = [value["reason_code"] for value in result["items"]]
+    expected = [
+        "required_ci_failed",
+        "review_feedback_required",
+        "run_failed",
+        "issue_proposal_review_required",
+        "local_review_required",
+        "merge_check_required",
+        "untracked_pull_request",
+    ]
+    actual_set = set(actual)
+    expected_set = set(expected)
+    true_positives = len(actual_set & expected_set)
+    precision = true_positives / len(actual_set)
+    recall = true_positives / len(expected_set)
+    top_two_recall = len(set(actual[:2]) & set(expected[:2])) / 2
+    _require(actual == expected, "inbox differs from the reviewed gold ordering")
+    _require(
+        "run:noise" not in {value["id"] for value in result["items"]}, "noise leaked"
+    )
+    return {
+        "metrics": {
+            "gold_items": len(expected),
+            "selected_items": len(actual),
+            "precision_basis_points": round(precision * 10_000),
+            "recall_basis_points": round(recall * 10_000),
+            "top_two_blocker_recall_basis_points": round(top_two_recall * 10_000),
+            "irrelevant_items": len(actual_set - expected_set),
+        },
+        "facts": {"reason_codes": actual},
+    }
+
+
+def _snapshot(numbers: list[int]) -> dict[str, Any]:
+    return {
+        "repository": "owner/repo",
+        "snapshot_digest": "f" * 64,
+        "complete": True,
+        "pull_requests": [
+            {"number": number, "head_sha": f"{number:040x}"} for number in numbers
+        ],
+        "overlaps": [],
+    }
+
+
+def _declaration(pull_number: int, dependency_number: int) -> dict[str, Any]:
+    values = parse_dependency_declarations(
+        "owner/repo",
+        pull_number,
+        f"{pull_number:040x}",
+        f"Depends on #{dependency_number}",
+    )
+    return values[0]
+
+
+def _scenario_dependency_order() -> ScenarioResult:
+    count = 100
+    declarations = [_declaration(number, number - 1) for number in range(2, count + 1)]
+    plan = build_dependency_plan(
+        _snapshot(list(reversed(range(1, count + 1)))), declarations, [], {}
+    )
+    expected = list(range(1, count + 1))
+    _require(plan["suggested_merge_order"] == expected, "dependency order is wrong")
+    _require(plan["dependency_ready_pull_requests"] == [1], "ready set is wrong")
+    return {
+        "metrics": {
+            "pull_requests": count,
+            "dependency_edges": len(declarations),
+            "ordered_pull_requests": len(plan["suggested_merge_order"]),
+            "ready_pull_requests": len(plan["dependency_ready_pull_requests"]),
+        },
+        "facts": {
+            "first": plan["suggested_merge_order"][0],
+            "last": plan["suggested_merge_order"][-1],
+            "plan_digest": plan["plan_digest"],
+        },
+    }
+
+
+def _scenario_dependency_cycle() -> ScenarioResult:
+    declarations = [
+        _declaration(1, 2),
+        _declaration(2, 1),
+        _declaration(3, 2),
+    ]
+    plan = build_dependency_plan(_snapshot([3, 1, 2]), declarations, [], {})
+    _require(plan["cycles"] == [[1, 2]], "cycle was not identified exactly")
+    _require(plan["unscheduled_pull_requests"] == [1, 2, 3], "cycle leaked work")
+    return {
+        "metrics": {
+            "cycles": len(plan["cycles"]),
+            "cycle_members": len(plan["cycles"][0]),
+            "unscheduled_pull_requests": len(plan["unscheduled_pull_requests"]),
+        },
+        "facts": {
+            "cycles": plan["cycles"],
+            "unscheduled": plan["unscheduled_pull_requests"],
+        },
+    }
+
+
+def _publication_identity(run_id: str) -> dict[str, Any]:
+    return {
+        "attempt_id": "attempt-1",
+        "step_id": "step-1",
+        "run_id": run_id,
+        "repository": "owner/repo",
+        "issue_number": 7,
+        "actor": "alice",
+        "action": "push",
+        "destination": "owner/repo",
+        "branch": "alice/feat/example",
+        "head_sha": "a" * 40,
+        "base_branch": "main",
+        "expected_remote_sha": "b" * 40,
+        "target_pull_number": 12,
+    }
+
+
+def _scenario_publication_reconciliation() -> ScenarioResult:
+    duplicate_rejected = False
+    with tempfile.TemporaryDirectory() as directory:
+        store = Store(Path(directory) / "state.sqlite3")
+        run_id = store.start_run("owner/repo", 7, "benchmark")
+        identity = _publication_identity(run_id)
+        first_lease = store.acquire_run_lease("issue:owner/repo#7", owner="worker-1")
+        store.append_publication_attempt(
+            **identity,
+            stage="applying",
+            outcome="pending",
+            lease=first_lease,
+            payload={},
+        )
+        pending_before = len(store.incomplete_publication_attempts(run_id))
+        store.release_run_lease(first_lease)
+        second_lease = store.acquire_run_lease("issue:owner/repo#7", owner="worker-2")
+        store.append_publication_attempt(
+            **identity,
+            stage="completed",
+            outcome="reconciled",
+            lease=second_lease,
+            payload={
+                "public_write": False,
+                "remote_head_sha": "a" * 40,
+                "reconciliation": "remote_branch_read",
+            },
+        )
+        try:
+            store.append_publication_attempt(
+                **identity,
+                stage="completed",
+                outcome="succeeded",
+                lease=second_lease,
+                payload={"public_write": True},
+            )
+        except StoreError:
+            duplicate_rejected = True
+        pending_after = len(store.incomplete_publication_attempts(run_id))
+        records = store.publication_attempts(run_id)
+        completed = store.publication_action_completed(
+            run_id, action="push", target_pull_number=12
+        )
+    _require(pending_before == 1 and pending_after == 0, "intent was not reconciled")
+    _require(completed, "reconciled action was not recognized")
+    _require(duplicate_rejected, "duplicate publication completion was accepted")
+    return {
+        "metrics": {
+            "pending_before_recovery": pending_before,
+            "pending_after_recovery": pending_after,
+            "audit_records": len(records),
+            "duplicate_completions_rejected": int(duplicate_rejected),
+        },
+        "facts": {"stages": [value["stage"] for value in records]},
+    }
+
+
+def _scenario_stale_lease_rejected() -> ScenarioResult:
+    rejected = False
+    with tempfile.TemporaryDirectory() as directory:
+        store = Store(Path(directory) / "state.sqlite3")
+        run_id = store.start_run("owner/repo", 7, "benchmark")
+        first_lease = store.acquire_run_lease("issue:owner/repo#7", owner="worker-1")
+        store.release_run_lease(first_lease)
+        store.acquire_run_lease("issue:owner/repo#7", owner="worker-2")
+        try:
+            store.append_publication_attempt(
+                **_publication_identity(run_id),
+                stage="applying",
+                outcome="pending",
+                lease=first_lease,
+                payload={},
+            )
+        except StoreError:
+            rejected = True
+        records = store.publication_attempts(run_id)
+    _require(rejected, "stale lease appended a publication intent")
+    _require(not records, "stale lease left an audit record")
+    return {
+        "metrics": {
+            "stale_actions_rejected": int(rejected),
+            "records_written": len(records),
+        },
+        "facts": {"outcome": "rejected"},
+    }
+
+
+def _scenario_inbox_1000_bounded() -> ScenarioResult:
+    count = 1_000
+    result = build_maintainer_inbox(
+        "owner/repo",
+        proposals=[],
+        runs=[],
+        portfolio={
+            "snapshot": {
+                "complete": True,
+                "pull_requests": [_pull(number) for number in range(1, count + 1)],
+            }
+        },
+        observed_at="2026-01-01T01:00:00+00:00",
+        limit=50,
+    )
+    rendered_bytes = len(render_inbox_text(result).encode("utf-8"))
+    _require(len(result["items"]) == 50, "inbox item limit changed")
+    _require(result["omitted_count"] == 950, "inbox omission count is wrong")
+    _require(rendered_bytes < 20_000, "rendered inbox is not bounded")
+    return {
+        "metrics": {
+            "input_pull_requests": count,
+            "retained_items": len(result["items"]),
+            "omitted_items": result["omitted_count"],
+            "rendered_bytes": rendered_bytes,
+        },
+        "facts": {"complete": result["complete"]},
+    }
+
+
+def _scenario_dependency_chain_1000() -> ScenarioResult:
+    count = 1_000
+    declarations = [_declaration(number, number - 1) for number in range(2, count + 1)]
+    plan = build_dependency_plan(
+        _snapshot(list(reversed(range(1, count + 1)))), declarations, [], {}
+    )
+    order = plan["suggested_merge_order"]
+    _require(len(order) == count, "large dependency chain was not fully ordered")
+    _require(order[0] == 1 and order[-1] == count, "large order is incorrect")
+    _require(not plan["cycles"], "acyclic large chain reported a cycle")
+    return {
+        "metrics": {
+            "pull_requests": count,
+            "dependency_edges": len(declarations),
+            "ordered_pull_requests": len(order),
+            "cycles": len(plan["cycles"]),
+        },
+        "facts": {
+            "first": order[0],
+            "last": order[-1],
+            "plan_digest": plan["plan_digest"],
+        },
+    }
+
+
+_SCENARIOS: dict[str, Scenario] = {
+    "safety.context_mandatory_facts": _scenario_context_mandatory_facts,
+    "safety.context_fail_closed": _scenario_context_fail_closed,
+    "safety.untrusted_dependency_text": _scenario_untrusted_dependency_text,
+    "safety.inbox_read_only": _scenario_inbox_read_only,
+    "context.events_10000_bounded": _scenario_events_10000_bounded,
+    "context.utf8_estimate": _scenario_utf8_estimate,
+    "management.inbox_gold_set": _scenario_inbox_gold_set,
+    "management.dependency_order": _scenario_dependency_order,
+    "management.dependency_cycle": _scenario_dependency_cycle,
+    "recovery.publication_reconciliation": _scenario_publication_reconciliation,
+    "recovery.stale_lease_rejected": _scenario_stale_lease_rejected,
+    "scale.inbox_1000_bounded": _scenario_inbox_1000_bounded,
+    "scale.dependency_chain_1000": _scenario_dependency_chain_1000,
+}
+
+
+def _git_sha() -> str:
+    source_root = Path(__file__).resolve().parents[2]
+    if not (source_root / ".git").exists():
+        return ""
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=source_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    value = result.stdout.strip().casefold()
+    if result.returncode == 0 and len(value) == 40:
+        return value
+    return ""
+
+
+def _run_scenario(metadata: dict[str, Any], *, repeat: int) -> dict[str, Any]:
+    scenario_id = str(metadata["id"])
+    implementation = _SCENARIOS[scenario_id]
+    durations = []
+    digests = []
+    results = []
+    failures = []
+    for index in range(repeat):
+        started = time.perf_counter_ns()
+        try:
+            result = implementation()
+            _apply_metric_assertions(metadata, result)
+            digests.append(_digest(result))
+            results.append(result)
+        except Exception as exc:  # noqa: BLE001 - benchmark must report all failures
+            failures.append(f"repeat {index + 1}: {type(exc).__name__}: {exc}")
+        finally:
+            durations.append((time.perf_counter_ns() - started) / 1_000_000)
+    deterministic = bool(digests) and len(digests) == repeat and len(set(digests)) == 1
+    if not deterministic and not failures:
+        failures.append("scenario results changed between repeats")
+    passed = not failures and deterministic
+    first = results[0] if results else {"metrics": {}, "facts": {}}
+    return {
+        "id": scenario_id,
+        "category": str(metadata["category"]),
+        "critical": bool(metadata["critical"]),
+        "description": str(metadata["description"]),
+        "assertions": metadata["assertions"],
+        "passed": passed,
+        "deterministic": deterministic,
+        "repeat": repeat,
+        "median_duration_ms": round(statistics.median(durations), 3),
+        "result_digest": digests[0] if deterministic else "",
+        "metrics": first["metrics"],
+        "facts": first["facts"],
+        "failures": failures,
+    }
+
+
+def _baseline_comparison(
+    current: list[dict[str, Any]], baseline: dict[str, Any]
+) -> dict[str, Any]:
+    baseline_rows = {
+        str(value.get("id") or ""): value
+        for value in baseline.get("scenarios", [])
+        if isinstance(value, dict)
+    }
+    metric_deltas: dict[str, dict[str, int | float]] = {}
+    new_failures = []
+    changed_digests = []
+    missing_from_baseline = []
+    for row in current:
+        scenario_id = str(row["id"])
+        previous = baseline_rows.get(scenario_id)
+        if previous is None:
+            missing_from_baseline.append(scenario_id)
+            continue
+        if bool(previous.get("passed")) and not row["passed"]:
+            new_failures.append(scenario_id)
+        previous_digest = str(previous.get("result_digest") or "")
+        if previous_digest and previous_digest != row["result_digest"]:
+            changed_digests.append(scenario_id)
+        previous_metrics = previous.get("metrics")
+        if not isinstance(previous_metrics, dict):
+            continue
+        deltas = {}
+        for key, value in row["metrics"].items():
+            old = previous_metrics.get(key)
+            if (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and isinstance(old, (int, float))
+                and not isinstance(old, bool)
+            ):
+                deltas[key] = value - old
+        if deltas:
+            metric_deltas[scenario_id] = deltas
+    return {
+        "baseline_suite_id": str(baseline.get("suite_id") or ""),
+        "baseline_git_sha": str(baseline.get("git_sha") or ""),
+        "matched_scenarios": len(current) - len(missing_from_baseline),
+        "missing_from_baseline": missing_from_baseline,
+        "new_failures": new_failures,
+        "changed_result_digests": changed_digests,
+        "metric_deltas": metric_deltas,
+        "timing_compared": False,
+    }
+
+
+def run_benchmark(
+    *,
+    categories: tuple[str, ...] = (),
+    scenario_ids: tuple[str, ...] = (),
+    repeat: int = 2,
+    baseline: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not MIN_REPEATS <= repeat <= MAX_REPEATS:
+        raise ValueError(
+            f"benchmark repeat must be between {MIN_REPEATS} and {MAX_REPEATS}"
+        )
+    manifest = benchmark_manifest()
+    if baseline is not None:
+        validate_benchmark_report(baseline)
+        if baseline.get("suite_id") != manifest["suite_id"]:
+            raise ValueError("baseline benchmark report belongs to a different suite")
+    known_categories = {str(value) for value in manifest["categories"]}
+    unknown_categories = sorted(set(categories) - known_categories)
+    if unknown_categories:
+        raise ValueError(
+            "unknown benchmark categories: " + ", ".join(unknown_categories)
+        )
+    unknown_scenarios = sorted(set(scenario_ids) - set(_SCENARIOS))
+    if unknown_scenarios:
+        raise ValueError("unknown benchmark scenarios: " + ", ".join(unknown_scenarios))
+    selected = [
+        value
+        for value in manifest["scenarios"]
+        if (not categories or value["category"] in categories)
+        and (not scenario_ids or value["id"] in scenario_ids)
+    ]
+    if not selected:
+        raise ValueError("benchmark selection contains no scenarios")
+    rows = [_run_scenario(value, repeat=repeat) for value in selected]
+    category_summary = {}
+    for category in manifest["categories"]:
+        values = [row for row in rows if row["category"] == category]
+        if values:
+            category_summary[category] = {
+                "scenarios": len(values),
+                "passed": sum(bool(value["passed"]) for value in values),
+                "failed": sum(not value["passed"] for value in values),
+            }
+    critical = [row for row in rows if row["critical"]]
+    failed = [row for row in rows if not row["passed"]]
+    critical_failed = [row for row in critical if not row["passed"]]
+    report: dict[str, Any] = {
+        "schema_version": BENCHMARK_REPORT_SCHEMA_VERSION,
+        "suite_id": manifest["suite_id"],
+        "benchmark_version": manifest["benchmark_version"],
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "git_sha": _git_sha(),
+        "environment": {
+            "python": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "selection": {
+            "categories": list(categories),
+            "scenario_ids": list(scenario_ids),
+            "repeat": repeat,
+        },
+        "summary": {
+            "scenario_count": len(rows),
+            "passed": len(rows) - len(failed),
+            "failed": len(failed),
+            "critical_scenarios": len(critical),
+            "critical_failed": len(critical_failed),
+            "hard_gate_pass": not critical_failed,
+            "all_passed": not failed,
+            "deterministic": all(row["deterministic"] for row in rows),
+            "categories": category_summary,
+            "timing_is_informational": True,
+        },
+        "scenarios": rows,
+        "harness_invoked": False,
+        "network_access": False,
+        "public_write": False,
+    }
+    if baseline is not None:
+        report["baseline_comparison"] = _baseline_comparison(rows, baseline)
+    validate_benchmark_report(report)
+    return report
+
+
+def load_benchmark_report(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("baseline benchmark report must be an object")
+    validate_benchmark_report(value)
+    return value
+
+
+def write_benchmark_report(path: Path, report: dict[str, Any]) -> None:
+    validate_benchmark_report(report)
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        temporary = Path(handle.name)
+        json.dump(report, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+    temporary.replace(path)

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -8,6 +8,12 @@ import sys
 from pathlib import Path
 
 from .batch import render_batch_plan_text
+from .benchmark import (
+    BENCHMARK_CATEGORIES,
+    load_benchmark_report,
+    run_benchmark,
+    write_benchmark_report,
+)
 from .config import ConfigError, load_config
 from .dependencies import render_dependency_plan_text
 from .discovery import DiscoveryService
@@ -230,6 +236,32 @@ def _parser() -> argparse.ArgumentParser:
         default="pull-request",
     )
     usage_report.add_argument("--include-runs", action="store_true")
+
+    benchmark = subparsers.add_parser(
+        "benchmark", help="run deterministic offline RepoStewardBench scenarios"
+    )
+    benchmark_commands = benchmark.add_subparsers(
+        dest="benchmark_command", required=True
+    )
+    benchmark_run = benchmark_commands.add_parser(
+        "run", help="evaluate safety gates and multi-dimensional metrics"
+    )
+    benchmark_run.add_argument(
+        "--category",
+        action="append",
+        choices=BENCHMARK_CATEGORIES,
+        default=[],
+        help="limit the suite to one or more categories",
+    )
+    benchmark_run.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help="limit the suite to one or more exact scenario IDs",
+    )
+    benchmark_run.add_argument("--repeat", type=int, default=2)
+    benchmark_run.add_argument("--baseline", type=Path, default=None)
+    benchmark_run.add_argument("--output", type=Path, default=None)
 
     ci = subparsers.add_parser("ci", help="inspect CI failures without rerunning jobs")
     ci_commands = ci.add_subparsers(dest="ci_command", required=True)
@@ -470,6 +502,24 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 return 0
             raise AssertionError(f"unhandled repo command: {args.repo_command}")
+        if args.command == "benchmark":
+            if args.benchmark_command == "run":
+                baseline = (
+                    load_benchmark_report(args.baseline) if args.baseline else None
+                )
+                report = run_benchmark(
+                    categories=tuple(args.category),
+                    scenario_ids=tuple(args.scenario),
+                    repeat=args.repeat,
+                    baseline=baseline,
+                )
+                if args.output is not None:
+                    write_benchmark_report(args.output, report)
+                _json(report)
+                return 0 if report["summary"]["all_passed"] else 1
+            raise AssertionError(
+                f"unhandled benchmark command: {args.benchmark_command}"
+            )
         config = load_config(args.config, include_user=True)
         pipeline = Pipeline(config)
         if args.command == "issue":

--- a/src/reposteward/data/benchmark-scenarios-v1.json
+++ b/src/reposteward/data/benchmark-scenarios-v1.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": 1,
+  "suite_id": "repostewardbench-v0",
+  "benchmark_version": "0.1.0",
+  "categories": [
+    "safety",
+    "context",
+    "management",
+    "recovery",
+    "scale"
+  ],
+  "scenarios": [
+    {
+      "id": "safety.context_mandatory_facts",
+      "category": "safety",
+      "critical": true,
+      "description": "Mandatory failed-check and safety facts survive context trimming.",
+      "assertions": [
+        {"metric": "mandatory_safety_facts_retained", "operator": "eq", "value": 2},
+        {"metric": "estimated_tokens", "operator": "le", "value": 5000}
+      ]
+    },
+    {
+      "id": "safety.context_fail_closed",
+      "category": "safety",
+      "critical": true,
+      "description": "An undersized budget rejects mandatory facts instead of dropping them.",
+      "assertions": [
+        {"metric": "unsafe_compaction_rejected", "operator": "eq", "value": 1}
+      ]
+    },
+    {
+      "id": "safety.untrusted_dependency_text",
+      "category": "safety",
+      "critical": true,
+      "description": "Quoted, fenced, commented, and prose dependency text is not authoritative.",
+      "assertions": [
+        {"metric": "authoritative_declarations", "operator": "eq", "value": 3},
+        {"metric": "ignored_mentions", "operator": "ge", "value": 4}
+      ]
+    },
+    {
+      "id": "safety.inbox_read_only",
+      "category": "safety",
+      "critical": true,
+      "description": "Inbox evaluation fails closed without a Harness, workspace mutation, or public write.",
+      "assertions": [
+        {"metric": "harness_invocations", "operator": "eq", "value": 0},
+        {"metric": "workspace_mutations", "operator": "eq", "value": 0},
+        {"metric": "public_writes", "operator": "eq", "value": 0}
+      ]
+    },
+    {
+      "id": "context.events_10000_bounded",
+      "category": "context",
+      "critical": false,
+      "description": "Ten thousand follow-up events produce deterministic bounded context.",
+      "assertions": [
+        {"metric": "input_events", "operator": "eq", "value": 10000},
+        {"metric": "estimated_tokens", "operator": "le", "value": 5000}
+      ]
+    },
+    {
+      "id": "context.utf8_estimate",
+      "category": "context",
+      "critical": false,
+      "description": "The vendor-neutral token estimate accounts for UTF-8 bytes.",
+      "assertions": [
+        {"metric": "utf8_bytes", "operator": "eq", "value": 6000},
+        {"metric": "estimated_tokens", "operator": "eq", "value": 6000}
+      ]
+    },
+    {
+      "id": "management.inbox_gold_set",
+      "category": "management",
+      "critical": false,
+      "description": "Maintainer attention matches a fixed gold set and blocker ordering.",
+      "assertions": [
+        {"metric": "precision_basis_points", "operator": "eq", "value": 10000},
+        {"metric": "recall_basis_points", "operator": "eq", "value": 10000},
+        {"metric": "top_two_blocker_recall_basis_points", "operator": "eq", "value": 10000},
+        {"metric": "irrelevant_items", "operator": "eq", "value": 0}
+      ]
+    },
+    {
+      "id": "management.dependency_order",
+      "category": "management",
+      "critical": false,
+      "description": "A prerequisite chain receives a stable prerequisite-first order.",
+      "assertions": [
+        {"metric": "ordered_pull_requests", "operator": "eq", "value": 100},
+        {"metric": "ready_pull_requests", "operator": "eq", "value": 1}
+      ]
+    },
+    {
+      "id": "management.dependency_cycle",
+      "category": "management",
+      "critical": false,
+      "description": "Dependency cycles and their downstream work are blocked.",
+      "assertions": [
+        {"metric": "cycles", "operator": "eq", "value": 1},
+        {"metric": "unscheduled_pull_requests", "operator": "eq", "value": 3}
+      ]
+    },
+    {
+      "id": "recovery.publication_reconciliation",
+      "category": "recovery",
+      "critical": true,
+      "description": "An interrupted publication intent is reconciled once without duplicate completion.",
+      "assertions": [
+        {"metric": "pending_after_recovery", "operator": "eq", "value": 0},
+        {"metric": "audit_records", "operator": "eq", "value": 2},
+        {"metric": "duplicate_completions_rejected", "operator": "eq", "value": 1}
+      ]
+    },
+    {
+      "id": "recovery.stale_lease_rejected",
+      "category": "recovery",
+      "critical": true,
+      "description": "A stale worker lease cannot append a publication action.",
+      "assertions": [
+        {"metric": "stale_actions_rejected", "operator": "eq", "value": 1},
+        {"metric": "records_written", "operator": "eq", "value": 0}
+      ]
+    },
+    {
+      "id": "scale.inbox_1000_bounded",
+      "category": "scale",
+      "critical": false,
+      "description": "A one-thousand-PR inbox remains bounded and reports omissions.",
+      "assertions": [
+        {"metric": "retained_items", "operator": "eq", "value": 50},
+        {"metric": "omitted_items", "operator": "eq", "value": 950},
+        {"metric": "rendered_bytes", "operator": "le", "value": 20000}
+      ]
+    },
+    {
+      "id": "scale.dependency_chain_1000",
+      "category": "scale",
+      "critical": false,
+      "description": "A one-thousand-node dependency chain is ordered without recursion.",
+      "assertions": [
+        {"metric": "ordered_pull_requests", "operator": "eq", "value": 1000},
+        {"metric": "cycles", "operator": "eq", "value": 0}
+      ]
+    }
+  ]
+}

--- a/src/reposteward/schemas/benchmark-report-v1.schema.json
+++ b/src/reposteward/schemas/benchmark-report-v1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tiammomo/RepoSteward/schemas/benchmark-report-v1.schema.json",
+  "title": "RepoStewardBench report v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "suite_id",
+    "benchmark_version",
+    "generated_at",
+    "git_sha",
+    "environment",
+    "selection",
+    "summary",
+    "scenarios",
+    "harness_invoked",
+    "network_access",
+    "public_write"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "suite_id": {"type": "string", "minLength": 1},
+    "benchmark_version": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "git_sha": {"type": "string", "pattern": "^([0-9a-f]{40})?$"},
+    "environment": {
+      "type": "object",
+      "required": ["python", "implementation", "system", "machine"],
+      "additionalProperties": {"type": "string"}
+    },
+    "selection": {
+      "type": "object",
+      "required": ["categories", "scenario_ids", "repeat"],
+      "properties": {
+        "categories": {"type": "array", "items": {"type": "string"}},
+        "scenario_ids": {"type": "array", "items": {"type": "string"}},
+        "repeat": {"type": "integer", "minimum": 2, "maximum": 20}
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "scenario_count",
+        "passed",
+        "failed",
+        "critical_scenarios",
+        "critical_failed",
+        "hard_gate_pass",
+        "all_passed",
+        "deterministic",
+        "categories",
+        "timing_is_informational"
+      ],
+      "properties": {
+        "scenario_count": {"type": "integer", "minimum": 0},
+        "passed": {"type": "integer", "minimum": 0},
+        "failed": {"type": "integer", "minimum": 0},
+        "critical_scenarios": {"type": "integer", "minimum": 0},
+        "critical_failed": {"type": "integer", "minimum": 0},
+        "hard_gate_pass": {"type": "boolean"},
+        "all_passed": {"type": "boolean"},
+        "deterministic": {"type": "boolean"},
+        "categories": {"type": "object"},
+        "timing_is_informational": {"const": true}
+      },
+      "additionalProperties": false
+    },
+    "scenarios": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "category",
+          "critical",
+          "description",
+          "assertions",
+          "passed",
+          "deterministic",
+          "repeat",
+          "median_duration_ms",
+          "result_digest",
+          "metrics",
+          "facts",
+          "failures"
+        ],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "category": {"type": "string", "minLength": 1},
+          "critical": {"type": "boolean"},
+          "description": {"type": "string", "minLength": 1},
+          "assertions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["metric", "operator", "value"],
+              "properties": {
+                "metric": {"type": "string", "minLength": 1},
+                "operator": {"enum": ["eq", "ge", "gt", "le", "lt"]},
+                "value": {"type": "number"}
+              },
+              "additionalProperties": false
+            }
+          },
+          "passed": {"type": "boolean"},
+          "deterministic": {"type": "boolean"},
+          "repeat": {"type": "integer", "minimum": 2},
+          "median_duration_ms": {"type": "number", "minimum": 0},
+          "result_digest": {"type": "string", "pattern": "^([0-9a-f]{64})?$"},
+          "metrics": {"type": "object"},
+          "facts": {"type": "object"},
+          "failures": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": false
+      }
+    },
+    "baseline_comparison": {"type": "object"},
+    "harness_invoked": {"const": false},
+    "network_access": {"const": false},
+    "public_write": {"const": false}
+  },
+  "additionalProperties": false
+}

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from reposteward.benchmark import (
+    BENCHMARK_CATEGORIES,
+    benchmark_manifest,
+    run_benchmark,
+    validate_benchmark_report,
+)
+from reposteward.cli import main
+
+
+class RepoStewardBenchTests(unittest.TestCase):
+    def test_complete_suite_passes_hard_gates_and_all_categories(self) -> None:
+        report = run_benchmark()
+
+        validate_benchmark_report(report)
+        self.assertEqual(report["summary"]["scenario_count"], 13)
+        self.assertEqual(report["summary"]["failed"], 0)
+        self.assertTrue(report["summary"]["hard_gate_pass"])
+        self.assertTrue(report["summary"]["deterministic"])
+        self.assertEqual(
+            set(report["summary"]["categories"]), set(BENCHMARK_CATEGORIES)
+        )
+        self.assertFalse(report["harness_invoked"])
+        self.assertFalse(report["network_access"])
+        self.assertFalse(report["public_write"])
+        self.assertTrue(report["summary"]["timing_is_informational"])
+
+    def test_manifest_is_versioned_and_has_unique_scenarios(self) -> None:
+        manifest = benchmark_manifest()
+        identifiers = [value["id"] for value in manifest["scenarios"]]
+
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(manifest["suite_id"], "repostewardbench-v0")
+        self.assertEqual(tuple(manifest["categories"]), BENCHMARK_CATEGORIES)
+        self.assertEqual(len(identifiers), len(set(identifiers)))
+
+    def test_selection_and_baseline_compare_semantic_metrics_only(self) -> None:
+        baseline = run_benchmark(scenario_ids=("context.utf8_estimate",))
+        baseline = deepcopy(baseline)
+        baseline_row = baseline["scenarios"][0]
+        baseline_row["metrics"]["estimated_tokens"] -= 10
+        digest_payload = {
+            "metrics": baseline_row["metrics"],
+            "facts": baseline_row["facts"],
+        }
+        baseline_row["result_digest"] = hashlib.sha256(
+            json.dumps(
+                digest_payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+
+        report = run_benchmark(
+            categories=("context",),
+            scenario_ids=("context.utf8_estimate",),
+            baseline=baseline,
+        )
+        comparison = report["baseline_comparison"]
+
+        self.assertEqual(comparison["matched_scenarios"], 1)
+        self.assertEqual(
+            comparison["metric_deltas"]["context.utf8_estimate"]["estimated_tokens"],
+            10,
+        )
+        self.assertFalse(comparison["timing_compared"])
+
+    def test_cli_writes_machine_readable_report_without_project_config(self) -> None:
+        with TemporaryDirectory() as directory:
+            output_path = Path(directory) / "reports" / "benchmark.json"
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "benchmark",
+                        "run",
+                        "--scenario",
+                        "context.utf8_estimate",
+                        "--output",
+                        str(output_path),
+                    ]
+                )
+            printed = json.loads(stdout.getvalue())
+            saved = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(printed, saved)
+        self.assertEqual(printed["summary"]["scenario_count"], 1)
+
+    def test_invalid_repeat_and_empty_selection_fail_before_running(self) -> None:
+        with self.assertRaisesRegex(ValueError, "repeat"):
+            run_benchmark(repeat=1)
+        with self.assertRaisesRegex(ValueError, "unknown benchmark scenarios"):
+            run_benchmark(scenario_ids=("missing",))
+
+    def test_report_schema_rejects_a_claimed_public_write(self) -> None:
+        report = run_benchmark(scenario_ids=("context.utf8_estimate",))
+        report["public_write"] = True
+
+        with self.assertRaisesRegex(ValueError, "public_write"):
+            validate_benchmark_report(report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #88

Add RepoStewardBench v0 with 13 deterministic offline scenarios, versioned thresholds and schema, baseline comparison, and CI-friendly reports.

---

Implements safety hard gates plus context, management, recovery, and scale metrics. Timing remains informational; the runner does not load project config, call a Harness, access the network, or perform public writes.

Verified with `uv run python -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
