### PR TITLE
fix(observability): preserve current lifecycle facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ uv run reposteward portfolio inspect owner/repository --format text
 uv run reposteward portfolio plan owner/repository --format text
 uv run reposteward branch-cleanup plan owner/repository --format text
 uv run reposteward batch plan owner/repository --format text
+uv run reposteward trace owner/repository 123 --format text
 uv run reposteward usage report owner/repository
 uv run reposteward storage stats --repo owner/repository
 uv run reposteward benchmark run --output .artifacts/benchmark.json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,7 @@ uv run reposteward inbox --repo owner/repository --format text
 uv run reposteward portfolio inspect owner/repository --format text
 uv run reposteward portfolio plan owner/repository --format text
 uv run reposteward batch plan owner/repository --format text
+uv run reposteward trace owner/repository 123 --format text
 uv run reposteward usage report owner/repository
 uv run reposteward storage stats --repo owner/repository
 uv run reposteward benchmark run --output .artifacts/benchmark.json

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -477,7 +477,15 @@ Harness 摘要、验证、租约、队列、发布、GitHub PR 事件与合并�
 默认最多返回 200 个事件，`--limit` 允许 1 到 500；文本渲染另有 50 个事件和 12,000 字符上限。
 被数量或文本边界裁剪的事实会进入 `stats` 与各 `sources[].omitted_records`，不会静默丢失。
 旧运行或尚未进入发布/合并阶段时，无法可靠关联的来源显示为 `unknown` 或 `incomplete`，不能把
-缺失事实解释成零事件。`next_action` 只由本地最新 run 的确定性状态推导。
+缺失事实解释成零事件。`current` 单独保留最新 run、HEAD/base、验证状态和 checkpoint 引用，
+不会随历史事件数量上限一起丢失。同一秒创建多个 run 时，以本地插入顺序确定最新记录。
+`next_action` 根据该 run 的状态推导；只有绑定同一 run 与精确 HEAD 的原生合并终态才表示
+`complete`，尚未完成的合并意图提示 `reconcile_merge`。这些结果是本地事实，不替代发布前的
+远端新鲜度检查。
+
+Checkpoint 中的自由文本下一步不直接输出，只有已知控制面动作码可以展示，其余显示 `unknown`。
+Checkpoint 来源标记为 `derived_review_required`，导入来源标记为 `imported_untrusted`。
+精简文本保留 `passed=False`、`eligible=False` 与零计数，避免省略影响判断的结果。
 
 ## 生命周期用量与成本
 

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -459,6 +459,26 @@ RepoSteward 会从 Codex CLI JSONL 或 Codex SDK turn result 中提取输入、�
 token，并记录工具调用次数；CLI 适配器还记录事件流大小。资源预算告警会出现在 Review Packet
 中，但不会绕过验证。
 
+## Work-item 生命周期轨迹
+
+按仓库与 Issue 读取本地生命周期事实：
+
+```bash
+uv run reposteward trace owner/repository 40 --format text
+uv run reposteward trace owner/repository 40 --format json --limit 200
+```
+
+Trace 使用版本化 JSON 契约，把同一 work item 的 successor runs、Context Pack、Checkpoint、
+Harness 摘要、验证、租约、队列、发布、GitHub PR 事件与合并审计按稳定顺序聚合，并生成稳定的
+`trace_digest`。它不联网、不调用 Harness，也不修改 Store、workspace 或 GitHub；输出只保留
+白名单字段和摘要，不包含原始 Prompt、命令或日志正文、凭据、原生会话 ID、绝对 workspace 路径
+及 token 计数。
+
+默认最多返回 200 个事件，`--limit` 允许 1 到 500；文本渲染另有 50 个事件和 12,000 字符上限。
+被数量或文本边界裁剪的事实会进入 `stats` 与各 `sources[].omitted_records`，不会静默丢失。
+旧运行或尚未进入发布/合并阶段时，无法可靠关联的来源显示为 `unknown` 或 `incomplete`，不能把
+缺失事实解释成零事件。`next_action` 只由本地最新 run 的确定性状态推导。
+
 ## 生命周期用量与成本
 
 每次 `prepare` 和 `repair` 的 Harness 执行完成后，RepoSteward 都会追加一条有摘要保护的紧凑

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -21,7 +21,13 @@ from .discovery import DiscoveryService
 from .doctor import run_doctor
 from .inbox import render_inbox_text
 from .issues import read_details
+from .lifecycle import (
+    DEFAULT_EVENT_LIMIT,
+    build_lifecycle_trace,
+    render_lifecycle_text,
+)
 from .pipeline import Pipeline
+from .policy import PolicyError
 from .portfolio import render_portfolio_text
 from .setup import add_repository, initialize_user_config
 
@@ -130,6 +136,14 @@ def _parser() -> argparse.ArgumentParser:
     listing.add_argument(
         "--all", action="store_true", help="include blocked candidates"
     )
+
+    lifecycle = subparsers.add_parser(
+        "trace", help="read one bounded work-item lifecycle trace"
+    )
+    lifecycle.add_argument("repository")
+    lifecycle.add_argument("issue", type=int)
+    lifecycle.add_argument("--limit", type=int, default=DEFAULT_EVENT_LIMIT)
+    lifecycle.add_argument("--format", choices=("json", "text"), default="json")
     listing.add_argument("--status", default="candidate")
     listing.add_argument("--limit", type=int, default=30)
 
@@ -543,6 +557,24 @@ def main(argv: list[str] | None = None) -> int:
                 f"unhandled benchmark command: {args.benchmark_command}"
             )
         config = load_config(args.config, include_user=True)
+        if args.command == "trace":
+            try:
+                policy = config.repositories[args.repository.casefold()]
+            except KeyError as exc:
+                raise PolicyError(
+                    f"repository is not allowlisted: {args.repository}"
+                ) from exc
+            result = build_lifecycle_trace(
+                config.state_dir,
+                policy.name,
+                args.issue,
+                event_limit=args.limit,
+            )
+            if args.format == "text":
+                print(render_lifecycle_text(result))
+            else:
+                _json(result)
+            return 0
         pipeline = Pipeline(config)
         if args.command == "issue":
             if args.issue_command == "draft":

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -136,6 +136,8 @@ def _parser() -> argparse.ArgumentParser:
     listing.add_argument(
         "--all", action="store_true", help="include blocked candidates"
     )
+    listing.add_argument("--status", default="candidate")
+    listing.add_argument("--limit", type=int, default=30)
 
     lifecycle = subparsers.add_parser(
         "trace", help="read one bounded work-item lifecycle trace"
@@ -144,8 +146,6 @@ def _parser() -> argparse.ArgumentParser:
     lifecycle.add_argument("issue", type=int)
     lifecycle.add_argument("--limit", type=int, default=DEFAULT_EVENT_LIMIT)
     lifecycle.add_argument("--format", choices=("json", "text"), default="json")
-    listing.add_argument("--status", default="candidate")
-    listing.add_argument("--limit", type=int, default=30)
 
     gate = subparsers.add_parser("gate", help="check contribution gates for one issue")
     gate.add_argument("repository")

--- a/src/reposteward/lifecycle.py
+++ b/src/reposteward/lifecycle.py
@@ -1,0 +1,1242 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .store import SCHEMA_VERSION, StoreError
+
+LIFECYCLE_SCHEMA_VERSION = 1
+DEFAULT_EVENT_LIMIT = 200
+MAX_EVENT_LIMIT = 500
+MAX_PULL_NUMBERS = 200
+MAX_FIELD_CHARS = 300
+MAX_STORED_JSON_CHARS = 2_000_000
+MAX_TEXT_CHARS = 12_000
+MAX_TEXT_EVENTS = 50
+MAX_JSON_CHARS = 1_000_000
+
+SOURCE_ORDER = {
+    name: index
+    for index, name in enumerate(
+        (
+            "work_item",
+            "run",
+            "context_pack",
+            "context_import",
+            "harness",
+            "checkpoint",
+            "harness_usage",
+            "verification",
+            "lease",
+            "queue_task",
+            "queue_attempt",
+            "submission",
+            "publication",
+            "github_watermark",
+            "github_pr",
+            "owner_review",
+            "merge_decision",
+            "merge_execution",
+            "dependency",
+        )
+    )
+}
+SOURCE_TRUST = {
+    **{name: "local_control_plane" for name in SOURCE_ORDER},
+    "github_pr": "github_untrusted",
+    "owner_review": "operator_attested",
+    "merge_decision": "local_deterministic",
+    "dependency": "operator_attested",
+}
+
+
+class LifecycleTraceError(StoreError):
+    """Stored lifecycle facts cannot be read without guessing."""
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _read_object(value: object, *, source: str, record_id: str) -> dict[str, Any]:
+    serialized = str(value)
+    if len(serialized) > MAX_STORED_JSON_CHARS:
+        raise LifecycleTraceError(
+            f"{source} record {record_id} exceeds the lifecycle read boundary"
+        )
+    try:
+        result = json.loads(serialized)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise LifecycleTraceError(
+            f"{source} record {record_id} contains invalid JSON"
+        ) from exc
+    if not isinstance(result, dict):
+        raise LifecycleTraceError(f"{source} record {record_id} is not a JSON object")
+    return result
+
+
+def _pull_number(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    text = str(value or "")
+    match = re.search(r"/pull/(\d+)(?:/|$)", text)
+    return int(match.group(1)) if match else 0
+
+
+def _next_action(runs: list[dict[str, Any]], work_item: dict[str, Any] | None) -> str:
+    if not runs:
+        return "prepare" if work_item is not None else "inspect_local_state"
+    latest = max(
+        runs,
+        key=lambda row: (str(row["created_at"]), str(row["id"])),
+    )
+    status = str(latest["status"])
+    stage = str(latest["stage"])
+    if status == "ready":
+        return "human_review"
+    if status == "submitted":
+        return "monitor_pull_request"
+    if status == "failed":
+        return "diagnose_failure"
+    if status == "running":
+        return f"wait_for_{stage or 'pipeline'}"
+    return "inspect_run"
+
+
+def _placeholders(values: list[object] | tuple[object, ...]) -> str:
+    return ",".join("?" for _ in values)
+
+
+def _bounded_rows(
+    connection: sqlite3.Connection,
+    *,
+    select: str,
+    count: str,
+    parameters: tuple[object, ...],
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    total_row = connection.execute(count, parameters).fetchone()
+    assert total_row is not None
+    total = int(total_row[0])
+    rows = connection.execute(f"{select} LIMIT ?", (*parameters, limit)).fetchall()
+    return [dict(row) for row in rows], total
+
+
+def _database_path(state_dir: Path) -> Path:
+    current = state_dir / "reposteward.sqlite3"
+    legacy = state_dir / "starfix.sqlite3"
+    if legacy.exists() and not current.exists():
+        return legacy
+    return current
+
+
+def build_lifecycle_trace(
+    state_dir: Path,
+    repository: str,
+    issue_number: int,
+    *,
+    event_limit: int = DEFAULT_EVENT_LIMIT,
+) -> dict[str, Any]:
+    """Build one deterministic lifecycle trace from a read-only Store snapshot."""
+    normalized_repository = repository.casefold().strip()
+    if not re.fullmatch(r"[a-z0-9_.-]+/[a-z0-9_.-]+", normalized_repository):
+        raise ValueError("repository must use owner/name")
+    if issue_number < 1:
+        raise ValueError("issue_number must be positive")
+    if event_limit < 1 or event_limit > MAX_EVENT_LIMIT:
+        raise ValueError(f"event_limit must be between 1 and {MAX_EVENT_LIMIT}")
+
+    database = _database_path(state_dir)
+    if not database.is_file():
+        raise KeyError(
+            f"no local lifecycle facts for {normalized_repository}#{issue_number}"
+        )
+    uri = f"{database.resolve().as_uri()}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only=ON")
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("PRAGMA busy_timeout=5000")
+
+    try:
+        connection.execute("BEGIN")
+        database_schema_version = int(
+            connection.execute("PRAGMA user_version").fetchone()[0]
+        )
+        if database_schema_version != SCHEMA_VERSION:
+            raise LifecycleTraceError(
+                "lifecycle trace requires the current Store schema; run another "
+                "RepoSteward command to migrate it first"
+            )
+
+        work_item_row = connection.execute(
+            """
+            SELECT id, repository, kind, external_id, status, created_at, updated_at
+            FROM work_items
+            WHERE repository=? AND kind='github_issue' AND external_id=?
+            """,
+            (normalized_repository, str(issue_number)),
+        ).fetchone()
+        work_item = dict(work_item_row) if work_item_row is not None else None
+        work_item_id = str(work_item["id"]) if work_item is not None else ""
+
+        runs, run_total = _bounded_rows(
+            connection,
+            select="""
+                SELECT id, repository, issue_number, stage, status, details,
+                       created_at, updated_at
+                FROM runs WHERE repository=? AND issue_number=?
+                ORDER BY created_at, id
+            """,
+            count="SELECT COUNT(*) FROM runs WHERE repository=? AND issue_number=?",
+            parameters=(normalized_repository, issue_number),
+            limit=event_limit,
+        )
+        latest_run_row = connection.execute(
+            """
+            SELECT id, stage, status, created_at
+            FROM runs WHERE repository=? AND issue_number=?
+            ORDER BY created_at DESC, id DESC LIMIT 1
+            """,
+            (normalized_repository, issue_number),
+        ).fetchone()
+        latest_runs = [dict(latest_run_row)] if latest_run_row is not None else []
+        if work_item is None and run_total == 0:
+            raise KeyError(
+                f"no local lifecycle facts for {normalized_repository}#{issue_number}"
+            )
+        run_ids = [str(row["id"]) for row in runs]
+        run_details = {
+            str(row["id"]): _read_object(
+                row["details"], source="run", record_id=str(row["id"])
+            )
+            for row in runs
+        }
+
+        contexts: list[dict[str, Any]] = []
+        context_total = 0
+        harnesses: list[dict[str, Any]] = []
+        harness_total = 0
+        checkpoints: list[dict[str, Any]] = []
+        checkpoint_total = 0
+        imports: list[dict[str, Any]] = []
+        import_total = 0
+        usage_rows: list[dict[str, Any]] = []
+        usage_total = 0
+        context_run_total = 0
+        checkpoint_run_total = 0
+        usage_run_total = 0
+        if work_item_id:
+            contexts, context_total = _bounded_rows(
+                connection,
+                select="""
+                    SELECT id, work_item_id, run_id, schema_version, source_digest,
+                           base_commit, payload, created_at
+                    FROM context_packs WHERE work_item_id=?
+                    ORDER BY created_at, id
+                """,
+                count="SELECT COUNT(*) FROM context_packs WHERE work_item_id=?",
+                parameters=(work_item_id,),
+                limit=event_limit,
+            )
+            harnesses, harness_total = _bounded_rows(
+                connection,
+                select="""
+                    SELECT run_id, work_item_id, context_pack_id, harness, model,
+                           created_at
+                    FROM harness_runs WHERE work_item_id=?
+                    ORDER BY created_at, run_id
+                """,
+                count="SELECT COUNT(*) FROM harness_runs WHERE work_item_id=?",
+                parameters=(work_item_id,),
+                limit=event_limit,
+            )
+            checkpoints, checkpoint_total = _bounded_rows(
+                connection,
+                select="""
+                    SELECT id, work_item_id, run_id, context_pack_id, sequence,
+                           status, payload, created_at
+                    FROM checkpoints WHERE work_item_id=?
+                    ORDER BY created_at, run_id, sequence, id
+                """,
+                count="SELECT COUNT(*) FROM checkpoints WHERE work_item_id=?",
+                parameters=(work_item_id,),
+                limit=event_limit,
+            )
+            imports, import_total = _bounded_rows(
+                connection,
+                select="""
+                    SELECT id, bundle_digest, work_item_id, source_run_id, imported_at
+                    FROM context_imports WHERE work_item_id=?
+                    ORDER BY imported_at, id
+                """,
+                count="SELECT COUNT(*) FROM context_imports WHERE work_item_id=?",
+                parameters=(work_item_id,),
+                limit=event_limit,
+            )
+            usage_rows, usage_total = _bounded_rows(
+                connection,
+                select="""
+                    SELECT sequence, id, run_id, work_item_id, run_stage, harness,
+                           event_digest, payload, created_at
+                    FROM harness_usage_events WHERE work_item_id=?
+                    ORDER BY sequence, id
+                """,
+                count=(
+                    "SELECT COUNT(*) FROM harness_usage_events WHERE work_item_id=?"
+                ),
+                parameters=(work_item_id,),
+                limit=event_limit,
+            )
+            relationship_counts = connection.execute(
+                """
+                SELECT
+                    (SELECT COUNT(DISTINCT run_id) FROM context_packs
+                     WHERE work_item_id=?) AS context_runs,
+                    (SELECT COUNT(DISTINCT run_id) FROM checkpoints
+                     WHERE work_item_id=?) AS checkpoint_runs,
+                    (SELECT COUNT(DISTINCT run_id) FROM harness_usage_events
+                     WHERE work_item_id=?) AS usage_runs
+                """,
+                (work_item_id, work_item_id, work_item_id),
+            ).fetchone()
+            assert relationship_counts is not None
+            context_run_total = int(relationship_counts["context_runs"])
+            checkpoint_run_total = int(relationship_counts["checkpoint_runs"])
+            usage_run_total = int(relationship_counts["usage_runs"])
+
+        verification_total = int(
+            connection.execute(
+                """
+                SELECT COUNT(*) FROM runs
+                WHERE repository=? AND issue_number=?
+                  AND json_type(details, '$.verification')='object'
+                """,
+                (normalized_repository, issue_number),
+            ).fetchone()[0]
+        )
+
+        context_payloads = {
+            str(row["id"]): _read_object(
+                row["payload"], source="context_pack", record_id=str(row["id"])
+            )
+            for row in contexts
+        }
+        checkpoint_payloads = {
+            str(row["id"]): _read_object(
+                row["payload"], source="checkpoint", record_id=str(row["id"])
+            )
+            for row in checkpoints
+        }
+
+        scope = f"issue:{normalized_repository}#{issue_number}"
+        leases, lease_total = _bounded_rows(
+            connection,
+            select="""
+                SELECT sequence, scope, owner, generation, action, expires_at,
+                       created_at
+                FROM run_lease_events WHERE scope=?
+                ORDER BY sequence
+            """,
+            count="SELECT COUNT(*) FROM run_lease_events WHERE scope=?",
+            parameters=(scope,),
+            limit=event_limit,
+        )
+        publications, publication_total = _bounded_rows(
+            connection,
+            select="""
+                SELECT sequence, id, attempt_id, step_id, run_id, actor, action,
+                       stage, outcome, destination, branch, head_sha, base_branch,
+                       expected_remote_sha, target_pull_number, created_at
+                FROM publication_attempts
+                WHERE repository=? AND issue_number=?
+                ORDER BY sequence, id
+            """,
+            count="""
+                SELECT COUNT(*) FROM publication_attempts
+                WHERE repository=? AND issue_number=?
+            """,
+            parameters=(normalized_repository, issue_number),
+            limit=event_limit,
+        )
+        submissions, submission_total = _bounded_rows(
+            connection,
+            select="""
+                SELECT repository, issue_number, pr_url, created_at
+                FROM submissions WHERE repository=? AND issue_number=?
+                ORDER BY created_at, pr_url
+            """,
+            count="""
+                SELECT COUNT(*) FROM submissions
+                WHERE repository=? AND issue_number=?
+            """,
+            parameters=(normalized_repository, issue_number),
+            limit=event_limit,
+        )
+
+        run_predicate = ""
+        run_parameters: tuple[object, ...] = ()
+        if run_ids:
+            run_predicate = f" OR run_id IN ({_placeholders(run_ids)})"
+            run_parameters = tuple(run_ids)
+        queue_parameters = (
+            normalized_repository,
+            issue_number,
+            work_item_id,
+            *run_parameters,
+        )
+        queue_where = (
+            "repository=? AND (issue_number=? OR work_item_id=?" + run_predicate + ")"
+        )
+        queue_tasks, queue_task_total = _bounded_rows(
+            connection,
+            select=f"""
+                SELECT sequence, id, action, work_item_id, run_id, issue_number,
+                       pull_number, parameters_digest, idempotency_digest, priority,
+                       state, max_attempts, attempt_count, manual_required,
+                       last_error_code, created_at, updated_at
+                FROM queue_tasks WHERE {queue_where}
+                ORDER BY sequence, id
+            """,
+            count=f"SELECT COUNT(*) FROM queue_tasks WHERE {queue_where}",
+            parameters=queue_parameters,
+            limit=event_limit,
+        )
+        queue_attempts, queue_attempt_total = _bounded_rows(
+            connection,
+            select=f"""
+                SELECT a.sequence, a.id, a.task_id, a.generation, a.worker,
+                       a.event, a.outcome, a.payload_digest, a.created_at
+                FROM queue_attempts a
+                JOIN queue_tasks t ON t.id=a.task_id
+                WHERE t.{queue_where}
+                ORDER BY a.sequence, a.id
+            """,
+            count=f"""
+                SELECT COUNT(*) FROM queue_attempts a
+                JOIN queue_tasks t ON t.id=a.task_id
+                WHERE t.{queue_where}
+            """,
+            parameters=queue_parameters,
+            limit=event_limit,
+        )
+
+        pull_numbers: set[int] = set()
+        for row in submissions:
+            number = _pull_number(row["pr_url"])
+            if number:
+                pull_numbers.add(number)
+        for row in publications:
+            number = _pull_number(row["target_pull_number"])
+            if number:
+                pull_numbers.add(number)
+        for row in queue_tasks:
+            number = _pull_number(row["pull_number"])
+            if number:
+                pull_numbers.add(number)
+        for details in run_details.values():
+            number = _pull_number(details.get("pr_url"))
+            guard = details.get("repair_guard")
+            if not number and isinstance(guard, dict):
+                number = _pull_number(guard.get("pull_number"))
+            if number:
+                pull_numbers.add(number)
+        watermarks: list[dict[str, Any]] = []
+        watermark_total = 0
+        if run_ids:
+            marks = _placeholders(run_ids)
+            parameters = tuple(run_ids)
+            watermarks, watermark_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT run_id, pull_number, sequence, batch_digest, updated_at
+                    FROM github_pr_watermarks WHERE run_id IN ({marks})
+                    ORDER BY updated_at, run_id
+                """,
+                count=f"""
+                    SELECT COUNT(*) FROM github_pr_watermarks
+                    WHERE run_id IN ({marks})
+                """,
+                parameters=parameters,
+                limit=event_limit,
+            )
+            pull_numbers.update(
+                int(row["pull_number"])
+                for row in watermarks
+                if int(row["pull_number"]) > 0
+            )
+
+        all_pull_numbers = sorted(pull_numbers)
+        selected_pull_numbers = all_pull_numbers[:MAX_PULL_NUMBERS]
+        pull_numbers_omitted = len(all_pull_numbers) - len(selected_pull_numbers)
+
+        github_events: list[dict[str, Any]] = []
+        github_event_total = 0
+        owner_reviews: list[dict[str, Any]] = []
+        owner_review_total = 0
+        merge_decisions: list[dict[str, Any]] = []
+        merge_decision_total = 0
+        merge_executions: list[dict[str, Any]] = []
+        merge_execution_total = 0
+        dependencies: list[dict[str, Any]] = []
+        dependency_total = 0
+        if selected_pull_numbers:
+            pulls = _placeholders(selected_pull_numbers)
+            pull_parameters = (normalized_repository, *selected_pull_numbers)
+            github_events, github_event_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT sequence, pull_number, event_type, external_id,
+                           version_digest, head_sha, source_trust, source_created_at,
+                           source_updated_at, source_actor, source_state, ingested_at
+                    FROM github_pr_events
+                    WHERE repository=? AND pull_number IN ({pulls})
+                    ORDER BY sequence
+                """,
+                count=f"""
+                    SELECT COUNT(*) FROM github_pr_events
+                    WHERE repository=? AND pull_number IN ({pulls})
+                """,
+                parameters=pull_parameters,
+                limit=event_limit,
+            )
+            merge_decisions, merge_decision_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT id, pull_number, head_sha, base_sha, policy_digest,
+                           snapshot_digest, eligible, decision_digest, created_at
+                    FROM merge_decisions
+                    WHERE repository=? AND pull_number IN ({pulls})
+                    ORDER BY created_at, id
+                """,
+                count=f"""
+                    SELECT COUNT(*) FROM merge_decisions
+                    WHERE repository=? AND pull_number IN ({pulls})
+                """,
+                parameters=pull_parameters,
+                limit=event_limit,
+            )
+            dependencies, dependency_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT sequence, id, pull_number, dependency_number, head_sha,
+                           action, actor, source, event_digest, created_at
+                    FROM portfolio_dependency_events
+                    WHERE repository=? AND pull_number IN ({pulls})
+                    ORDER BY sequence, id
+                """,
+                count=f"""
+                    SELECT COUNT(*) FROM portfolio_dependency_events
+                    WHERE repository=? AND pull_number IN ({pulls})
+                """,
+                parameters=pull_parameters,
+                limit=event_limit,
+            )
+
+        relationship_clauses: list[str] = []
+        relationship_parameters: list[object] = [normalized_repository]
+        if run_ids:
+            relationship_clauses.append(f"run_id IN ({_placeholders(run_ids)})")
+            relationship_parameters.extend(run_ids)
+        if selected_pull_numbers:
+            relationship_clauses.append(
+                f"pull_number IN ({_placeholders(selected_pull_numbers)})"
+            )
+            relationship_parameters.extend(selected_pull_numbers)
+        if relationship_clauses:
+            relationship_where = (
+                "repository=? AND (" + " OR ".join(relationship_clauses) + ")"
+            )
+            parameters = tuple(relationship_parameters)
+            merge_executions, merge_execution_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT id, attempt_id, run_id, decision_id, pull_number, actor,
+                           merge_method, stage, outcome, reason, decision_digest,
+                           head_sha, created_at
+                    FROM merge_executions WHERE {relationship_where}
+                    ORDER BY created_at, id
+                """,
+                count=f"SELECT COUNT(*) FROM merge_executions WHERE {relationship_where}",
+                parameters=parameters,
+                limit=event_limit,
+            )
+            owner_reviews, owner_review_total = _bounded_rows(
+                connection,
+                select=f"""
+                    SELECT sequence, id, pull_number, run_id, actor, head_sha, base_sha,
+                           policy_digest, review_facts_digest, attestation_digest,
+                           created_at
+                    FROM owner_review_attestations WHERE {relationship_where}
+                    ORDER BY sequence, id
+                """,
+                count=f"""
+                    SELECT COUNT(*) FROM owner_review_attestations
+                    WHERE {relationship_where}
+                """,
+                parameters=parameters,
+                limit=event_limit,
+            )
+    finally:
+        connection.rollback()
+        connection.close()
+
+    clipped_fields = 0
+    clipped_chars = 0
+
+    def clip(value: object, limit: int = MAX_FIELD_CHARS) -> str:
+        nonlocal clipped_fields, clipped_chars
+        text = " ".join(str(value or "").split())
+        if len(text) <= limit:
+            return text
+        clipped_fields += 1
+        clipped_chars += len(text) - limit
+        return text[:limit]
+
+    def event(
+        source: str,
+        kind: str,
+        occurred_at: object,
+        stable_id: object,
+        facts: dict[str, Any],
+        *,
+        sequence: int = 0,
+    ) -> dict[str, Any]:
+        return {
+            "source": source,
+            "kind": kind,
+            "occurred_at": clip(occurred_at, 100),
+            "id": clip(stable_id, 200),
+            "sequence": sequence,
+            "facts": facts,
+        }
+
+    events: list[dict[str, Any]] = []
+    if work_item is not None:
+        events.append(
+            event(
+                "work_item",
+                "work_item_created",
+                work_item["created_at"],
+                work_item["id"],
+                {
+                    "work_item_id": clip(work_item["id"], 200),
+                    "kind": clip(work_item["kind"], 80),
+                    "external_id": clip(work_item["external_id"], 100),
+                    "status": clip(work_item["status"], 80),
+                    "updated_at": clip(work_item["updated_at"], 100),
+                },
+            )
+        )
+
+    context_by_run: dict[str, dict[str, Any]] = {}
+    for row in contexts:
+        payload = context_payloads[str(row["id"])]
+        sources = payload.get("sources")
+        policy_digest = ""
+        if isinstance(sources, list):
+            for source in sources:
+                if (
+                    isinstance(source, dict)
+                    and source.get("kind") == "repository_policy"
+                ):
+                    policy_digest = str(source.get("digest") or "")
+                    break
+        fact = {
+            "run_id": clip(row["run_id"], 200),
+            "context_pack_id": clip(row["id"], 200),
+            "schema_version": int(row["schema_version"]),
+            "source_digest": clip(row["source_digest"], 100),
+            "base_sha": clip(row["base_commit"], 100),
+            "policy_digest": clip(policy_digest, 100),
+        }
+        context_by_run.setdefault(str(row["run_id"]), fact)
+        events.append(
+            event(
+                "context_pack",
+                "context_bound",
+                row["created_at"],
+                row["id"],
+                fact,
+            )
+        )
+
+    latest_checkpoint_by_run: dict[str, dict[str, Any]] = {}
+    for row in checkpoints:
+        payload = checkpoint_payloads[str(row["id"])]
+        facts = {
+            "run_id": clip(row["run_id"], 200),
+            "context_pack_id": clip(row["context_pack_id"], 200),
+            "checkpoint_id": clip(row["id"], 200),
+            "status": clip(row["status"], 80),
+            "head_sha": clip(payload.get("head_commit"), 100),
+            "next_action": clip(payload.get("next_action"), 120),
+            "completed_count": len(payload.get("completed", ()))
+            if isinstance(payload.get("completed"), list)
+            else 0,
+            "remaining_count": len(payload.get("remaining", ()))
+            if isinstance(payload.get("remaining"), list)
+            else 0,
+            "blocker_count": len(payload.get("blockers", ()))
+            if isinstance(payload.get("blockers"), list)
+            else 0,
+            "evidence_count": len(payload.get("evidence", ()))
+            if isinstance(payload.get("evidence"), list)
+            else 0,
+        }
+        latest_checkpoint_by_run[str(row["run_id"])] = facts
+        events.append(
+            event(
+                "checkpoint",
+                "checkpoint_saved",
+                row["created_at"],
+                row["id"],
+                facts,
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in runs:
+        run_id = str(row["id"])
+        details = run_details[run_id]
+        context = context_by_run.get(run_id, {})
+        checkpoint = latest_checkpoint_by_run.get(run_id, {})
+        head_sha = details.get("commit_sha") or checkpoint.get("head_sha") or ""
+        base_sha = details.get("base_commit") or context.get("base_sha") or ""
+        events.append(
+            event(
+                "run",
+                "run_state",
+                row["updated_at"],
+                run_id,
+                {
+                    "run_id": clip(run_id, 200),
+                    "stage": clip(row["stage"], 80),
+                    "status": clip(row["status"], 80),
+                    "created_at": clip(row["created_at"], 100),
+                    "head_sha": clip(head_sha, 100),
+                    "base_sha": clip(base_sha, 100),
+                    "policy_digest": clip(context.get("policy_digest"), 100),
+                    "source_run_id": clip(details.get("source_run_id"), 200),
+                },
+            )
+        )
+        verification = details.get("verification")
+        if isinstance(verification, dict):
+            commands = verification.get("commands")
+            command_rows = commands if isinstance(commands, list) else []
+            events.append(
+                event(
+                    "verification",
+                    "verification_summary",
+                    row["updated_at"],
+                    f"verification:{run_id}",
+                    {
+                        "run_id": clip(run_id, 200),
+                        "passed": verification.get("passed")
+                        if isinstance(verification.get("passed"), bool)
+                        else None,
+                        "command_count": len(command_rows),
+                        "failed_command_count": sum(
+                            isinstance(command, dict) and command.get("exit_code") != 0
+                            for command in command_rows
+                        ),
+                        "truncated_output_count": sum(
+                            isinstance(command, dict)
+                            and bool(command.get("output_truncated"))
+                            for command in command_rows
+                        ),
+                    },
+                )
+            )
+
+    for row in imports:
+        events.append(
+            event(
+                "context_import",
+                "context_imported",
+                row["imported_at"],
+                row["id"],
+                {
+                    "work_item_id": clip(row["work_item_id"], 200),
+                    "source_run_id": clip(row["source_run_id"], 200),
+                    "bundle_digest": clip(row["bundle_digest"], 100),
+                },
+            )
+        )
+
+    for row in harnesses:
+        events.append(
+            event(
+                "harness",
+                "harness_bound",
+                row["created_at"],
+                row["run_id"],
+                {
+                    "run_id": clip(row["run_id"], 200),
+                    "context_pack_id": clip(row["context_pack_id"], 200),
+                    "harness": clip(row["harness"], 100),
+                    "model": clip(row["model"], 200),
+                },
+            )
+        )
+
+    for row in usage_rows:
+        payload = _read_object(
+            row["payload"], source="harness_usage", record_id=str(row["id"])
+        )
+        if _digest(payload) != str(row["event_digest"]):
+            raise LifecycleTraceError(
+                f"harness_usage record {row['id']} failed its digest check"
+            )
+        metrics = payload.get("metrics")
+        metrics = metrics if isinstance(metrics, dict) else {}
+        run_id = str(row["run_id"])
+        numeric_metrics: dict[str, int | float | None] = {}
+        for source_key, output_key in (
+            ("event_count", "event_count"),
+            ("tool_call_count", "tool_call_count"),
+            ("duration_seconds", "duration_seconds"),
+        ):
+            value = metrics.get(source_key)
+            numeric_metrics[output_key] = (
+                value
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
+                else None
+            )
+        events.append(
+            event(
+                "harness_usage",
+                "usage_summary",
+                row["created_at"],
+                row["id"],
+                {
+                    "run_id": clip(run_id, 200),
+                    "run_stage": clip(row["run_stage"], 80),
+                    "harness": clip(row["harness"], 100),
+                    **numeric_metrics,
+                    "event_digest": clip(row["event_digest"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in leases:
+        events.append(
+            event(
+                "lease",
+                "lease_event",
+                row["created_at"],
+                f"lease:{row['sequence']}",
+                {
+                    "generation": int(row["generation"]),
+                    "action": clip(row["action"], 80),
+                    "expires_at": clip(row["expires_at"], 100),
+                    "owner_digest": _digest(str(row["owner"]))[:16],
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in queue_tasks:
+        events.append(
+            event(
+                "queue_task",
+                "queue_state",
+                row["updated_at"],
+                row["id"],
+                {
+                    "task_id": clip(row["id"], 200),
+                    "action": clip(row["action"], 80),
+                    "work_item_id": clip(row["work_item_id"], 200),
+                    "run_id": clip(row["run_id"], 200),
+                    "issue_number": int(row["issue_number"]),
+                    "pull_number": int(row["pull_number"]),
+                    "state": clip(row["state"], 80),
+                    "priority": int(row["priority"]),
+                    "attempt_count": int(row["attempt_count"]),
+                    "max_attempts": int(row["max_attempts"]),
+                    "manual_required": bool(row["manual_required"]),
+                    "error_code": clip(row["last_error_code"], 120),
+                    "parameters_digest": clip(row["parameters_digest"], 100),
+                    "idempotency_digest": clip(row["idempotency_digest"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in queue_attempts:
+        events.append(
+            event(
+                "queue_attempt",
+                "queue_attempt",
+                row["created_at"],
+                row["id"],
+                {
+                    "task_id": clip(row["task_id"], 200),
+                    "generation": int(row["generation"]),
+                    "event": clip(row["event"], 80),
+                    "outcome": clip(row["outcome"], 80),
+                    "worker_digest": _digest(str(row["worker"]))[:16],
+                    "payload_digest": clip(row["payload_digest"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in submissions:
+        events.append(
+            event(
+                "submission",
+                "pull_recorded",
+                row["created_at"],
+                row["pr_url"],
+                {
+                    "pull_number": _pull_number(row["pr_url"]),
+                    "pull_url": clip(row["pr_url"], 300),
+                },
+            )
+        )
+
+    for row in publications:
+        events.append(
+            event(
+                "publication",
+                "publication_attempt",
+                row["created_at"],
+                row["id"],
+                {
+                    "attempt_id": clip(row["attempt_id"], 200),
+                    "step_id": clip(row["step_id"], 200),
+                    "run_id": clip(row["run_id"], 200),
+                    "actor": clip(row["actor"], 100),
+                    "action": clip(row["action"], 80),
+                    "stage": clip(row["stage"], 80),
+                    "outcome": clip(row["outcome"], 80),
+                    "destination": clip(row["destination"], 300),
+                    "branch": clip(row["branch"], 300),
+                    "head_sha": clip(row["head_sha"], 100),
+                    "base_branch": clip(row["base_branch"], 300),
+                    "expected_remote_sha": clip(row["expected_remote_sha"], 100),
+                    "pull_number": int(row["target_pull_number"]),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in watermarks:
+        events.append(
+            event(
+                "github_watermark",
+                "github_activity_bound",
+                row["updated_at"],
+                row["run_id"],
+                {
+                    "run_id": clip(row["run_id"], 200),
+                    "pull_number": int(row["pull_number"]),
+                    "github_sequence": int(row["sequence"]),
+                    "batch_digest": clip(row["batch_digest"], 100),
+                },
+            )
+        )
+
+    for row in github_events:
+        events.append(
+            event(
+                "github_pr",
+                "github_event",
+                row["source_updated_at"]
+                or row["source_created_at"]
+                or row["ingested_at"],
+                f"github:{row['sequence']}",
+                {
+                    "pull_number": int(row["pull_number"]),
+                    "event_type": clip(row["event_type"], 80),
+                    "external_id": clip(row["external_id"], 200),
+                    "version_digest": clip(row["version_digest"], 100),
+                    "head_sha": clip(row["head_sha"], 100),
+                    "source_trust": clip(row["source_trust"], 80),
+                    "actor": clip(row["source_actor"], 100),
+                    "state": clip(row["source_state"], 80),
+                    "ingested_at": clip(row["ingested_at"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in owner_reviews:
+        events.append(
+            event(
+                "owner_review",
+                "owner_review_attested",
+                row["created_at"],
+                row["id"],
+                {
+                    "run_id": clip(row["run_id"], 200),
+                    "pull_number": int(row["pull_number"]),
+                    "actor": clip(row["actor"], 100),
+                    "head_sha": clip(row["head_sha"], 100),
+                    "base_sha": clip(row["base_sha"], 100),
+                    "policy_digest": clip(row["policy_digest"], 100),
+                    "review_facts_digest": clip(row["review_facts_digest"], 100),
+                    "attestation_digest": clip(row["attestation_digest"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    for row in merge_decisions:
+        events.append(
+            event(
+                "merge_decision",
+                "merge_evaluated",
+                row["created_at"],
+                row["id"],
+                {
+                    "pull_number": int(row["pull_number"]),
+                    "head_sha": clip(row["head_sha"], 100),
+                    "base_sha": clip(row["base_sha"], 100),
+                    "policy_digest": clip(row["policy_digest"], 100),
+                    "snapshot_digest": clip(row["snapshot_digest"], 100),
+                    "eligible": bool(row["eligible"]),
+                    "decision_digest": clip(row["decision_digest"], 100),
+                },
+            )
+        )
+
+    for row in merge_executions:
+        events.append(
+            event(
+                "merge_execution",
+                "merge_attempt",
+                row["created_at"],
+                row["id"],
+                {
+                    "attempt_id": clip(row["attempt_id"], 200),
+                    "run_id": clip(row["run_id"], 200),
+                    "decision_id": clip(row["decision_id"], 200),
+                    "pull_number": int(row["pull_number"]),
+                    "actor": clip(row["actor"], 100),
+                    "merge_method": clip(row["merge_method"], 80),
+                    "stage": clip(row["stage"], 80),
+                    "outcome": clip(row["outcome"], 80),
+                    "reason": clip(row["reason"], 120),
+                    "decision_digest": clip(row["decision_digest"], 100),
+                    "head_sha": clip(row["head_sha"], 100),
+                },
+            )
+        )
+
+    for row in dependencies:
+        events.append(
+            event(
+                "dependency",
+                "dependency_attested",
+                row["created_at"],
+                row["id"],
+                {
+                    "pull_number": int(row["pull_number"]),
+                    "dependency_number": int(row["dependency_number"]),
+                    "head_sha": clip(row["head_sha"], 100),
+                    "action": clip(row["action"], 80),
+                    "actor": clip(row["actor"], 100),
+                    "source": clip(row["source"], 80),
+                    "event_digest": clip(row["event_digest"], 100),
+                },
+                sequence=int(row["sequence"]),
+            )
+        )
+
+    events.sort(
+        key=lambda value: (
+            value["occurred_at"],
+            SOURCE_ORDER[value["source"]],
+            value["sequence"],
+            value["id"],
+        )
+    )
+    events = events[:event_limit]
+    represented = Counter(str(value["source"]) for value in events)
+
+    source_totals = {
+        "work_item": 1 if work_item is not None else 0,
+        "run": run_total,
+        "context_pack": context_total,
+        "context_import": import_total,
+        "harness": harness_total,
+        "checkpoint": checkpoint_total,
+        "harness_usage": usage_total,
+        "verification": verification_total,
+        "lease": lease_total,
+        "queue_task": queue_task_total,
+        "queue_attempt": queue_attempt_total,
+        "submission": submission_total,
+        "publication": publication_total,
+        "github_watermark": watermark_total,
+        "github_pr": github_event_total,
+        "owner_review": owner_review_total,
+        "merge_decision": merge_decision_total,
+        "merge_execution": merge_execution_total,
+        "dependency": dependency_total,
+    }
+    available_events = sum(source_totals.values())
+    coverage: dict[str, tuple[str, str]] = {}
+    for source, total in source_totals.items():
+        if total == 0:
+            coverage[source] = ("unknown", "no_recorded_facts")
+        elif represented[source] < total:
+            coverage[source] = ("incomplete", "bounded_output_omitted_records")
+        else:
+            coverage[source] = ("complete", "recorded_facts_complete")
+
+    if run_total and context_run_total < run_total:
+        coverage["context_pack"] = ("incomplete", "some_runs_have_no_context_pack")
+    if run_total and checkpoint_run_total < run_total:
+        coverage["checkpoint"] = ("incomplete", "some_runs_have_no_checkpoint")
+    if harness_total and usage_run_total < harness_total:
+        coverage["harness_usage"] = (
+            "incomplete",
+            "some_harness_runs_have_no_usage_ledger",
+        )
+    if run_total and verification_total < run_total:
+        coverage["verification"] = (
+            "incomplete",
+            "some_runs_have_no_verification_summary",
+        )
+    if pull_numbers_omitted:
+        for source in (
+            "github_pr",
+            "owner_review",
+            "merge_decision",
+            "merge_execution",
+            "dependency",
+        ):
+            coverage[source] = ("incomplete", "bounded_pull_relationships")
+    if (
+        run_total > len(runs)
+        or publication_total > len(publications)
+        or queue_task_total > len(queue_tasks)
+    ):
+        for source in (
+            "github_pr",
+            "owner_review",
+            "merge_decision",
+            "merge_execution",
+            "dependency",
+        ):
+            coverage[source] = ("incomplete", "parent_records_omitted")
+
+    sources = [
+        {
+            "name": name,
+            "trust": SOURCE_TRUST[name],
+            "status": coverage[name][0],
+            "reason": coverage[name][1],
+            "records": represented[name],
+            "available_records": source_totals[name],
+            "omitted_records": max(0, source_totals[name] - represented[name]),
+        }
+        for name in SOURCE_ORDER
+    ]
+    work_item_summary = (
+        {
+            "id": clip(work_item["id"], 200),
+            "kind": clip(work_item["kind"], 80),
+            "external_id": clip(work_item["external_id"], 100),
+            "status": clip(work_item["status"], 80),
+        }
+        if work_item is not None
+        else None
+    )
+    trace = {
+        "schema_version": LIFECYCLE_SCHEMA_VERSION,
+        "database_schema_version": database_schema_version,
+        "repository": normalized_repository,
+        "issue_number": issue_number,
+        "work_item": work_item_summary,
+        "complete": all(value["status"] == "complete" for value in sources),
+        "next_action": _next_action(latest_runs, work_item),
+        "sources": sources,
+        "events": events,
+        "stats": {
+            "event_limit": event_limit,
+            "events": len(events),
+            "available_events": available_events,
+            "events_omitted": max(0, available_events - len(events)),
+            "runs": represented["run"],
+            "available_runs": run_total,
+            "runs_omitted": max(0, run_total - represented["run"]),
+            "pull_numbers": len(selected_pull_numbers),
+            "pull_numbers_omitted": pull_numbers_omitted,
+            "fields_clipped": clipped_fields,
+            "field_chars_omitted": clipped_chars,
+        },
+        "network_access": False,
+        "harness_invoked": False,
+        "workspace_modified": False,
+        "store_modified": False,
+        "public_write": False,
+    }
+    if len(_canonical_json(trace)) > MAX_JSON_CHARS:
+        raise LifecycleTraceError(
+            "bounded lifecycle trace exceeded its maximum serialized size"
+        )
+    return {**trace, "trace_digest": _digest(trace)}
+
+
+def render_lifecycle_text(trace: dict[str, Any]) -> str:
+    """Render a compact bounded view from an already-built trace."""
+    stats = trace["stats"]
+    lines = [
+        f"Lifecycle: {trace['repository']}#{trace['issue_number']}",
+        f"Digest: {trace['trace_digest']}",
+        f"Complete: {'yes' if trace['complete'] else 'no'}",
+        f"Next action: {trace['next_action']}",
+        (
+            f"Events: {stats['events']}/{stats['available_events']} "
+            f"(omitted {stats['events_omitted']})"
+        ),
+        "Sources:",
+    ]
+    for source in trace["sources"]:
+        lines.append(
+            f"- {source['name']}: {source['status']} "
+            f"({source['records']}/{source['available_records']}; "
+            f"{source['reason']})"
+        )
+    lines.append("Events:")
+    text_events = trace["events"][:MAX_TEXT_EVENTS]
+    for value in text_events:
+        scalar_facts = [
+            f"{key}={fact}"
+            for key, fact in value["facts"].items()
+            if fact not in ("", None, False, 0) and not isinstance(fact, (dict, list))
+        ][:6]
+        suffix = f" {' '.join(scalar_facts)}" if scalar_facts else ""
+        lines.append(
+            f"- {value['occurred_at']} {value['source']}/{value['kind']}{suffix}"
+        )
+    text_omitted = len(trace["events"]) - len(text_events)
+    if text_omitted:
+        lines.append(f"- ... {text_omitted} additional events omitted from text")
+    result = "\n".join(lines)
+    if len(result) <= MAX_TEXT_CHARS:
+        return result
+    suffix = "\n... text output clipped to 12000 characters"
+    return result[: MAX_TEXT_CHARS - len(suffix)] + suffix

--- a/src/reposteward/lifecycle.py
+++ b/src/reposteward/lifecycle.py
@@ -48,11 +48,37 @@ SOURCE_ORDER = {
 }
 SOURCE_TRUST = {
     **{name: "local_control_plane" for name in SOURCE_ORDER},
+    "checkpoint": "derived_review_required",
+    "context_import": "imported_untrusted",
     "github_pr": "github_untrusted",
     "owner_review": "operator_attested",
     "merge_decision": "local_deterministic",
     "dependency": "operator_attested",
 }
+CHECKPOINT_ACTIONS = frozenset(
+    {
+        "human_review",
+        "diagnose_failure",
+        "run_coding_harness",
+        "verify_adopted_change",
+        "run_repair_harness",
+        "monitor_pull_request",
+        "reverify_changed_head",
+        "complete",
+        "inspect_closed_pull_request",
+        "diagnose_failed_checks",
+        "review_new_activity",
+        "wait_for_checks",
+        "wait_for_activity",
+        "review_suggestions",
+    }
+)
+
+
+def _checkpoint_action(value: object) -> str:
+    return (
+        value if isinstance(value, str) and value in CHECKPOINT_ACTIONS else "unknown"
+    )
 
 
 class LifecycleTraceError(StoreError):
@@ -202,7 +228,7 @@ def build_lifecycle_trace(
                 SELECT id, repository, issue_number, stage, status, details,
                        created_at, updated_at
                 FROM runs WHERE repository=? AND issue_number=?
-                ORDER BY created_at, id
+                ORDER BY created_at, rowid
             """,
             count="SELECT COUNT(*) FROM runs WHERE repository=? AND issue_number=?",
             parameters=(normalized_repository, issue_number),
@@ -210,13 +236,54 @@ def build_lifecycle_trace(
         )
         latest_run_row = connection.execute(
             """
-            SELECT id, stage, status, created_at
+            SELECT id, stage, status, details, created_at
             FROM runs WHERE repository=? AND issue_number=?
-            ORDER BY created_at DESC, id DESC LIMIT 1
+            ORDER BY created_at DESC, rowid DESC LIMIT 1
             """,
             (normalized_repository, issue_number),
         ).fetchone()
         latest_runs = [dict(latest_run_row)] if latest_run_row is not None else []
+        current_details: dict[str, Any] = {}
+        current_checkpoint: dict[str, Any] | None = None
+        current_context: dict[str, Any] | None = None
+        current_merge: dict[str, Any] | None = None
+        if latest_runs:
+            current_run_id = str(latest_runs[0]["id"])
+            current_details = _read_object(
+                latest_runs[0]["details"], source="run", record_id=current_run_id
+            )
+            for table, columns, order, label in (
+                ("checkpoints", "id, payload", "sequence DESC", "checkpoint"),
+                (
+                    "context_packs",
+                    "id, base_commit, payload",
+                    "created_at DESC, rowid DESC",
+                    "context",
+                ),
+                (
+                    "merge_executions",
+                    "id, stage, outcome, head_sha",
+                    "created_at DESC, rowid DESC",
+                    "merge",
+                ),
+            ):
+                row = connection.execute(
+                    f"SELECT {columns} FROM {table} WHERE run_id=? ORDER BY {order} LIMIT 1",
+                    (current_run_id,),
+                ).fetchone()
+                if row is None:
+                    continue
+                material = dict(row)
+                if "payload" in material:
+                    material["payload"] = _read_object(
+                        material["payload"], source=table, record_id=str(material["id"])
+                    )
+                if label == "checkpoint":
+                    current_checkpoint = material
+                elif label == "context":
+                    current_context = material
+                else:
+                    current_merge = material
         if work_item is None and run_total == 0:
             raise KeyError(
                 f"no local lifecycle facts for {normalized_repository}#{issue_number}"
@@ -390,20 +457,18 @@ def build_lifecycle_trace(
             limit=event_limit,
         )
 
-        run_predicate = ""
-        run_parameters: tuple[object, ...] = ()
-        if run_ids:
-            run_predicate = f" OR run_id IN ({_placeholders(run_ids)})"
-            run_parameters = tuple(run_ids)
-        queue_parameters = (
+        run_scope = "SELECT id FROM runs WHERE repository=? AND issue_number=?"
+        queue_predicates = ["t.issue_number=?", f"t.run_id IN ({run_scope})"]
+        queue_parameters: tuple[object, ...] = (
             normalized_repository,
             issue_number,
-            work_item_id,
-            *run_parameters,
+            normalized_repository,
+            issue_number,
         )
-        queue_where = (
-            "repository=? AND (issue_number=? OR work_item_id=?" + run_predicate + ")"
-        )
+        if work_item_id:
+            queue_predicates.append("t.work_item_id=?")
+            queue_parameters = (*queue_parameters, work_item_id)
+        queue_where = "t.repository=? AND (" + " OR ".join(queue_predicates) + ")"
         queue_tasks, queue_task_total = _bounded_rows(
             connection,
             select=f"""
@@ -411,10 +476,10 @@ def build_lifecycle_trace(
                        pull_number, parameters_digest, idempotency_digest, priority,
                        state, max_attempts, attempt_count, manual_required,
                        last_error_code, created_at, updated_at
-                FROM queue_tasks WHERE {queue_where}
+                FROM queue_tasks t WHERE {queue_where}
                 ORDER BY sequence, id
             """,
-            count=f"SELECT COUNT(*) FROM queue_tasks WHERE {queue_where}",
+            count=f"SELECT COUNT(*) FROM queue_tasks t WHERE {queue_where}",
             parameters=queue_parameters,
             limit=event_limit,
         )
@@ -425,13 +490,13 @@ def build_lifecycle_trace(
                        a.event, a.outcome, a.payload_digest, a.created_at
                 FROM queue_attempts a
                 JOIN queue_tasks t ON t.id=a.task_id
-                WHERE t.{queue_where}
+                WHERE {queue_where}
                 ORDER BY a.sequence, a.id
             """,
             count=f"""
                 SELECT COUNT(*) FROM queue_attempts a
                 JOIN queue_tasks t ON t.id=a.task_id
-                WHERE t.{queue_where}
+                WHERE {queue_where}
             """,
             parameters=queue_parameters,
             limit=event_limit,
@@ -459,19 +524,18 @@ def build_lifecycle_trace(
                 pull_numbers.add(number)
         watermarks: list[dict[str, Any]] = []
         watermark_total = 0
-        if run_ids:
-            marks = _placeholders(run_ids)
-            parameters = tuple(run_ids)
+        if run_total:
+            parameters = (normalized_repository, issue_number)
             watermarks, watermark_total = _bounded_rows(
                 connection,
                 select=f"""
                     SELECT run_id, pull_number, sequence, batch_digest, updated_at
-                    FROM github_pr_watermarks WHERE run_id IN ({marks})
+                    FROM github_pr_watermarks WHERE run_id IN ({run_scope})
                     ORDER BY updated_at, run_id
                 """,
                 count=f"""
                     SELECT COUNT(*) FROM github_pr_watermarks
-                    WHERE run_id IN ({marks})
+                    WHERE run_id IN ({run_scope})
                 """,
                 parameters=parameters,
                 limit=event_limit,
@@ -686,7 +750,7 @@ def build_lifecycle_trace(
             "checkpoint_id": clip(row["id"], 200),
             "status": clip(row["status"], 80),
             "head_sha": clip(payload.get("head_commit"), 100),
-            "next_action": clip(payload.get("next_action"), 120),
+            "next_action": _checkpoint_action(payload.get("next_action")),
             "completed_count": len(payload.get("completed", ()))
             if isinstance(payload.get("completed"), list)
             else 0,
@@ -1132,6 +1196,8 @@ def build_lifecycle_trace(
         run_total > len(runs)
         or publication_total > len(publications)
         or queue_task_total > len(queue_tasks)
+        or submission_total > len(submissions)
+        or watermark_total > len(watermarks)
     ):
         for source in (
             "github_pr",
@@ -1164,6 +1230,49 @@ def build_lifecycle_trace(
         if work_item is not None
         else None
     )
+    current: dict[str, Any] | None = None
+    next_action = _next_action(latest_runs, work_item)
+    if latest_runs:
+        latest = latest_runs[0]
+        checkpoint = current_checkpoint["payload"] if current_checkpoint else {}
+        context = current_context["payload"] if current_context else {}
+        project = context.get("project")
+        project = project if isinstance(project, dict) else {}
+        verification = current_details.get("verification")
+        verification = verification if isinstance(verification, dict) else {}
+        head_sha = str(
+            current_details.get("commit_sha") or checkpoint.get("head_commit") or ""
+        )
+        current = {
+            "run_id": clip(latest["id"], 200),
+            "status": clip(latest["status"], 80),
+            "stage": clip(latest["stage"], 80),
+            "head_sha": clip(head_sha, 100),
+            "base_sha": clip(
+                current_details.get("base_commit")
+                or (current_context or {}).get("base_commit"),
+                100,
+            ),
+            "policy_digest": clip(project.get("policy_digest"), 100),
+            "checkpoint_id": clip((current_checkpoint or {}).get("id"), 200),
+            "verification_passed": verification.get("passed")
+            if isinstance(verification.get("passed"), bool)
+            else None,
+            "merge_outcome": clip((current_merge or {}).get("outcome"), 80),
+        }
+        if (
+            str(latest["status"]) == "submitted"
+            and current_merge
+            and head_sha
+            and current_merge["head_sha"] == head_sha
+        ):
+            if current_merge["stage"] == "applying":
+                next_action = "reconcile_merge"
+            elif current_merge["stage"] == "completed" and current_merge["outcome"] in {
+                "merged",
+                "already_merged",
+            }:
+                next_action = "complete"
     trace = {
         "schema_version": LIFECYCLE_SCHEMA_VERSION,
         "database_schema_version": database_schema_version,
@@ -1171,7 +1280,8 @@ def build_lifecycle_trace(
         "issue_number": issue_number,
         "work_item": work_item_summary,
         "complete": all(value["status"] == "complete" for value in sources),
-        "next_action": _next_action(latest_runs, work_item),
+        "next_action": next_action,
+        "current": current,
         "sources": sources,
         "events": events,
         "stats": {
@@ -1212,8 +1322,16 @@ def render_lifecycle_text(trace: dict[str, Any]) -> str:
             f"Events: {stats['events']}/{stats['available_events']} "
             f"(omitted {stats['events_omitted']})"
         ),
-        "Sources:",
     ]
+    current = trace.get("current")
+    if isinstance(current, dict):
+        lines.append(
+            f"Current: run={current['run_id']} status={current['status']} stage={current['stage']}"
+        )
+        lines.append(
+            f"HEAD: {current['head_sha'] or 'unknown'}; base={current['base_sha'] or 'unknown'}"
+        )
+    lines.append("Sources:")
     for source in trace["sources"]:
         lines.append(
             f"- {source['name']}: {source['status']} "
@@ -1226,7 +1344,7 @@ def render_lifecycle_text(trace: dict[str, Any]) -> str:
         scalar_facts = [
             f"{key}={fact}"
             for key, fact in value["facts"].items()
-            if fact not in ("", None, False, 0) and not isinstance(fact, (dict, list))
+            if fact is not None and fact != "" and not isinstance(fact, (dict, list))
         ][:6]
         suffix = f" {' '.join(scalar_facts)}" if scalar_facts else ""
         lines.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -349,6 +349,49 @@ class CliSetupTests(unittest.TestCase):
         pipeline.ci_failure_analysis.assert_called_once_with("owner/repo", 12)
         self.assertIn('"public_write": false', output.getvalue())
 
+    def test_lifecycle_trace_supports_json_and_text(self) -> None:
+        result = {
+            "repository": "owner/repo",
+            "issue_number": 7,
+            "trace_digest": "a" * 64,
+            "complete": False,
+            "next_action": "human_review",
+            "sources": [],
+            "events": [],
+            "stats": {"events": 0, "available_events": 0, "events_omitted": 0},
+        }
+        config = MagicMock()
+        config.state_dir = Path("/state")
+        config.repositories = {"owner/repo": MagicMock(name="owner/repo")}
+        config.repositories["owner/repo"].name = "owner/repo"
+        json_output = io.StringIO()
+        text_output = io.StringIO()
+
+        with (
+            patch("reposteward.cli.load_config", return_value=config),
+            patch(
+                "reposteward.cli.build_lifecycle_trace", return_value=result
+            ) as build_trace,
+            patch("reposteward.cli.Pipeline") as pipeline,
+        ):
+            with redirect_stdout(json_output):
+                json_code = main(["trace", "owner/repo", "7", "--limit", "12"])
+            with redirect_stdout(text_output):
+                text_code = main(["trace", "owner/repo", "7", "--format", "text"])
+
+        self.assertEqual(json_code, 0)
+        self.assertEqual(text_code, 0)
+        self.assertEqual(json.loads(json_output.getvalue()), result)
+        self.assertIn("Lifecycle: owner/repo#7", text_output.getvalue())
+        pipeline.assert_not_called()
+        self.assertEqual(
+            build_trace.call_args_list,
+            [
+                unittest.mock.call(Path("/state"), "owner/repo", 7, event_limit=12),
+                unittest.mock.call(Path("/state"), "owner/repo", 7, event_limit=200),
+            ],
+        )
+
     def test_logs_list_and_tail_are_routed_without_overwriting_command(self) -> None:
         pipeline = MagicMock()
         pipeline.run_logs.return_value = {"logs": [], "public_write": False}

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from reposteward.lifecycle import (
+    MAX_TEXT_CHARS,
+    SOURCE_ORDER,
+    LifecycleTraceError,
+    build_lifecycle_trace,
+    render_lifecycle_text,
+)
+from reposteward.store import Store
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _dump(path: Path) -> str:
+    with sqlite3.connect(path) as connection:
+        return "\n".join(connection.iterdump())
+
+
+def _seed_lifecycle(state_dir: Path) -> tuple[Path, str, str]:
+    database = state_dir / "reposteward.sqlite3"
+    store = Store(database)
+    work_item = store.ensure_work_item(
+        "owner/repo",
+        kind="github_issue",
+        external_id="7",
+        title="A secret title that must not be rendered",
+        payload={"prompt": "ghp_secret_token"},
+    )
+    run_one = store.start_run("owner/repo", 7, "agent")
+    run_two = store.start_run("owner/repo", 7, "repair")
+    store.update_run(
+        run_one,
+        status="ready",
+        worktree="/tmp/private-workspace",
+        details={
+            "commit_sha": "1" * 40,
+            "worktree": "/tmp/private-workspace",
+            "prompt": "ghp_secret_token",
+            "verification": {
+                "passed": True,
+                "commands": [
+                    {
+                        "command": "print ghp_secret_token",
+                        "exit_code": 0,
+                        "output": "ghp_secret_token",
+                    }
+                ],
+            },
+        },
+    )
+    store.update_run(
+        run_two,
+        status="failed",
+        details={
+            "source_run_id": run_one,
+            "verification": {
+                "passed": False,
+                "commands": [{"command": "pytest", "exit_code": 1}],
+            },
+        },
+    )
+
+    policy_digest = "a" * 64
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            UPDATE work_items SET created_at='2026-01-01T00:00:00Z',
+                                  updated_at='2026-01-01T00:00:30Z'
+            WHERE id=?
+            """,
+            (work_item["id"],),
+        )
+        for index, run_id in enumerate((run_one, run_two), start=1):
+            created_at = f"2026-01-01T00:0{index}:00Z"
+            context_at = f"2026-01-01T00:0{index}:10Z"
+            checkpoint_at = f"2026-01-01T00:0{index}:20Z"
+            usage_at = f"2026-01-01T00:0{index}:30Z"
+            pack_id = f"pack-{index}"
+            checkpoint_id = f"checkpoint-{index}"
+            context_payload = {
+                "sources": [{"kind": "repository_policy", "digest": policy_digest}],
+                "prompt": "ghp_secret_token",
+            }
+            checkpoint_payload = {
+                "head_commit": str(index) * 40,
+                "next_action": "human_review" if index == 1 else "diagnose_failure",
+                "completed": ["implementation"],
+                "remaining": ["review"],
+                "blockers": [] if index == 1 else ["tests"],
+                "evidence": ["verification"],
+                "prompt": "ghp_secret_token",
+            }
+            usage_payload = {
+                "run_id": run_id,
+                "work_item_id": str(work_item["id"]),
+                "repository": "owner/repo",
+                "issue_number": 7,
+                "run_stage": "prepare" if index == 1 else "repair",
+                "harness": "codex-cli",
+                "model": "model-a",
+                "metrics": {
+                    "input_tokens": 999,
+                    "prompt_chars": 999,
+                    "event_count": index,
+                    "tool_call_count": index + 1,
+                    "duration_seconds": 2.5 * index,
+                },
+            }
+            connection.execute(
+                "UPDATE runs SET created_at=?, updated_at=? WHERE id=?",
+                (created_at, usage_at, run_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO context_packs(
+                    id, work_item_id, run_id, schema_version, source_digest,
+                    base_commit, payload, created_at
+                ) VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+                """,
+                (
+                    pack_id,
+                    work_item["id"],
+                    run_id,
+                    "b" * 64,
+                    "0" * 40,
+                    json.dumps(context_payload),
+                    context_at,
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO harness_runs(
+                    run_id, work_item_id, context_pack_id, harness, model,
+                    native_session_id, created_at
+                ) VALUES (?, ?, ?, 'codex-cli', 'model-a', ?, ?)
+                """,
+                (run_id, work_item["id"], pack_id, "private-session", context_at),
+            )
+            connection.execute(
+                """
+                INSERT INTO checkpoints(
+                    id, work_item_id, run_id, context_pack_id, sequence, status,
+                    payload, created_at
+                ) VALUES (?, ?, ?, ?, 1, ?, ?, ?)
+                """,
+                (
+                    checkpoint_id,
+                    work_item["id"],
+                    run_id,
+                    pack_id,
+                    "ready" if index == 1 else "failed",
+                    json.dumps(checkpoint_payload),
+                    checkpoint_at,
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO harness_usage_events(
+                    id, run_id, work_item_id, repository, issue_number, run_stage,
+                    harness, model, session_resume, portable_context_fallback,
+                    event_digest, payload, created_at
+                ) VALUES (?, ?, ?, 'owner/repo', 7, ?, 'codex-cli', 'model-a',
+                          'not_requested', 0, ?, ?, ?)
+                """,
+                (
+                    f"usage-{index}",
+                    run_id,
+                    work_item["id"],
+                    "prepare" if index == 1 else "repair",
+                    _digest(usage_payload),
+                    json.dumps(usage_payload),
+                    usage_at,
+                ),
+            )
+
+        connection.execute(
+            """
+            INSERT INTO run_lease_events(
+                scope, owner, generation, action, expires_at, created_at
+            ) VALUES ('issue:owner/repo#7', '123:private-owner', 1, 'acquired',
+                      '2026-01-01T00:05:00Z', '2026-01-01T00:00:40Z')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO context_imports(
+                id, bundle_digest, work_item_id, source_run_id, payload, imported_at
+            ) VALUES (
+                'import-1', ?, ?, ?, ?, '2026-01-01T00:02:40Z'
+            )
+            """,
+            (
+                "9" * 64,
+                work_item["id"],
+                run_one,
+                json.dumps({"prompt": "ghp_secret_token"}),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO queue_tasks(
+                id, dedupe_key, repository, action, work_item_id, run_id,
+                issue_number, pull_number, parameters, parameters_digest,
+                idempotency_digest, priority, state, depends_on_task_id,
+                max_attempts, attempt_count, manual_required, last_error_code,
+                lease_owner, lease_generation, lease_expires_at, available_at,
+                created_at, updated_at
+            ) VALUES (
+                'task-1', 'dedupe-1', 'owner/repo', 'submit', ?, ?, 7, 12,
+                '{}', ?, ?, 10, 'completed', NULL, 3, 1, 0, '', '', 0, '',
+                '2026-01-01T00:02:45Z', '2026-01-01T00:02:45Z',
+                '2026-01-01T00:02:50Z'
+            )
+            """,
+            (work_item["id"], run_one, "4" * 64, "5" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO queue_attempts(
+                id, task_id, generation, worker, event, outcome, payload,
+                payload_digest, created_at
+            ) VALUES (
+                'queue-attempt-1', 'task-1', 1, 'private-worker', 'completed',
+                'completed', ?, ?, '2026-01-01T00:02:50Z'
+            )
+            """,
+            (json.dumps({"prompt": "ghp_secret_token"}), "6" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO submissions(repository, issue_number, pr_url, created_at)
+            VALUES ('owner/repo', 7, 'https://github.com/owner/repo/pull/12',
+                    '2026-01-01T00:03:00Z')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO publication_attempts(
+                id, attempt_id, step_id, run_id, repository, issue_number, actor,
+                action, stage, outcome, destination, branch, head_sha, base_branch,
+                expected_remote_sha, target_pull_number, lease_owner,
+                lease_generation, payload, created_at
+            ) VALUES (
+                'publication-1', 'attempt-1', 'step-1', ?, 'owner/repo', 7,
+                'alice', 'create', 'completed', 'succeeded', 'owner/repo',
+                'alice/feat/example', ?, 'main', '', 12, 'owner', 1, '{}',
+                '2026-01-01T00:03:00Z'
+            )
+            """,
+            (run_one, "1" * 40),
+        )
+        connection.execute(
+            """
+            INSERT INTO github_pr_watermarks(
+                run_id, repository, pull_number, sequence, batch_digest, updated_at
+            ) VALUES (
+                ?, 'owner/repo', 12, 1, ?, '2026-01-01T00:03:10Z'
+            )
+            """,
+            (run_one, "7" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO github_pr_events(
+                repository, pull_number, event_type, external_id, version_digest,
+                head_sha, source_trust, source_created_at, source_updated_at,
+                payload, ingested_at, payload_digest, source_actor, source_state
+            ) VALUES (
+                'owner/repo', 12, 'pull_request', '12', ?, ?,
+                'github_untrusted', '2026-01-01T00:03:15Z',
+                '2026-01-01T00:03:20Z', '', '2026-01-01T00:03:21Z', ?,
+                'external-user', 'open'
+            )
+            """,
+            ("8" * 64, "1" * 40, "8" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO portfolio_dependency_events(
+                id, repository, pull_number, dependency_number, head_sha, action,
+                actor, source, event_digest, payload, created_at
+            ) VALUES (
+                'dependency-1', 'owner/repo', 12, 11, ?, 'confirm', 'alice',
+                'maintainer_attestation', ?, '{}', '2026-01-01T00:03:30Z'
+            )
+            """,
+            ("1" * 40, "3" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO merge_decisions(
+                id, repository, pull_number, head_sha, base_sha, policy_digest,
+                snapshot_digest, eligible, decision_digest, payload, created_at
+            ) VALUES (
+                'decision-1', 'owner/repo', 12, ?, ?, ?, ?, 1, ?, '{}',
+                '2026-01-01T00:04:00Z'
+            )
+            """,
+            ("1" * 40, "0" * 40, policy_digest, "c" * 64, "d" * 64),
+        )
+        connection.execute(
+            """
+            INSERT INTO owner_review_attestations(
+                id, repository, pull_number, run_id, actor, head_sha, base_sha,
+                policy_digest, review_facts_digest, attestation_digest, payload,
+                created_at
+            ) VALUES (
+                'review-1', 'owner/repo', 12, ?, 'alice', ?, ?, ?, ?, ?, '{}',
+                '2026-01-01T00:04:10Z'
+            )
+            """,
+            (
+                run_one,
+                "1" * 40,
+                "0" * 40,
+                policy_digest,
+                "e" * 64,
+                "f" * 64,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO merge_executions(
+                id, attempt_id, run_id, decision_id, repository, pull_number,
+                actor, merge_method, stage, outcome, reason, decision_digest,
+                head_sha, payload, created_at
+            ) VALUES (
+                'merge-1', 'merge-attempt-1', ?, 'decision-1', 'owner/repo', 12,
+                'alice', 'squash', 'completed', 'merged', 'merged', ?, ?, '{}',
+                '2026-01-01T00:04:20Z'
+            )
+            """,
+            (run_one, "d" * 64, "1" * 40),
+        )
+        connection.commit()
+    return database, run_one, run_two
+
+
+class LifecycleTraceTests(unittest.TestCase):
+    def test_trace_is_stable_bounded_sanitized_and_read_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            database, run_one, run_two = _seed_lifecycle(state_dir)
+            before = _dump(database)
+
+            first = build_lifecycle_trace(state_dir, "OWNER/REPO", 7)
+            second = build_lifecycle_trace(state_dir, "owner/repo", 7)
+            text = render_lifecycle_text(first)
+            after = _dump(database)
+
+        self.assertEqual(first, second)
+        self.assertEqual(before, after)
+        self.assertEqual(first["schema_version"], 1)
+        self.assertEqual(len(first["trace_digest"]), 64)
+        self.assertEqual(first["next_action"], "diagnose_failure")
+        self.assertFalse(first["network_access"])
+        self.assertFalse(first["harness_invoked"])
+        self.assertFalse(first["workspace_modified"])
+        self.assertFalse(first["store_modified"])
+        self.assertFalse(first["public_write"])
+        run_events = [value for value in first["events"] if value["source"] == "run"]
+        self.assertEqual(
+            {value["facts"]["run_id"] for value in run_events}, {run_one, run_two}
+        )
+        self.assertTrue(
+            {
+                "context_import",
+                "queue_task",
+                "queue_attempt",
+                "github_watermark",
+                "github_pr",
+                "dependency",
+                "owner_review",
+                "merge_decision",
+                "merge_execution",
+            }.issubset({value["source"] for value in first["events"]})
+        )
+        self.assertEqual(
+            [
+                (
+                    value["occurred_at"],
+                    SOURCE_ORDER[value["source"]],
+                    value["sequence"],
+                    value["id"],
+                )
+                for value in first["events"]
+            ],
+            sorted(
+                (
+                    value["occurred_at"],
+                    SOURCE_ORDER[value["source"]],
+                    value["sequence"],
+                    value["id"],
+                )
+                for value in first["events"]
+            ),
+        )
+        serialized = json.dumps(first, ensure_ascii=False).casefold()
+        self.assertNotIn("ghp_secret", serialized)
+        self.assertNotIn("private-workspace", serialized)
+        self.assertNotIn("private-session", serialized)
+        self.assertNotIn("private-worker", serialized)
+        self.assertNotIn("input_tokens", serialized)
+        self.assertNotIn("prompt_chars", serialized)
+        self.assertLessEqual(len(serialized), 1_000_000)
+        self.assertLessEqual(len(text), MAX_TEXT_CHARS)
+        self.assertIn("Lifecycle: owner/repo#7", text)
+
+    def test_missing_relationships_and_global_limit_are_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            store = Store(state_dir / "reposteward.sqlite3")
+            store.ensure_work_item(
+                "owner/repo",
+                kind="github_issue",
+                external_id="8",
+                title="Missing relationships",
+            )
+            run_ids = [store.start_run("owner/repo", 8, "agent") for _ in range(3)]
+            store.update_run(run_ids[-1], status="failed")
+
+            trace = build_lifecycle_trace(state_dir, "owner/repo", 8, event_limit=2)
+
+        sources = {value["name"]: value for value in trace["sources"]}
+        self.assertFalse(trace["complete"])
+        self.assertEqual(trace["next_action"], "diagnose_failure")
+        self.assertEqual(trace["stats"]["available_runs"], 3)
+        self.assertGreater(trace["stats"]["events_omitted"], 0)
+        self.assertEqual(sources["run"]["status"], "incomplete")
+        self.assertEqual(sources["context_pack"]["status"], "incomplete")
+        self.assertEqual(
+            sources["context_pack"]["reason"], "some_runs_have_no_context_pack"
+        )
+        self.assertEqual(sources["publication"]["status"], "unknown")
+        self.assertEqual(sources["publication"]["reason"], "no_recorded_facts")
+        self.assertEqual(sources["github_pr"]["trust"], "github_untrusted")
+        self.assertEqual(sources["owner_review"]["trust"], "operator_attested")
+
+    def test_no_local_work_item_or_run_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            Store(state_dir / "reposteward.sqlite3")
+
+            with self.assertRaisesRegex(KeyError, "no local lifecycle facts"):
+                build_lifecycle_trace(state_dir, "owner/repo", 404)
+
+    def test_usage_digest_tampering_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            database, _, _ = _seed_lifecycle(state_dir)
+            with sqlite3.connect(database) as connection:
+                connection.execute(
+                    "UPDATE harness_usage_events SET event_digest=? WHERE id='usage-1'",
+                    ("0" * 64,),
+                )
+                connection.commit()
+
+            with self.assertRaisesRegex(LifecycleTraceError, "digest check"):
+                build_lifecycle_trace(state_dir, "owner/repo", 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -6,6 +6,8 @@ import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+from uuid import UUID
 
 from reposteward.lifecycle import (
     MAX_TEXT_CHARS,
@@ -429,7 +431,14 @@ class LifecycleTraceTests(unittest.TestCase):
                 external_id="8",
                 title="Missing relationships",
             )
-            run_ids = [store.start_run("owner/repo", 8, "agent") for _ in range(3)]
+            with (
+                patch("reposteward.store.utc_now", return_value="2026-01-01T00:00:00Z"),
+                patch(
+                    "reposteward.store.uuid.uuid4",
+                    side_effect=[UUID(int=n) for n in (3, 2, 1)],
+                ),
+            ):
+                run_ids = [store.start_run("owner/repo", 8, "agent") for _ in range(3)]
             store.update_run(run_ids[-1], status="failed")
 
             trace = build_lifecycle_trace(state_dir, "owner/repo", 8, event_limit=2)
@@ -448,6 +457,117 @@ class LifecycleTraceTests(unittest.TestCase):
         self.assertEqual(sources["publication"]["reason"], "no_recorded_facts")
         self.assertEqual(sources["github_pr"]["trust"], "github_untrusted")
         self.assertEqual(sources["owner_review"]["trust"], "operator_attested")
+
+    def test_legacy_run_does_not_include_other_issues_queue_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            store = Store(state_dir / "reposteward.sqlite3")
+            store.start_run("owner/repo", 7, "agent")
+            store.enqueue_queue_task(
+                "owner/repo", action="prepare", enqueued_by="alice", issue_number=8
+            )
+            own_task = store.enqueue_queue_task(
+                "owner/repo", action="prepare", enqueued_by="alice", issue_number=7
+            )
+            with sqlite3.connect(state_dir / "reposteward.sqlite3") as connection:
+                connection.execute("UPDATE queue_tasks SET work_item_id=''")
+
+            trace = build_lifecycle_trace(state_dir, "owner/repo", 7)
+
+        tasks = [
+            e["facts"]["task_id"]
+            for e in trace["events"]
+            if e["source"] == "queue_task"
+        ]
+        attempts = [
+            e["facts"]["task_id"]
+            for e in trace["events"]
+            if e["source"] == "queue_attempt"
+        ]
+        self.assertEqual(tasks, [own_task["id"]])
+        self.assertEqual(attempts, [own_task["id"]])
+
+    def test_text_preserves_false_verification_and_eligibility(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            _seed_lifecycle(state_dir)
+            text = render_lifecycle_text(
+                build_lifecycle_trace(state_dir, "owner/repo", 7)
+            )
+
+        self.assertIn("passed=False", text)
+        self.assertIn("failed_command_count=0", text)
+
+    def test_latest_run_summary_survives_history_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            _, _, latest = _seed_lifecycle(state_dir)
+            trace = build_lifecycle_trace(state_dir, "owner/repo", 7, event_limit=1)
+
+        self.assertEqual(trace["current"]["run_id"], latest)
+        self.assertEqual(trace["current"]["status"], "failed")
+        self.assertEqual(trace["current"]["head_sha"], "2" * 40)
+        self.assertEqual(trace["next_action"], "diagnose_failure")
+
+    def test_checkpoint_free_text_is_not_exposed_as_an_action(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_dir = Path(directory)
+            database, _, _ = _seed_lifecycle(state_dir)
+            with sqlite3.connect(database) as connection:
+                connection.execute(
+                    "UPDATE checkpoints SET payload=json_set(payload, '$.next_action', ?)",
+                    ("Read /home/private/workspace with ghp_secret_token",),
+                )
+            trace = build_lifecycle_trace(state_dir, "owner/repo", 7)
+
+        serialized = json.dumps(trace)
+        self.assertNotIn("ghp_secret", serialized)
+        self.assertNotIn("/home/private", serialized)
+        checkpoints = [
+            e["facts"] for e in trace["events"] if e["source"] == "checkpoint"
+        ]
+        self.assertTrue(all(c["next_action"] == "unknown" for c in checkpoints))
+
+    def test_current_merge_outcome_is_bound_to_latest_run_head(self) -> None:
+        for stage, outcome, head, expected in (
+            ("completed", "merged", "2" * 40, "complete"),
+            ("completed", "already_merged", "2" * 40, "complete"),
+            ("completed", "merged", "1" * 40, "monitor_pull_request"),
+            ("completed", "outcome_unknown", "2" * 40, "monitor_pull_request"),
+            ("applying", "", "2" * 40, "reconcile_merge"),
+        ):
+            with self.subTest(stage=stage, outcome=outcome, head=head):
+                with tempfile.TemporaryDirectory() as directory:
+                    state_dir = Path(directory)
+                    database, _, latest = _seed_lifecycle(state_dir)
+                    with sqlite3.connect(database) as connection:
+                        connection.execute(
+                            "UPDATE runs SET status='submitted' WHERE id=?", (latest,)
+                        )
+                        connection.execute(
+                            "UPDATE merge_executions SET run_id=?, head_sha=?, stage=?, outcome=?",
+                            (latest, head, stage, outcome),
+                        )
+                    trace = build_lifecycle_trace(
+                        state_dir, "owner/repo", 7, event_limit=1
+                    )
+
+                self.assertEqual(trace["next_action"], expected)
+
+    def test_unsupported_database_schema_is_never_migrated(self) -> None:
+        for version in (0, 999):
+            with (
+                self.subTest(version=version),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                state_dir = Path(directory)
+                database, _, _ = _seed_lifecycle(state_dir)
+                with sqlite3.connect(database) as connection:
+                    connection.execute(f"PRAGMA user_version={version}")
+                before = database.read_bytes()
+                with self.assertRaises(LifecycleTraceError):
+                    build_lifecycle_trace(state_dir, "owner/repo", 7)
+                self.assertEqual(database.read_bytes(), before)
 
     def test_no_local_work_item_or_run_is_an_error(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Closes #91

Add reposteward trace to reconstruct one Issue's local lifecycle, including its current run, verification, pending publication and merge outcome.

---

The read-only JSON/text view combines existing local task, run, checkpoint, verification, queue and audit records without constructing Pipeline or contacting GitHub. It preserves the current run when history is bounded, resolves same-second ties deterministically, scopes legacy queue links, retains false/zero results and reports missing evidence explicitly. Checkpoint actions are selected from known codes; imported summaries retain their trust labels. Terminal merge results must match the current run and exact head. This focused implementation is rebased onto the current main, including native branch cleanup and inbox terminal suppression; it does not migrate the database or change publication authority.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
