### PR TITLE
feat(projects): link existing local clones and worktrees

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -807,3 +807,26 @@ apply 前会追加 `applying` 审计；每个工作区在删除前会重新扫�
 项目原名为 Starfix。由于 PyPI 已存在活跃的 `starfix` 包，且 GitHub 上已有同名开发工具，
 公开产品改名为 RepoSteward：Python distribution 和 CLI 均使用 `reposteward`，建议 GitHub
 仓库使用 `repo-steward`。旧状态目录和 `starfix.sqlite3` 数据库仍会被兼容读取。
+
+## 关联已经在本地开发的项目
+
+在项目 clone 或 worktree 中执行 `reposteward project link .`，即可登记本机
+工作区。命令返回稳定的项目 ID 和工作区 binding ID。相同 GitHub 仓库的多个
+clone/worktree 共用项目身份，各自保留工作区身份；子目录会解析到 Git 根目录。
+
+```bash
+reposteward project link /path/to/project --name 我的项目
+reposteward project inspect /path/to/project
+reposteward project list --limit 50
+reposteward project unlink <binding-id>
+```
+
+`inspect` 检查关联是否仍匹配，并显示当前 HEAD、分支和 dirty 状态。移动目录后
+可以重新关联新路径；旧路径会在列表中显示缺失。替换目录或修改 origin 指向后，
+需要明确解除旧关联再重新关联。`unlink` 只解除本地关联，不删除源码或 Git 历史。
+这些命令不连接 GitHub，不启动 coding agent，也不发布任何内容。
+
+登记保存在用户 state 目录的 `projects.sqlite3`，工作区路径不进入可移植任务包。
+关联身份与仓库执行策略分别配置：`repo add owner/repository --mode maintainer`
+生成维护者策略，其新配置的 `min_stars` 默认为 0；已有策略中的显式值保持不变。
+Contributor 模式仍默认 1000。执行验证前仍需设置命令白名单。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -75,6 +75,24 @@ def _parser() -> argparse.ArgumentParser:
         "--mode", choices=("contributor", "maintainer"), default="contributor"
     )
 
+    project = subparsers.add_parser("project", help="associate existing local projects")
+    project_commands = project.add_subparsers(dest="project_command", required=True)
+    project_link = project_commands.add_parser("link", help="link a clone or worktree")
+    project_link.add_argument("path", type=Path, nargs="?", default=Path.cwd())
+    project_link.add_argument("--name", default="")
+    project_inspect = project_commands.add_parser(
+        "inspect", help="inspect one linked workspace"
+    )
+    project_inspect.add_argument("path", type=Path, nargs="?", default=Path.cwd())
+    project_list = project_commands.add_parser(
+        "list", help="list local project identities"
+    )
+    project_list.add_argument("--limit", type=int, default=50)
+    project_unlink = project_commands.add_parser(
+        "unlink", help="remove a binding while keeping code"
+    )
+    project_unlink.add_argument("binding_id")
+
     issue = subparsers.add_parser("issue", help="prepare local issue drafts")
     issue_commands = issue.add_subparsers(dest="issue_command", required=True)
     issue_draft = issue_commands.add_parser(
@@ -557,6 +575,20 @@ def main(argv: list[str] | None = None) -> int:
                 f"unhandled benchmark command: {args.benchmark_command}"
             )
         config = load_config(args.config, include_user=True)
+        if args.command == "project":
+            from .projects import ProjectRegistry
+
+            registry = ProjectRegistry(config.state_dir / "projects.sqlite3")
+            if args.project_command == "link":
+                result = registry.link(args.path, name=args.name)
+            elif args.project_command == "inspect":
+                result = registry.inspect(args.path)
+            elif args.project_command == "list":
+                result = registry.list(limit=args.limit)
+            else:
+                result = registry.unlink(args.binding_id)
+            _json(result)
+            return 0
         if args.command == "trace":
             try:
                 policy = config.repositories[args.repository.casefold()]

--- a/src/reposteward/projects.py
+++ b/src/reposteward/projects.py
@@ -1,0 +1,385 @@
+"""User-owned local project identities and workspace bindings.
+
+The small registry is separate from the task ledger: machine paths are never
+portable task facts. Constructors and queries do not create or migrate files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import subprocess
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from .workspace import sanitized_environment
+
+PROJECT_SCHEMA_VERSION = 1
+MAX_GIT_OUTPUT = 1_000_000
+
+
+class ProjectError(RuntimeError):
+    """A project binding or its current local identity is not usable."""
+
+
+def canonical_digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+
+
+def local_git(path: Path, *args: str, optional: bool = False) -> str:
+    """Run a bounded local Git query without hooks, network or credentials."""
+    env = sanitized_environment(keep_codex_credentials=False)
+    # Ambient repository routing must not redirect an explicitly supplied path.
+    for name in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ):
+        env.pop(name, None)
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "--no-optional-locks",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.untrackedCache=false",
+                "-c",
+                "credential.helper=",
+                "-C",
+                str(path),
+                *args,
+            ],
+            capture_output=True,
+            check=False,
+            timeout=15,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ProjectError("local Git query unavailable") from exc
+    if len(result.stdout) > MAX_GIT_OUTPUT:
+        raise ProjectError("local Git result exceeds the metadata limit")
+    if result.returncode:
+        if optional and result.returncode == 1:
+            return ""
+        # Git stderr may include an original credential-bearing remote URL.
+        raise ProjectError("local Git query failed; inspect the selected workspace")
+    return result.stdout.decode("utf-8", errors="strict").rstrip("\n")
+
+
+def normalize_remote(raw: str) -> dict[str, str]:
+    if not raw or len(raw) > 4096 or any(ord(c) < 32 for c in raw):
+        raise ProjectError("invalid remote identity")
+    if "://" not in raw:
+        match = re.fullmatch(r"(?:[^/@:\s]+@)?([a-zA-Z0-9.-]+):([^\s]+)", raw)
+        if not match:
+            raise ProjectError("origin must identify a hosted repository")
+        raw = f"ssh://{match[1]}/{match[2]}"
+    try:
+        parsed = urlsplit(raw)
+        host = (parsed.hostname or "").casefold()
+        port = parsed.port
+    except ValueError as exc:
+        raise ProjectError("invalid remote identity") from exc
+    if parsed.scheme not in {"https", "ssh", "git"} or not re.fullmatch(
+        r"[a-z0-9.-]+", host
+    ):
+        raise ProjectError("unsupported remote identity")
+    if parsed.query or parsed.fragment or port not in {None, 22, 443, 9418}:
+        raise ProjectError("remote identity contains unsupported URL components")
+    path = parsed.path.removeprefix("/").removesuffix(".git")
+    parts = path.split("/")
+    if len(parts) != 2 or any(
+        not re.fullmatch(r"[A-Za-z0-9_.-]+", p) or p in {".", ".."} for p in parts
+    ):
+        raise ProjectError("origin must identify owner/repository")
+    repository = path.casefold() if host == "github.com" else path
+    return {"host": host, "repository": repository, "identity": f"{host}/{repository}"}
+
+
+def workspace_metadata(path: Path) -> dict[str, Any]:
+    start = path.expanduser().resolve(strict=True)
+    if not start.is_dir():
+        raise ProjectError("workspace must be a directory")
+    root = Path(local_git(start, "rev-parse", "--show-toplevel")).resolve(strict=True)
+    if not start.is_relative_to(root):
+        raise ProjectError("Git root is outside the selected workspace")
+    git_dir = Path(local_git(root, "rev-parse", "--absolute-git-dir")).resolve(
+        strict=True
+    )
+    common = Path(
+        local_git(root, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    ).resolve(strict=True)
+    if any(ord(c) < 32 for c in str(root)):
+        raise ProjectError("workspace path contains control characters")
+    remote = normalize_remote(
+        local_git(root, "config", "--no-includes", "--get", "remote.origin.url")
+    )
+    root_stat, git_stat = root.stat(), git_dir.stat()
+    fingerprint = canonical_digest(
+        {
+            "root_device": root_stat.st_dev,
+            "root_inode": root_stat.st_ino,
+            "git_directory": str(git_dir),
+            "git_device": git_stat.st_dev,
+            "git_inode": git_stat.st_ino,
+            "common_directory": str(common),
+        }
+    )
+    return {
+        "root": str(root),
+        "git_directory": str(git_dir),
+        "common_directory": str(common),
+        "fingerprint": fingerprint,
+        **remote,
+    }
+
+
+def workspace_state(root: Path) -> dict[str, Any]:
+    head = local_git(root, "rev-parse", "--verify", "HEAD")
+    branch = local_git(root, "symbolic-ref", "--short", "-q", "HEAD", optional=True)
+    status = local_git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=normal"
+    )
+    return {"head": head, "branch": branch, "dirty": bool(status)}
+
+
+class ProjectRegistry:
+    def __init__(self, path: Path):
+        self.path = path.expanduser().resolve()
+
+    @contextmanager
+    def connection(self, *, write: bool = False) -> Iterator[sqlite3.Connection | None]:
+        if not write and not self.path.exists():
+            yield None
+            return
+        if write:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        db = sqlite3.connect(
+            str(self.path) if write else self.path.as_uri() + "?mode=ro",
+            uri=not write,
+            timeout=10,
+            isolation_level=None,
+        )
+        db.row_factory = sqlite3.Row
+        try:
+            db.execute("PRAGMA foreign_keys=ON")
+            if not write:
+                db.execute("PRAGMA query_only=ON")
+            db.execute("BEGIN IMMEDIATE" if write else "BEGIN")
+            version = int(db.execute("PRAGMA user_version").fetchone()[0])
+            if write and version == 0:
+                if db.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' LIMIT 1"
+                ).fetchone():
+                    raise ProjectError("unknown project registry schema")
+                db.execute("""CREATE TABLE projects (
+                    id TEXT PRIMARY KEY, identity TEXT NOT NULL UNIQUE,
+                    host TEXT NOT NULL, repository TEXT NOT NULL,
+                    name TEXT NOT NULL, created_at TEXT NOT NULL)""")
+                db.execute("""CREATE TABLE workspace_bindings (
+                    id TEXT PRIMARY KEY, project_id TEXT NOT NULL REFERENCES projects(id),
+                    root TEXT NOT NULL UNIQUE, fingerprint TEXT NOT NULL,
+                    active INTEGER NOT NULL DEFAULT 1, created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL)""")
+                db.execute(
+                    "CREATE INDEX project_workspaces ON workspace_bindings(project_id,active)"
+                )
+                db.execute("""CREATE TABLE project_events (
+                    sequence INTEGER PRIMARY KEY, binding_id TEXT NOT NULL,
+                    kind TEXT NOT NULL, created_at TEXT NOT NULL)""")
+                db.execute(f"PRAGMA user_version={PROJECT_SCHEMA_VERSION}")
+                version = PROJECT_SCHEMA_VERSION
+            if version != PROJECT_SCHEMA_VERSION:
+                raise ProjectError(f"unsupported project registry schema {version}")
+            yield db
+            if write:
+                db.commit()
+            else:
+                db.rollback()
+        except BaseException:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    def link(self, path: Path, *, name: str = "") -> dict[str, Any]:
+        meta = workspace_metadata(path)
+        label = name.strip() or meta["repository"].split("/")[-1]
+        if len(label) > 120 or any(ord(c) < 32 for c in label):
+            raise ProjectError("project name must be at most 120 printable characters")
+        project_id = uuid.uuid5(uuid.NAMESPACE_URL, meta["identity"]).hex
+        binding_id = uuid.uuid5(uuid.NAMESPACE_URL, "workspace:" + meta["root"]).hex
+        now = datetime.now(UTC).isoformat()
+        with self.connection(write=True) as db:
+            assert db is not None
+            existing = db.execute(
+                "SELECT * FROM workspace_bindings WHERE root=?", (meta["root"],)
+            ).fetchone()
+            if (
+                existing
+                and existing["active"]
+                and (
+                    existing["fingerprint"] != meta["fingerprint"]
+                    or existing["project_id"] != project_id
+                )
+            ):
+                raise ProjectError(
+                    "workspace identity changed; unlink before explicitly rebinding"
+                )
+            db.execute(
+                "INSERT OR IGNORE INTO projects VALUES (?,?,?,?,?,?)",
+                (
+                    project_id,
+                    meta["identity"],
+                    meta["host"],
+                    meta["repository"],
+                    label,
+                    now,
+                ),
+            )
+            if not existing or not existing["active"]:
+                db.execute(
+                    """INSERT INTO workspace_bindings VALUES (?,?,?,?,1,?,?)
+                    ON CONFLICT(root) DO UPDATE SET project_id=excluded.project_id,
+                    fingerprint=excluded.fingerprint,active=1,updated_at=excluded.updated_at""",
+                    (
+                        binding_id,
+                        project_id,
+                        meta["root"],
+                        meta["fingerprint"],
+                        now,
+                        now,
+                    ),
+                )
+                db.execute(
+                    "INSERT INTO project_events(binding_id,kind,created_at) VALUES (?,?,?)",
+                    (binding_id, "linked", now),
+                )
+        return self.inspect(path)
+
+    def inspect(self, path: Path) -> dict[str, Any]:
+        meta = workspace_metadata(path)
+        with self.connection() as db:
+            row = (
+                db.execute(
+                    "SELECT * FROM workspace_bindings WHERE root=? AND active=1",
+                    (meta["root"],),
+                ).fetchone()
+                if db
+                else None
+            )
+            if row is None:
+                raise ProjectError(
+                    "workspace is not linked; run reposteward project link"
+                )
+            project = db.execute(
+                "SELECT * FROM projects WHERE id=?", (row["project_id"],)
+            ).fetchone()
+            if (
+                project is None
+                or row["fingerprint"] != meta["fingerprint"]
+                or project["identity"] != meta["identity"]
+            ):
+                raise ProjectError("workspace identity changed; explicitly rebind it")
+            binding = dict(row)
+            state = workspace_state(Path(meta["root"]))
+            if workspace_metadata(Path(meta["root"])) != meta:
+                raise ProjectError("workspace identity changed during inspection")
+            result = {
+                "schema_version": 1,
+                "project": dict(project),
+                "binding": binding,
+                "workspace": state,
+                "public_write": False,
+            }
+        return result
+
+    def list(self, *, limit: int = 50) -> dict[str, Any]:
+        if type(limit) is not int or not 1 <= limit <= 500:
+            raise ProjectError("project limit must be between 1 and 500")
+        with self.connection() as db:
+            if db is None:
+                return {
+                    "schema_version": 1,
+                    "projects": [],
+                    "omitted": 0,
+                    "public_write": False,
+                }
+            total = db.execute("SELECT count(*) FROM projects").fetchone()[0]
+            rows = db.execute(
+                "SELECT * FROM projects ORDER BY identity LIMIT ?", (limit,)
+            ).fetchall()
+            projects = []
+            for row in rows:
+                count = db.execute(
+                    "SELECT count(*) FROM workspace_bindings WHERE project_id=? AND active=1",
+                    (row["id"],),
+                ).fetchone()[0]
+                bindings = db.execute(
+                    "SELECT id,root FROM workspace_bindings WHERE project_id=? AND active=1 ORDER BY root LIMIT 100",
+                    (row["id"],),
+                ).fetchall()
+                missing = sum(not Path(b["root"]).is_dir() for b in bindings)
+                projects.append(
+                    {
+                        **dict(row),
+                        "workspace_count": count,
+                        "missing_workspaces": missing,
+                        "workspace_check_omitted": max(0, count - 100),
+                        "workspaces": [dict(b) for b in bindings],
+                    }
+                )
+        return {
+            "schema_version": 1,
+            "projects": projects,
+            "omitted": max(0, total - limit),
+            "public_write": False,
+        }
+
+    def unlink(self, binding_id: str) -> dict[str, Any]:
+        if not re.fullmatch(r"[a-f0-9]{32}", binding_id):
+            raise ProjectError("invalid workspace binding ID")
+        with self.connection(write=True) as db:
+            assert db is not None
+            row = db.execute(
+                "SELECT active FROM workspace_bindings WHERE id=?", (binding_id,)
+            ).fetchone()
+            if row is None:
+                raise ProjectError("workspace binding does not exist")
+            if row["active"]:
+                now = datetime.now(UTC).isoformat()
+                db.execute(
+                    "UPDATE workspace_bindings SET active=0,updated_at=? WHERE id=?",
+                    (now, binding_id),
+                )
+                db.execute(
+                    "INSERT INTO project_events(binding_id,kind,created_at) VALUES (?,?,?)",
+                    (binding_id, "unlinked", now),
+                )
+        return {
+            "binding_id": binding_id,
+            "active": False,
+            "files_deleted": False,
+            "public_write": False,
+        }

--- a/src/reposteward/setup.py
+++ b/src/reposteward/setup.py
@@ -224,6 +224,7 @@ auto_merge_method = "squash"
 owner_attestation = false
 mode = {_toml_string(mode)}
 submission_strategy = {_toml_string("same-repository" if mode == "maintainer" else "fork")}
+min_stars = {0 if mode == "maintainer" else 1000}
 require_no_competing_work = true
 bootstrap_commands = []
 verification_prefixes = []

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing, redirect_stdout
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from reposteward.cli import main
+from reposteward.config import load_config
+from reposteward.projects import ProjectError, ProjectRegistry, normalize_remote
+from reposteward.setup import add_repository, initialize_user_config
+
+
+def git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "core.hooksPath=/dev/null", *args],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def repository(root: Path, remote: str = "https://github.com/Owner/Repo.git") -> Path:
+    root.mkdir()
+    git(root, "init", "--initial-branch=main")
+    git(root, "config", "user.name", "Test")
+    git(root, "config", "user.email", "test@example.invalid")
+    git(root, "config", "commit.gpgsign", "false")
+    git(root, "remote", "add", "origin", remote)
+    (root / "source.txt").write_text("initial\n")
+    git(root, "add", "source.txt")
+    git(root, "commit", "-m", "Initial")
+    return root
+
+
+class ProjectTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.repo = repository(self.root / "checkout")
+        self.db = self.root / "state/projects.sqlite3"
+        self.registry = ProjectRegistry(self.db)
+
+    def test_read_does_not_create_or_migrate_database(self) -> None:
+        self.assertEqual(self.registry.list()["projects"], [])
+        self.assertFalse(self.db.exists())
+        with self.assertRaises(ProjectError):
+            self.registry.inspect(self.repo)
+        self.assertFalse(self.db.exists())
+        self.registry.link(self.repo)
+        with closing(sqlite3.connect(self.db)) as db:
+            db.execute("PRAGMA user_version=99")
+        before = self.db.read_bytes()
+        with self.assertRaisesRegex(ProjectError, "schema"):
+            self.registry.list()
+        self.assertEqual(before, self.db.read_bytes())
+
+    def test_link_subdirectory_and_dirty_inspection_are_idempotent(self) -> None:
+        (self.repo / "src").mkdir()
+        first = self.registry.link(self.repo / "src")
+        again = self.registry.link(self.repo)
+        self.assertEqual(first["project"]["id"], again["project"]["id"])
+        self.assertEqual(first["binding"]["id"], again["binding"]["id"])
+        self.assertFalse(first["workspace"]["dirty"])
+        (self.repo / "source.txt").write_text("changed\n")
+        report = self.registry.inspect(self.repo / "src")
+        self.assertTrue(report["workspace"]["dirty"])
+        self.assertEqual(report["project"]["repository"], "owner/repo")
+        self.assertEqual(len(self.registry.list()["projects"]), 1)
+
+    def test_worktree_and_second_clone_share_project_but_not_binding(self) -> None:
+        first = self.registry.link(self.repo)
+        worktree = self.root / "worktree"
+        git(self.repo, "worktree", "add", "-b", "feature", str(worktree))
+        second = self.registry.link(worktree)
+        third = self.registry.link(repository(self.root / "clone"))
+        self.assertEqual(
+            {x["project"]["id"] for x in (first, second, third)},
+            {first["project"]["id"]},
+        )
+        self.assertEqual(len({x["binding"]["id"] for x in (first, second, third)}), 3)
+        self.assertEqual(self.registry.list()["projects"][0]["workspace_count"], 3)
+
+    def test_identity_changes_require_explicit_rebinding(self) -> None:
+        self.registry.link(self.repo)
+        git(
+            self.repo,
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:owner/different.git",
+        )
+        with self.assertRaisesRegex(ProjectError, "identity"):
+            self.registry.inspect(self.repo)
+        with self.assertRaisesRegex(ProjectError, "identity"):
+            self.registry.link(self.repo)
+
+    def test_unlink_preserves_files_and_can_be_repeated(self) -> None:
+        bound = self.registry.link(self.repo)
+        head = git(self.repo, "rev-parse", "HEAD")
+        self.registry.unlink(bound["binding"]["id"])
+        self.registry.unlink(bound["binding"]["id"])
+        self.assertTrue((self.repo / "source.txt").exists())
+        self.assertEqual(git(self.repo, "rev-parse", "HEAD"), head)
+        self.assertEqual(self.registry.list()["projects"][0]["workspace_count"], 0)
+        with self.assertRaises(ProjectError):
+            self.registry.inspect(self.repo)
+        self.assertEqual(
+            self.registry.link(self.repo)["project"]["id"], bound["project"]["id"]
+        )
+
+    def test_missing_moved_directory_is_visible_and_can_be_linked_again(self) -> None:
+        first = self.registry.link(self.repo)
+        moved = self.root / "moved"
+        self.repo.rename(moved)
+        self.assertEqual(self.registry.list()["projects"][0]["missing_workspaces"], 1)
+        self.assertEqual(
+            self.registry.link(moved)["project"]["id"], first["project"]["id"]
+        )
+
+    def test_concurrent_link_has_one_identity(self) -> None:
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            ids = list(
+                pool.map(
+                    lambda _: self.registry.link(self.repo)["binding"]["id"], range(4)
+                )
+            )
+        self.assertEqual(len(set(ids)), 1)
+        self.assertEqual(self.registry.list()["projects"][0]["workspace_count"], 1)
+
+    def test_normalized_remote_discards_auth_and_rejects_ambiguous_urls(self) -> None:
+        expected = "github.com/owner/repo"
+        for raw in (
+            "https://example:fake-password@github.com/Owner/Repo.git",
+            "ssh://git@github.com/Owner/Repo.git",
+            "git@github.com:Owner/Repo.git",
+        ):
+            self.assertEqual(normalize_remote(raw)["identity"], expected)
+        for raw in (
+            "/tmp/repo",
+            "https://github.com/a/b?token=example",
+            "https://github.com/a/../b",
+            "https://github.com/a/b#fragment",
+        ):
+            with self.assertRaises(ProjectError):
+                normalize_remote(raw)
+
+    def test_managed_metadata_does_not_run_repository_fsmonitor(self) -> None:
+        marker = self.root / "fsmonitor-ran"
+        script = self.root / "monitor.sh"
+        script.write_text(f"#!/bin/sh\ntouch {marker}\n")
+        script.chmod(0o755)
+        git(self.repo, "config", "core.fsmonitor", str(script))
+        self.registry.link(self.repo)
+        self.assertFalse(marker.exists())
+
+    def test_maintainer_scaffold_has_personal_repository_star_default(self) -> None:
+        user = self.root / "user.toml"
+        initialize_user_config(path=user, login="owner")
+        for mode, minimum in (("maintainer", 0), ("contributor", 1000)):
+            config = self.root / f"{mode}.toml"
+            add_repository("owner/repo", path=config, mode=mode)
+            self.assertEqual(
+                load_config(config, user_path=user)
+                .repositories["owner/repo"]
+                .min_stars,
+                minimum,
+            )
+
+    def test_project_cli_never_constructs_pipeline(self) -> None:
+        user = self.root / "user.toml"
+        initialize_user_config(path=user, login="owner")
+        config = replace(load_config(user), state_dir=self.root / "cli-state")
+        with (
+            patch("reposteward.cli.load_config", return_value=config),
+            patch(
+                "reposteward.cli.Pipeline",
+                side_effect=AssertionError("unexpected Pipeline"),
+            ),
+            redirect_stdout(io.StringIO()) as output,
+        ):
+            self.assertEqual(main(["project", "link", str(self.repo)]), 0)
+        self.assertEqual(
+            json.loads(output.getvalue())["project"]["repository"], "owner/repo"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #96

Link existing local Git clones and worktrees to stable project identities with reposteward project link, inspect, list and unlink.

---

Ordinary clones and worktrees of the same GitHub repository share a project identity while retaining separate local workspace bindings. Inspection detects missing paths and changed repository identity; unlink removes the association without deleting source. Registration uses a separate local projects database, performs no GitHub or agent calls, and keeps machine paths out of portable task context. Newly generated maintainer policies default min_stars to zero; explicit existing policy and contributor defaults are preserved.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
