### PR TITLE
feat(repair): support owned maintainer pull request heads

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -869,3 +869,16 @@ Context Pack / Portable Bundle v3 把 `task_contract`、`repair_feedback` 与 `c
 分词器无关。编译器可以缩短描述或省略可取回的历史摘要，但不会裁剪必须任务契约。
 最小必须集合无法放入预算时明确失败，需要增加预算或明确审阅更短的契约。
 `coverage` 记录描述、检查点字段和列表、skills 目录的省略数量、原因、来源和摘要。
+
+## 维护者修复同仓库 PR
+
+`repair <submitted-run-id>` 支持 `mode="maintainer"` 且
+`submission_strategy="same-repository"` 的已纳管 PR。开工前重新确认认证身份与
+配置登录名一致、该身份仍有仓库推送权限，PR 作者、head 仓库与工作分支均符合
+已登记事实；默认分支、外部作者分支和 fork head 不能进入这一维护者路径。
+Issue 必须仍满足当前贡献门禁，工作区须干净，HEAD/base/policy 须与原验证一致。
+
+修复继续使用未处理反馈、隔离 Harness 和加固验证器，结果只进入本地 ready。
+检查新提交后另行 `submit --reviewed-by <login>`，仍需
+`REPOSTEWARD_ENABLE_SUBMIT=1`。提交前重新核对 head 归属和冻结事实；原提交的审阅
+记录不作为新提交的审阅。Contributor fork 修复路径保留。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -407,7 +407,7 @@ def _parser() -> argparse.ArgumentParser:
 
     repair = subparsers.add_parser(
         "repair",
-        help="prepare and verify one contributor repair from new PR activity",
+        help="prepare and verify one repair from unprocessed PR feedback",
     )
     repair.add_argument("run_id", help="submitted run whose pull request changed")
 

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -944,6 +944,25 @@ class GitHubClient:
         payload, _ = self._request("GET", f"/repos/{upstream}/pulls/{number}")
         return self._parse_pull_request(payload)
 
+    def pull_request_head_identity(
+        self, repository: str, number: int
+    ) -> dict[str, Any]:
+        """Read the exact PR head owner and repository without fetching comments."""
+        value, _ = self._request("GET", f"/repos/{repository}/pulls/{number}")
+        head, base = value.get("head") or {}, value.get("base") or {}
+        head_repo = head.get("repo") or {}
+        return {
+            "number": int(value["number"]),
+            "state": str(value.get("state") or ""),
+            "author": str((value.get("user") or {}).get("login") or ""),
+            "head_owner": str((head_repo.get("owner") or {}).get("login") or ""),
+            "head_repository": str(head_repo.get("full_name") or ""),
+            "head_branch": str(head.get("ref") or ""),
+            "head_sha": str(head.get("sha") or ""),
+            "base_branch": str(base.get("ref") or ""),
+            "base_sha": str(base.get("sha") or ""),
+        }
+
     def pull_request_activity(
         self, upstream: str, number: int, *, include_body: bool = False
     ) -> dict[str, Any]:

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -80,6 +80,7 @@ from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
 from .store import QueueLease, RunLease, Store, StoreError
+from .task_contract import TaskContract
 from .usage import (
     build_usage_report,
     compact_usage_budget,
@@ -4055,15 +4056,59 @@ class Pipeline:
         ):
             return self._prepare_repair_leased(source_run_id)
 
+    @staticmethod
+    def _validate_repair_mode(policy: RepositoryPolicy) -> None:
+        if (policy.mode, policy.submission_strategy) not in {
+            ("contributor", "fork"),
+            ("maintainer", "same-repository"),
+        }:
+            raise PolicyError(
+                "repair requires contributor fork or maintainer same-repository mode"
+            )
+
+    def _validate_maintainer_repair_identity(
+        self,
+        client: GitHubClient,
+        policy: RepositoryPolicy,
+        details: dict[str, Any],
+        pull: dict[str, Any],
+    ) -> None:
+        if policy.mode != "maintainer":
+            return
+        actor = self.config.github.login.casefold()
+        if client.authenticated_login().casefold() != actor:
+            raise PolicyError(
+                "maintainer repair identity differs from configured login"
+            )
+        repository = client.repository(policy.name)
+        if not repository.can_push:
+            raise PolicyError("maintainer repair requires repository push permission")
+        identity = client.pull_request_head_identity(policy.name, int(pull["number"]))
+        if (
+            identity["author"].casefold() != actor
+            or identity["head_repository"].casefold() != policy.name.casefold()
+            or identity["head_owner"].casefold() != policy.name.split("/")[0].casefold()
+            or not details.get("branch")
+            or identity["head_branch"] != details["branch"]
+            or identity["head_branch"] == repository.default_branch
+        ):
+            raise PolicyError(
+                "maintainer repair requires the exact owned same-repository feature branch"
+            )
+        if any(
+            identity[key] != pull.get(key)
+            for key in ("number", "state", "head_sha", "base_sha", "base_branch")
+        ):
+            raise PolicyError("pull request changed while checking repair identity")
+
     def _prepare_repair_leased(self, source_run_id: str) -> dict[str, Any]:
-        """Prepare one contributor repair from newly committed PR activity."""
+        """Prepare one verified local repair from unprocessed PR feedback."""
         source_run = self.store.run(source_run_id)
         if source_run is None:
             raise KeyError(f"run not found: {source_run_id}")
         repository = str(source_run["repository"])
         policy = self.policy(repository)
-        if policy.mode != "contributor" or policy.submission_strategy != "fork":
-            raise PolicyError("repair is available only for contributor fork workflows")
+        self._validate_repair_mode(policy)
         if str(source_run.get("status")) != "submitted":
             raise PolicyError("repair requires a submitted pull-request run")
         details = source_run.get("details", {})
@@ -4073,10 +4118,20 @@ class Pipeline:
         pull_number = int(match.group(1))
 
         follow = self._follow_up(source_run_id, commit=False)
+        if policy.mode == "maintainer":
+            self._validate_maintainer_repair_identity(
+                self.github, policy, details, follow["pull_request"]
+            )
+            if not self.gate_status(repository, int(source_run["issue_number"]))[
+                "submission_ready"
+            ]:
+                raise PolicyError(
+                    "maintainer repair requires the current Issue contribution gates"
+                )
         if not follow["head_matches_verified_commit"]:
             raise PolicyError("pull request head changed; re-adopt and verify it first")
         if follow["next_action"] in {"complete", "inspect_closed_pull_request"}:
-            raise PolicyError("pull request is no longer open for a contributor repair")
+            raise PolicyError("pull request is no longer open for repair")
         if not follow.get("context_plan", {}).get("actionable") and (
             follow.get("_pending_suggestions")
             or follow.get("pending_feedback", {}).get("unknown")
@@ -4251,6 +4306,25 @@ class Pipeline:
                 event_batch_digest=str(follow["event_batch_digest"]),
                 repair_context=repair_context,
                 budget_tokens=int(context_plan["budget_tokens"]),
+                task_contract=(
+                    TaskContract(
+                        **{
+                            **source_context["context_pack"]["task_contract"],
+                            "acceptance_criteria": tuple(
+                                source_context["context_pack"]["task_contract"][
+                                    "acceptance_criteria"
+                                ]
+                            ),
+                            "scope_boundaries": tuple(
+                                source_context["context_pack"]["task_contract"][
+                                    "scope_boundaries"
+                                ]
+                            ),
+                        }
+                    )
+                    if source_context["context_pack"].get("schema_version") == 3
+                    else None
+                ),
             )
             failure_details["context_budget"] = final_prompt_budget
             selected_sequences = set(final_prompt_budget["retained_event_sequences"])
@@ -4459,8 +4533,7 @@ class Pipeline:
         guard = details.get("repair_guard")
         if not isinstance(guard, dict):
             return
-        if policy.mode != "contributor" or policy.submission_strategy != "fork":
-            raise PolicyError("prepared contributor repair has an invalid policy mode")
+        self._validate_repair_mode(policy)
         source_run_id = str(guard.get("source_run_id") or "")
         source_run = self.store.run(source_run_id)
         if source_run is None or str(source_run.get("status")) != "submitted":
@@ -4475,6 +4548,7 @@ class Pipeline:
         )
         snapshot = client.pull_request_merge_snapshot(policy.name, pull_number)
         pull = activity["pull_request"]
+        self._validate_maintainer_repair_identity(client, policy, details, pull)
         expected_sequence = int(guard.get("event_watermark") or 0)
         stale: list[str] = []
         if (

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -22,6 +22,7 @@ from reposteward.models import (
 from reposteward.pipeline import Pipeline
 from reposteward.policy import DiffSummary
 from reposteward.store import Store
+from reposteward.task_contract import issue_digest, review_contract
 
 
 class FeedbackTests(unittest.TestCase):
@@ -213,6 +214,37 @@ class FeedbackTests(unittest.TestCase):
                 for row in evidence
             )
         )
+
+    def test_repair_reuses_the_reviewed_source_contract(self) -> None:
+        issue = _candidate().issue
+        contract = review_contract(
+            issue,
+            {
+                "goal": issue.title,
+                "source_digest": issue_digest(issue),
+                "acceptance_criteria": ["Preserve the reviewed condition"],
+            },
+            reviewed_by="operator",
+        )
+        original = self.store.context_bundle
+
+        def bundle(run_id):
+            value = original(run_id)
+            if run_id == self.run_id:
+                value = {
+                    **value,
+                    "context_pack": {
+                        **value["context_pack"],
+                        "task_contract": contract.to_dict(),
+                    },
+                }
+            return value
+
+        self.store.context_bundle = bundle
+        self.pipeline.follow_up(self.run_id)
+        self.prepare()
+        request = self.pipeline.harness.run.call_args.args[0]
+        self.assertEqual(request.context.task_contract.digest, contract.digest)
 
     def test_failure_preserves_every_item_for_retry(self) -> None:
         self.pipeline.follow_up(self.run_id)

--- a/tests/test_maintainer_repair.py
+++ b/tests/test_maintainer_repair.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+
+import test_feedback
+
+from reposteward.context import repository_policy_digest
+from reposteward.pipeline import _canonical_digest
+from reposteward.policy import PolicyError
+
+
+class MaintainerRepairTests(test_feedback.FeedbackTests):
+    def setUp(self) -> None:
+        super().setUp()
+        self.policy = replace(
+            self.policy, mode="maintainer", submission_strategy="same-repository"
+        )
+        self.pipeline.config.repositories = {"owner/repo": self.policy}
+        self.pipeline.config.github = SimpleNamespace(login="owner")
+        self.pipeline.github.authenticated_login.return_value = "owner"
+        self.pipeline.github.repository.return_value = SimpleNamespace(
+            can_push=True, default_branch="main"
+        )
+        self.identity = {
+            **self.activity["pull_request"],
+            "author": "owner",
+            "head_owner": "owner",
+            "head_repository": "owner/repo",
+            "head_branch": "fix",
+        }
+        self.pipeline.github.pull_request_head_identity.side_effect = lambda *args: {
+            **self.identity,
+            "head_sha": self.activity["pull_request"]["head_sha"],
+        }
+        self.pipeline.github.issue.return_value = replace(
+            test_feedback._candidate().issue, assignees=("owner",)
+        )
+        self.pipeline.github.has_maintainer_approval.return_value = True
+        self.pipeline.github.competing_work.return_value = ()
+        # The inherited fixture's frozen policy must describe this maintainer workflow.
+        bundle = self.store.context_bundle(self.run_id)
+        pack = bundle["context_pack"]
+        pack["project"]["policy_digest"] = repository_policy_digest(self.policy)
+        original_bundle = self.store.context_bundle
+        self.store.context_bundle = lambda run_id: (
+            {**original_bundle(run_id), "context_pack": pack}
+            if run_id == self.run_id
+            else original_bundle(run_id)
+        )
+
+    def test_unowned_fork_and_default_heads_stop_before_harness(self) -> None:
+        self.pipeline.follow_up(self.run_id)
+        for changes in (
+            {"author": "other"},
+            {"head_repository": "fork/repo"},
+            {"head_branch": "other"},
+            {"head_branch": "main"},
+            {"head_owner": "other"},
+        ):
+            original = dict(self.identity)
+            self.identity.update(changes)
+            with (
+                self.subTest(changes=changes),
+                self.assertRaisesRegex(PolicyError, "exact owned"),
+            ):
+                self.prepare()
+            self.identity = original
+        self.pipeline.harness.run.assert_not_called()
+
+    def test_permission_authentication_and_issue_gates_stop_before_harness(
+        self,
+    ) -> None:
+        self.pipeline.follow_up(self.run_id)
+        self.pipeline.github.repository.return_value.can_push = False
+        with self.assertRaisesRegex(PolicyError, "push permission"):
+            self.prepare()
+        self.pipeline.github.repository.return_value.can_push = True
+        self.pipeline.github.authenticated_login.return_value = "different"
+        with self.assertRaisesRegex(PolicyError, "configured login"):
+            self.prepare()
+        self.pipeline.github.authenticated_login.return_value = "owner"
+        self.pipeline.github.issue.return_value = replace(
+            self.pipeline.github.issue.return_value, state="closed"
+        )
+        with self.assertRaisesRegex(PolicyError, "contribution gates"):
+            self.prepare()
+        self.pipeline.harness.run.assert_not_called()
+
+    def test_prepared_maintainer_repair_keeps_fresh_submission_guard(self) -> None:
+        self.pipeline.follow_up(self.run_id)
+        ready = self.prepare()
+        details = ready["details"]
+        # Same snapshot and observation watermark are eligible for the separate submit path.
+        self.assertEqual(
+            details["repair_guard"]["snapshot_digest"],
+            _canonical_digest(
+                self.pipeline.github.pull_request_merge_snapshot.return_value
+            ),
+        )
+        self.pipeline._validate_repair_submission(
+            client=self.pipeline.github, policy=self.policy, details=details
+        )
+        self.identity["author"] = "different"
+        with self.assertRaisesRegex(PolicyError, "exact owned"):
+            self.pipeline._validate_repair_submission(
+                client=self.pipeline.github, policy=self.policy, details=details
+            )
+        self.pipeline.github.create_pull_request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #109

Allow reviewed maintainer repairs on the exact owned, same-repository PR head.

---

Recheck authenticated identity, push permission, author, head repository, branch and current contribution gates before repair. Preserve contributor fork behavior, keep external authors and default branches out of the maintainer path, and reuse the reviewed source task contract in successor repairs. The previously reviewed integration regression is included. Repairs become locally ready after verification; publication still requires a separate submit.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
