### PR TITLE
feat(tasks): track external development with durable task checkpoints

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -882,3 +882,44 @@ Issue 必须仍满足当前贡献门禁，工作区须干净，HEAD/base/policy 
 检查新提交后另行 `submit --reviewed-by <login>`，仍需
 `REPOSTEWARD_ENABLE_SUBMIT=1`。提交前重新核对 head 归属和冻结事实；原提交的审阅
 记录不作为新提交的审阅。Contributor fork 修复路径保留。
+
+## 在自己启动的 Agent 中开发
+
+先关联项目，在独立 feature branch 上为已审阅的开放 Issue 开工：
+
+```bash
+reposteward project link /path/to/project
+reposteward task start /path/to/project --issue 123 --reviewed-by your-login
+reposteward task context <run-id> --format markdown
+reposteward task current /path/to/project --format markdown
+reposteward task inspect <run-id> --live
+```
+
+`start` 在线核对 Issue 的贡献门禁和本地 origin 基线，保存开发前的契约、指导来源、
+HEAD/base/policy 和快照。它不启动模型，也不修改源代码。源码存在未提交改动时可以
+登记开发快照，仍需独立分支。快照包含 tracked 和非忽略 untracked 文件，排除未跟踪
+敏感文件及缓存；数量或字节超限、特殊文件和无法安全解析的子模块明确拒绝。
+
+查询已有任务不需要 GitHub 认证或 Agent 安装。默认使用本地记录，`--live` 另外检查
+当前本地绑定；`task current` 返回所选工作区最新的活跃外部任务，并核对其
+当前本地绑定、代码与策略；这不等同于刷新线上 Issue。JSON 与 Markdown 由同一任务
+事实生成。任务契约、完整开放项、决定和下一步不能因输出预算静默丢失。
+
+在阶段结束时，把 Agent 自述写入一个 JSON 文件，例如：
+
+```json
+{"completed":["已完成初步调查"],"remaining":["补齐边界验证"],"next_action":"验证空输入"}
+```
+
+用 `task inspect --live` 返回的 revision 与 current_snapshot.digest 保存检查点：
+
+```bash
+reposteward task checkpoint <run-id> --expected-revision 0 \
+  --expected-snapshot <digest> --idempotency-key investigation-1 --input checkpoint.json
+```
+
+相同 key 和输入可以重试；过期 revision、代码变化或相同 key 对应不同内容会报冲突。
+省略的字段继承上一检查点，不会清空开放项。记录仍是 `running`，完成和测试声明是
+`agent_unverified`；Agent 不能用此入口设置 ready、verified 或人工审阅状态。
+数据库写入失败会同时回滚 checkpoint 与 revision。较旧包晚导入不取代当前外部任务
+的本地检查点。开发完毕后的发布资格继续通过干净提交的 `adopt`、验证和独立审阅取得。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -93,6 +93,44 @@ def _parser() -> argparse.ArgumentParser:
     )
     project_unlink.add_argument("binding_id")
 
+    task = subparsers.add_parser(
+        "task", help="assist coding agents in linked local projects"
+    )
+    task_commands = task.add_subparsers(dest="task_command", required=True)
+    task_start = task_commands.add_parser(
+        "start", help="freeze a reviewed Issue before external development"
+    )
+    task_start.add_argument("path", type=Path, nargs="?", default=Path.cwd())
+    task_start.add_argument("--issue", type=int, required=True)
+    task_start.add_argument("--reviewed-by", required=True)
+    task_start.add_argument("--contract", type=Path)
+    task_inspect = task_commands.add_parser(
+        "inspect", help="read an external development attempt"
+    )
+    task_inspect.add_argument("run_id")
+    task_inspect.add_argument("--live", action="store_true")
+    task_context = task_commands.add_parser(
+        "context", help="compile a bounded external task handoff"
+    )
+    task_context.add_argument("run_id")
+    task_context.add_argument("--budget", type=int, default=24_000)
+    task_context.add_argument("--live", action="store_true")
+    task_context.add_argument("--format", choices=("json", "markdown"), default="json")
+    task_current = task_commands.add_parser(
+        "current", help="get the current task for a linked workspace"
+    )
+    task_current.add_argument("path", type=Path, nargs="?", default=Path.cwd())
+    task_current.add_argument("--budget", type=int, default=24_000)
+    task_current.add_argument("--format", choices=("json", "markdown"), default="json")
+    task_checkpoint = task_commands.add_parser(
+        "checkpoint", help="save unverified Agent claims with revision checks"
+    )
+    task_checkpoint.add_argument("run_id")
+    task_checkpoint.add_argument("--expected-revision", type=int, required=True)
+    task_checkpoint.add_argument("--expected-snapshot", required=True)
+    task_checkpoint.add_argument("--idempotency-key", required=True)
+    task_checkpoint.add_argument("--input", type=Path, required=True)
+
     issue = subparsers.add_parser("issue", help="prepare local issue drafts")
     issue_commands = issue.add_subparsers(dest="issue_command", required=True)
     issue_draft = issue_commands.add_parser(
@@ -575,6 +613,56 @@ def main(argv: list[str] | None = None) -> int:
                 f"unhandled benchmark command: {args.benchmark_command}"
             )
         config = load_config(args.config, include_user=True)
+        if args.command == "task":
+            from .external_tasks import ExternalTasks
+
+            service = ExternalTasks(config)
+
+            def read_task_input(path: Path) -> dict:
+                if path.stat().st_size > 100_000:
+                    raise ValueError("task input exceeds the 100000 byte limit")
+                value = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(value, dict):
+                    raise ConfigError("task input must be a JSON object")
+                return value
+
+            if args.task_command == "start":
+                result = service.start(
+                    args.path,
+                    issue_number=args.issue,
+                    reviewed_by=args.reviewed_by,
+                    contract_proposal=read_task_input(args.contract)
+                    if args.contract
+                    else None,
+                )
+            elif args.task_command == "inspect":
+                result = service.inspect(args.run_id, live=args.live)
+            elif args.task_command == "current":
+                result = service.current(args.path, budget=args.budget)
+            elif args.task_command == "context":
+                result = service.context(
+                    args.run_id, budget=args.budget, live=args.live
+                )
+            else:
+                result = service.checkpoint(
+                    args.run_id,
+                    expected_revision=args.expected_revision,
+                    expected_snapshot=args.expected_snapshot,
+                    idempotency_key=args.idempotency_key,
+                    payload=read_task_input(args.input),
+                )
+            if (
+                args.task_command in {"context", "current"}
+                and args.format == "markdown"
+            ):
+                print(
+                    "# RepoSteward task handoff\n\n```json\n"
+                    + json.dumps(result, ensure_ascii=False, indent=2)
+                    + "\n```"
+                )
+            else:
+                _json(result)
+            return 0
         if args.command == "project":
             from .projects import ProjectRegistry
 

--- a/src/reposteward/external_ledger.py
+++ b/src/reposteward/external_ledger.py
@@ -1,0 +1,23 @@
+"""Storage extension for external attempts; work items, runs and checkpoints stay canonical."""
+
+from __future__ import annotations
+
+EXTERNAL_TASK_MIGRATION = (
+    """CREATE TABLE IF NOT EXISTS external_task_runs (
+        run_id TEXT PRIMARY KEY REFERENCES runs(id),
+        project_id TEXT NOT NULL, binding_id TEXT NOT NULL, workspace_root TEXT NOT NULL,
+        binding_fingerprint TEXT NOT NULL, checkpoint_revision INTEGER NOT NULL DEFAULT 0,
+        snapshot TEXT NOT NULL, policy_digest TEXT NOT NULL, base_commit TEXT NOT NULL,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL)""",
+    """CREATE INDEX IF NOT EXISTS external_tasks_by_project ON external_task_runs(project_id,updated_at)""",
+    """CREATE TABLE IF NOT EXISTS external_task_checkpoints (
+        run_id TEXT NOT NULL REFERENCES runs(id), revision INTEGER NOT NULL,
+        checkpoint_id TEXT NOT NULL REFERENCES checkpoints(id),
+        idempotency_key TEXT NOT NULL, request_digest TEXT NOT NULL,
+        snapshot TEXT NOT NULL, created_at TEXT NOT NULL,
+        PRIMARY KEY(run_id,revision), UNIQUE(run_id,idempotency_key))""",
+    """CREATE TABLE IF NOT EXISTS external_task_sources (
+        run_id TEXT NOT NULL REFERENCES runs(id), kind TEXT NOT NULL,
+        digest TEXT NOT NULL REFERENCES content_blobs(digest),
+        PRIMARY KEY(run_id,kind))""",
+)

--- a/src/reposteward/external_tasks.py
+++ b/src/reposteward/external_tasks.py
@@ -1,0 +1,590 @@
+"""Local project assistance for coding agents started by the user."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from .config import AppConfig
+from .context import build_context_pack, repository_policy_digest, running_checkpoint
+from .context_budget import ContextBudgetError, estimate_tokens
+from .discovery import score_issue
+from .github import GitHubClient
+from .policy import PolicyError
+from .projects import ProjectRegistry, canonical_digest, local_git
+from .prompt_budget import fit_context
+from .snapshots import snapshot_summary, workspace_snapshot
+from .store import Store, utc_now
+from .task_contract import review_contract
+from .task_intake import contribution_gate
+
+MAX_CHECKPOINT_BYTES = 100_000
+
+
+class TaskConflict(RuntimeError):
+    """The requested task revision, binding, or snapshot is no longer current."""
+
+
+class ExternalTasks:
+    def __init__(self, config: AppConfig, *, github: GitHubClient | None = None):
+        self.config = config
+        self.registry = ProjectRegistry(config.state_dir / "projects.sqlite3")
+        self.path = config.state_dir / "reposteward.sqlite3"
+        self._github = github
+
+    def _store(self, *, write: bool = False) -> Store:
+        return Store(self.path, read_only=not write)
+
+    def _policy(self, repository: str):
+        policy = self.config.repositories.get(repository.casefold())
+        if policy is None or not policy.enabled:
+            raise PolicyError("linked project needs an enabled repository policy")
+        return policy
+
+    def _snapshot(self, root: Path, repository: str) -> dict[str, Any]:
+        return workspace_snapshot(
+            root,
+            trusted_sensitive_paths=self.config.safety.tracked_sensitive_paths_for(
+                repository
+            ),
+        )
+
+    def start(
+        self,
+        path: Path,
+        *,
+        issue_number: int,
+        reviewed_by: str,
+        contract_proposal: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if type(issue_number) is not int or issue_number < 1:
+            raise ValueError("task needs a positive Issue number")
+        if (
+            not reviewed_by
+            or reviewed_by.casefold() != self.config.github.login.casefold()
+        ):
+            raise PolicyError("--reviewed-by must match the configured GitHub login")
+        linked = self.registry.inspect(path)
+        project, binding = linked["project"], linked["binding"]
+        api_host = urlsplit(self.config.github.api_url).hostname
+        expected_host = "github.com" if api_host == "api.github.com" else api_host
+        if project["host"] != expected_host:
+            raise PolicyError("project host does not match the configured GitHub API")
+        policy = self._policy(project["repository"])
+        github = self._github or GitHubClient(self.config.github)
+        if github.authenticated_login().casefold() != reviewed_by.casefold():
+            raise PolicyError("authenticated identity differs from the task reviewer")
+        issue = github.issue(policy.name, issue_number)
+        repository = github.repository(policy.name)
+        candidate = score_issue(issue, repository, policy, self.config)
+        gate = contribution_gate(self.config, github, policy, issue_number, issue=issue)
+        if candidate.blockers or not gate["submission_ready"]:
+            raise PolicyError(
+                "Issue contribution gates block external development: "
+                + "; ".join(
+                    candidate.blockers
+                    or ("assignment, approval, state or competing work",)
+                )
+            )
+        root = Path(binding["root"])
+        snapshot = self._snapshot(root, policy.name)
+        if snapshot["branch"] == repository.default_branch or not snapshot["branch"]:
+            raise PolicyError("external development requires a separate feature branch")
+        base = local_git(
+            root,
+            "rev-parse",
+            "--verify",
+            f"refs/remotes/origin/{repository.default_branch}^{{commit}}",
+        )
+        if github.branch_head_sha(policy.name, repository.default_branch) != base:
+            raise TaskConflict(
+                "local origin base is stale; fetch it before starting the task"
+            )
+        contract = (
+            review_contract(issue, contract_proposal, reviewed_by=reviewed_by)
+            if contract_proposal is not None
+            else None
+        )
+        store = self._store(write=True)
+        with store.atomic():
+            work = store.ensure_work_item(
+                policy.name,
+                kind="github_issue",
+                external_id=str(issue_number),
+                title=issue.title,
+                payload={
+                    "url": issue.url,
+                    "updated_at": issue.updated_at,
+                    "state": issue.state,
+                },
+            )
+            run_id = store.start_run(policy.name, issue_number, "external")
+            previous = self._latest_local_checkpoint(store, work["id"])
+            context = build_context_pack(
+                candidate,
+                policy,
+                work_item_id=work["id"],
+                run_id=run_id,
+                worktree=root,
+                base_commit=base,
+                harness="external-agent",
+                model="",
+                task_contract=contract,
+                previous_checkpoint=previous,
+            )
+            context, _ = fit_context(context, self.config.context.prepare_max_tokens)
+            if self._snapshot(root, policy.name)["digest"] != snapshot["digest"]:
+                raise TaskConflict("workspace changed while freezing task context")
+            store.upsert_candidate(candidate)
+            store.save_context_run(
+                pack_id=context.id,
+                work_item_id=work["id"],
+                run_id=run_id,
+                schema_version=context.schema_version,
+                source_digest=context.source_digest,
+                base_commit=base,
+                payload=context.to_dict(),
+                harness="external-agent",
+            )
+            checkpoint = running_checkpoint(
+                context,
+                head_commit=snapshot["head"],
+                completed=(),
+                next_action="develop_in_existing_agent",
+            )
+            checkpoint["remaining"] = list(
+                context.task_contract.acceptance_criteria
+            ) or ["Satisfy the complete source-bound task requirements."]
+            if previous is not None:
+                checkpoint["remaining"] = list(
+                    dict.fromkeys(
+                        (*checkpoint["remaining"], *previous.get("remaining", ()))
+                    )
+                )
+                checkpoint["decisions"] = list(previous.get("decisions", ()))
+                checkpoint["blockers"] = list(previous.get("blockers", ()))
+            checkpoint["evidence"] = [
+                {
+                    "kind": "development_snapshot",
+                    "locator": f"task:{run_id}:snapshot:0",
+                    "status": "observed",
+                    "digest": snapshot["digest"],
+                    "summary": "Local code observation; development is not yet verified.",
+                }
+            ]
+            stored = store.save_checkpoint(
+                work_item_id=work["id"],
+                run_id=run_id,
+                context_pack_id=context.id,
+                status="running",
+                payload=checkpoint,
+            )
+            now = utc_now()
+            with store._connection() as db:
+                db.execute(
+                    """INSERT INTO external_task_runs VALUES (?,?,?,?,?,0,?,?,?,?,?)""",
+                    (
+                        run_id,
+                        project["id"],
+                        binding["id"],
+                        binding["root"],
+                        binding["fingerprint"],
+                        json.dumps(snapshot),
+                        repository_policy_digest(policy),
+                        base,
+                        now,
+                        now,
+                    ),
+                )
+                source = {
+                    key: getattr(issue, key)
+                    for key in ("repository", "number", "title", "body", "updated_at")
+                }
+                payload = json.dumps(
+                    source, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                ).encode()
+                source_digest = canonical_digest(source)
+                db.execute(
+                    "INSERT OR IGNORE INTO content_blobs(digest,payload,size_bytes,created_at) VALUES (?,?,?,?)",
+                    (source_digest, payload, len(payload), now),
+                )
+                db.execute(
+                    "INSERT INTO external_task_sources VALUES (?,?,?)",
+                    (run_id, "issue", source_digest),
+                )
+                db.execute(
+                    "INSERT INTO external_task_checkpoints VALUES (?,0,?,?,?,?,?)",
+                    (
+                        run_id,
+                        stored["id"],
+                        "start",
+                        canonical_digest(
+                            {"snapshot": snapshot["digest"], "source": source_digest}
+                        ),
+                        json.dumps(snapshot),
+                        now,
+                    ),
+                )
+            store.update_run(
+                run_id,
+                status="running",
+                stage="external",
+                worktree=str(root),
+                details={
+                    "source": "external-development",
+                    "worktree": str(root),
+                    "base_branch": repository.default_branch,
+                    "base_commit": base,
+                    "branch": snapshot["branch"],
+                    "commit_sha": snapshot["head"],
+                    "project_id": project["id"],
+                    "binding_id": binding["id"],
+                    "external_revision": 0,
+                    "snapshot_digest": snapshot["digest"],
+                    "issue_gate": gate,
+                    "task_reviewed_by": reviewed_by,
+                    "claim_trust": "agent_unverified",
+                    "public_write": False,
+                },
+            )
+        return self.inspect(run_id)
+
+    @staticmethod
+    def _latest_local_checkpoint(
+        store: Store, work_item_id: str
+    ) -> dict[str, Any] | None:
+        with store._connection() as db:
+            row = db.execute(
+                """SELECT c.payload FROM external_task_runs e
+                JOIN harness_runs h ON h.run_id=e.run_id
+                JOIN external_task_checkpoints x ON x.run_id=e.run_id AND x.revision=e.checkpoint_revision
+                JOIN checkpoints c ON c.id=x.checkpoint_id
+                WHERE h.work_item_id=? ORDER BY e.updated_at DESC,e.created_at DESC,e.run_id DESC LIMIT 1""",
+                (work_item_id,),
+            ).fetchone()
+        if row is not None:
+            return json.loads(row["payload"])
+        return store.latest_checkpoint_for_work_item(work_item_id)
+
+    def _record(self, store: Store, run_id: str) -> dict[str, Any]:
+        if not re.fullmatch("[0-9a-f]{32}", run_id):
+            raise ValueError("invalid external task run ID")
+        with store._connection() as db:
+            row = db.execute(
+                "SELECT * FROM external_task_runs WHERE run_id=?", (run_id,)
+            ).fetchone()
+        if row is None:
+            raise KeyError("external task run not found")
+        return {**dict(row), "snapshot": json.loads(row["snapshot"])}
+
+    def inspect(self, run_id: str, *, live: bool = False) -> dict[str, Any]:
+        store = self._store()
+        record = self._record(store, run_id)
+        bundle = store.context_bundle(run_id)
+        run = store.run(run_id)
+        if bundle is None or run is None:
+            raise TaskConflict("external task context is unavailable")
+        validity = []
+        current = None
+        if live:
+            linked = self.registry.inspect(Path(record["workspace_root"]))
+            if (
+                linked["project"]["id"] != record["project_id"]
+                or linked["binding"]["fingerprint"] != record["binding_fingerprint"]
+            ):
+                raise TaskConflict("task workspace binding changed")
+            policy = self._policy(run["repository"])
+            current = self._snapshot(Path(record["workspace_root"]), policy.name)
+            if repository_policy_digest(policy) != record["policy_digest"]:
+                validity.append("policy_changed")
+            base = local_git(
+                Path(record["workspace_root"]),
+                "rev-parse",
+                "--verify",
+                f"refs/remotes/origin/{run['details']['base_branch']}^{{commit}}",
+            )
+            if base != record["base_commit"]:
+                validity.append("base_changed")
+            if current["digest"] != record["snapshot"]["digest"]:
+                validity.append("workspace_changed_since_checkpoint")
+        return {
+            "schema_version": 1,
+            "run_id": run_id,
+            "work_item_id": bundle["work_item"]["id"],
+            "project_id": record["project_id"],
+            "binding_id": record["binding_id"],
+            "revision": record["checkpoint_revision"],
+            "status": run["status"],
+            "snapshot": snapshot_summary(record["snapshot"]),
+            "current_snapshot": snapshot_summary(current) if current else None,
+            "validity": validity,
+            "remote_freshness": "not_refreshed",
+            "claim_trust": "agent_unverified",
+            "context_pack": bundle["context_pack"],
+            "checkpoint": bundle["checkpoint"],
+            "public_write": False,
+        }
+
+    def checkpoint(
+        self,
+        run_id: str,
+        *,
+        expected_revision: int,
+        idempotency_key: str,
+        expected_snapshot: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise ValueError("expected revision must be non-negative")
+        if (
+            not re.fullmatch("[A-Za-z0-9_.:-]{1,128}", idempotency_key)
+            or idempotency_key == "start"
+        ):
+            raise ValueError("invalid checkpoint idempotency key")
+        if not re.fullmatch("[a-f0-9]{64}", expected_snapshot):
+            raise ValueError("expected snapshot must be a SHA-256 digest")
+        allowed = {
+            "completed",
+            "remaining",
+            "decisions",
+            "next_action",
+            "blockers",
+            "notes",
+            "tests_observed",
+            "risks",
+        }
+        if not isinstance(payload, dict) or set(payload) - allowed:
+            raise ValueError(
+                "checkpoint contains unsupported fields or authority claims"
+            )
+        if estimate_tokens(payload) > MAX_CHECKPOINT_BYTES:
+            raise ValueError("checkpoint exceeds the input limit")
+        if (
+            not isinstance(payload.get("next_action"), str)
+            or not payload["next_action"].strip()
+        ):
+            raise ValueError("checkpoint requires a concrete next action")
+        for name in ("completed", "remaining", "blockers", "tests_observed", "risks"):
+            values = payload.get(name, [])
+            if (
+                not isinstance(values, list)
+                or len(values) > 128
+                or any(not isinstance(v, str) or len(v) > 2000 for v in values)
+            ):
+                raise ValueError(f"invalid checkpoint {name}")
+        request_digest = canonical_digest(
+            {
+                "expected_revision": expected_revision,
+                "snapshot": expected_snapshot,
+                "payload": payload,
+            }
+        )
+        store = self._store(write=True)
+        with store.atomic():
+            record = self._record(store, run_id)
+            with store._connection() as db:
+                existing = db.execute(
+                    "SELECT * FROM external_task_checkpoints WHERE run_id=? AND idempotency_key=?",
+                    (run_id, idempotency_key),
+                ).fetchone()
+            if existing is not None:
+                if existing["request_digest"] != request_digest:
+                    raise TaskConflict(
+                        "idempotency key already belongs to a different checkpoint request"
+                    )
+                return {
+                    "run_id": run_id,
+                    "revision": existing["revision"],
+                    "checkpoint_id": existing["checkpoint_id"],
+                    "snapshot": snapshot_summary(json.loads(existing["snapshot"])),
+                    "idempotent": True,
+                    "public_write": False,
+                }
+            if record["checkpoint_revision"] != expected_revision:
+                raise TaskConflict(
+                    "checkpoint revision changed; reload the current task"
+                )
+            observed = self.inspect(run_id, live=True)
+            if any(
+                reason != "workspace_changed_since_checkpoint"
+                for reason in observed["validity"]
+            ):
+                raise TaskConflict(
+                    "task baseline or policy changed; start a refreshed attempt"
+                )
+            if observed["current_snapshot"]["digest"] != expected_snapshot:
+                raise TaskConflict("workspace differs from the expected snapshot")
+            run = store.run(run_id)
+            if run["status"] != "running" or run["stage"] != "external":
+                raise TaskConflict(
+                    "external attempt no longer accepts development checkpoints"
+                )
+            snapshot = self._snapshot(Path(record["workspace_root"]), run["repository"])
+            if snapshot["digest"] != expected_snapshot:
+                raise TaskConflict("workspace changed before saving the checkpoint")
+            bundle = store.context_bundle(run_id)
+            previous = bundle["checkpoint"] or {}
+            checkpoint = {
+                "schema_version": 1,
+                "work_item_id": bundle["work_item"]["id"],
+                "run_id": run_id,
+                "context_pack_id": bundle["context_pack"]["id"],
+                "status": "running",
+                "head_commit": snapshot["head"],
+                "completed": payload.get("completed", previous.get("completed", [])),
+                "remaining": payload.get("remaining", previous.get("remaining", [])),
+                "next_action": payload["next_action"],
+                "blockers": payload.get("blockers", previous.get("blockers", [])),
+                "decisions": payload.get("decisions", previous.get("decisions", [])),
+                "implementation_notes": payload.get(
+                    "notes", previous.get("implementation_notes", "")
+                ),
+                "tests_observed": payload.get(
+                    "tests_observed", previous.get("tests_observed", [])
+                ),
+                "risks": payload.get("risks", previous.get("risks", [])),
+                "evidence": [
+                    {
+                        "kind": "development_snapshot",
+                        "locator": f"task:{run_id}:snapshot:{expected_revision + 1}",
+                        "status": "observed",
+                        "digest": snapshot["digest"],
+                        "summary": "Code observed by RepoSteward; Agent completion and tests remain unverified.",
+                    }
+                ],
+            }
+            saved = store.save_checkpoint(
+                work_item_id=bundle["work_item"]["id"],
+                run_id=run_id,
+                context_pack_id=bundle["context_pack"]["id"],
+                status="running",
+                payload=checkpoint,
+            )
+            revision = expected_revision + 1
+            now = utc_now()
+            with store._connection() as db:
+                updated = db.execute(
+                    """UPDATE external_task_runs SET checkpoint_revision=?,snapshot=?,updated_at=?
+                    WHERE run_id=? AND checkpoint_revision=?""",
+                    (revision, json.dumps(snapshot), now, run_id, expected_revision),
+                )
+                if updated.rowcount != 1:
+                    raise TaskConflict("checkpoint revision changed concurrently")
+                db.execute(
+                    "INSERT INTO external_task_checkpoints VALUES (?,?,?,?,?,?,?)",
+                    (
+                        run_id,
+                        revision,
+                        saved["id"],
+                        idempotency_key,
+                        request_digest,
+                        json.dumps(snapshot),
+                        now,
+                    ),
+                )
+            store.update_run(
+                run_id,
+                status="running",
+                stage="external",
+                details={
+                    **run["details"],
+                    "commit_sha": snapshot["head"],
+                    "external_revision": revision,
+                    "snapshot_digest": snapshot["digest"],
+                },
+            )
+        return {
+            "run_id": run_id,
+            "revision": revision,
+            "checkpoint_id": saved["id"],
+            "snapshot": snapshot_summary(snapshot),
+            "idempotent": False,
+            "public_write": False,
+        }
+
+    def context(
+        self, run_id: str, *, budget: int = 24_000, live: bool = False
+    ) -> dict[str, Any]:
+        if type(budget) is not int or not 512 <= budget <= 100_000:
+            raise ValueError("context budget must be between 512 and 100000")
+        report = self.inspect(run_id, live=live)
+        pack = report.pop("context_pack")
+        checkpoint = report.pop("checkpoint")
+        # Open work and decisions come directly from the current ledger, never from a summary of a summary.
+        mandatory = {
+            **report,
+            "task": {"title": pack["task"]["title"], "url": pack["task"]["url"]},
+            "contract": pack.get("task_contract"),
+            "project": pack["project"],
+            "sources": pack["sources"],
+            "open_work": checkpoint.get("remaining", []) if checkpoint else [],
+            "decisions": checkpoint.get("decisions", []) if checkpoint else [],
+            "next_action": checkpoint.get("next_action", "") if checkpoint else "",
+            "blockers": checkpoint.get("blockers", []) if checkpoint else [],
+            "evidence": checkpoint.get("evidence", []) if checkpoint else [],
+            "agent_claims": {
+                "completed": checkpoint.get("completed", []) if checkpoint else [],
+                "notes": checkpoint.get("implementation_notes", "")
+                if checkpoint
+                else "",
+                "tests_observed": checkpoint.get("tests_observed", [])
+                if checkpoint
+                else [],
+                "trust": "agent_unverified",
+            },
+            "coverage": list(pack.get("coverage", [])),
+            "budget": budget,
+            "estimated_tokens": 0,
+        }
+        for _ in range(8):
+            size = estimate_tokens(mandatory)
+            if mandatory["estimated_tokens"] == size:
+                break
+            mandatory["estimated_tokens"] = size
+        if estimate_tokens(mandatory) > budget:
+            claims = mandatory["agent_claims"]
+            count = len(json.dumps(claims, ensure_ascii=False, sort_keys=True))
+            mandatory["agent_claims"] = {
+                "trust": "agent_unverified",
+                "omitted": count,
+                "evidence_id": f"checkpoint:{run_id}:{report['revision']}",
+            }
+            mandatory["coverage"].append(
+                {
+                    "field": "agent_claims",
+                    "reason": "context_budget",
+                    "omitted": count,
+                    "unit": "serialized_characters",
+                    "locator": f"checkpoint:{run_id}:{report['revision']}",
+                    "digest": canonical_digest(checkpoint),
+                }
+            )
+            for _ in range(8):
+                size = estimate_tokens(mandatory)
+                if mandatory["estimated_tokens"] == size:
+                    break
+                mandatory["estimated_tokens"] = size
+        if estimate_tokens(mandatory) > budget:
+            raise ContextBudgetError(
+                "task contract, open work, decisions and current evidence exceed the context budget"
+            )
+        return mandatory
+
+    def current(self, path: Path, *, budget: int = 24_000) -> dict[str, Any]:
+        linked = self.registry.inspect(path)
+        store = self._store()
+        with store._connection() as db:
+            row = db.execute(
+                """SELECT e.run_id FROM external_task_runs e JOIN runs r ON r.id=e.run_id
+                WHERE e.binding_id=? AND e.project_id=? AND r.stage='external' AND r.status='running'
+                ORDER BY e.updated_at DESC,e.created_at DESC,e.rowid DESC LIMIT 1""",
+                (linked["binding"]["id"], linked["project"]["id"]),
+            ).fetchone()
+        if row is None:
+            raise KeyError(
+                "no active external task; start a reviewed Issue in this workspace"
+            )
+        return self.context(row["run_id"], budget=budget, live=True)

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -81,6 +81,7 @@ from .repair_prompt import build_budgeted_repair_context_pack
 from .review import compact_command, compact_run
 from .store import QueueLease, RunLease, Store, StoreError
 from .task_contract import TaskContract
+from .task_intake import contribution_gate
 from .usage import (
     build_usage_report,
     compact_usage_budget,
@@ -2268,44 +2269,9 @@ class Pipeline:
         }
 
     def gate_status(self, repository: str, issue_number: int) -> dict[str, Any]:
-        policy = self.policy(repository)
-        issue = self.github.issue(policy.name, issue_number)
-        assigned = self.config.github.login.casefold() in {
-            login.casefold() for login in issue.assignees
-        }
-        approval = True
-        if policy.maintainer_approval:
-            approval = self.github.has_maintainer_approval(
-                policy.name,
-                issue_number,
-                policy.maintainer_approval,
-                policy.allowed_approver_associations,
-            )
-        competing_work = ()
-        if policy.require_no_competing_work:
-            competing_work = self.github.competing_work(
-                policy.name,
-                issue_number,
-                own_login=self.config.github.login,
-            )
-        return {
-            "repository": policy.name,
-            "issue": issue_number,
-            "state": issue.state,
-            "assignees": list(issue.assignees),
-            "assignment_required": policy.require_assignment_before_submit,
-            "assigned_to_login": assigned,
-            "approval_command": policy.maintainer_approval,
-            "maintainer_approval": approval,
-            "competing_work_required_absent": policy.require_no_competing_work,
-            "competing_work": [asdict(value) for value in competing_work],
-            "submission_ready": (
-                issue.state == "open"
-                and (not policy.require_assignment_before_submit or assigned)
-                and approval
-                and not competing_work
-            ),
-        }
+        return contribution_gate(
+            self.config, self.github, self.policy(repository), issue_number
+        )
 
     def _ensure_no_competing_work(
         self, policy: RepositoryPolicy, issue_number: int

--- a/src/reposteward/snapshots.py
+++ b/src/reposteward/snapshots.py
@@ -1,0 +1,169 @@
+"""Bounded code identities for development handoff, including uncommitted files."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+from .projects import ProjectError, canonical_digest, local_git, workspace_state
+from .verifier import UNTRACKED_SANDBOX_EXCLUDED_NAMES, DockerVerifier
+
+MAX_SNAPSHOT_FILES = 20_000
+MAX_SNAPSHOT_FILE_BYTES = 20_000_000
+MAX_SNAPSHOT_BYTES = 200_000_000
+
+
+def _entries(
+    root: Path, *, trusted_sensitive_paths: tuple[str, ...]
+) -> tuple[list[dict[str, Any]], int]:
+    tracked = local_git(root, "ls-files", "--cached", "-z").split("\0")
+    untracked = local_git(
+        root, "ls-files", "--others", "--exclude-standard", "-z"
+    ).split("\0")
+    names = {name: True for name in tracked if name}
+    for name in untracked:
+        if name:
+            names.setdefault(name, False)
+    if len(names) > MAX_SNAPSHOT_FILES:
+        raise ProjectError("workspace exceeds snapshot file limit")
+    manifest, total, excluded = [], 0, 0
+    for name, is_tracked in sorted(names.items()):
+        relative = Path(name)
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or any(ord(c) < 32 for c in name)
+        ):
+            raise ProjectError("unsupported snapshot path")
+        source = root / relative
+        if DockerVerifier._sensitive_path(relative):
+            if is_tracked and DockerVerifier._is_supported_env_template(relative):
+                DockerVerifier._validate_env_template(source, relative)
+            elif (
+                is_tracked
+                and not DockerVerifier._environment_path(relative)
+                and DockerVerifier._is_allowlisted_tracked_sensitive_path(
+                    relative, trusted_sensitive_paths
+                )
+            ):
+                DockerVerifier._validate_allowlisted_sensitive_source(source, relative)
+            elif is_tracked:
+                raise ProjectError(
+                    "tracked sensitive path cannot enter a task snapshot"
+                )
+            else:
+                excluded += 1
+                continue
+        if not is_tracked and any(
+            part in UNTRACKED_SANDBOX_EXCLUDED_NAMES for part in relative.parts
+        ):
+            excluded += 1
+            continue
+        if not source.parent.resolve().is_relative_to(root):
+            raise ProjectError("snapshot path escapes the workspace")
+        # Do not follow directory links even when they resolve back inside the root.
+        parent = source.parent
+        while parent != root:
+            if parent.is_symlink():
+                raise ProjectError("snapshot parent must not be a symlink")
+            parent = parent.parent
+        try:
+            before = source.lstat()
+        except FileNotFoundError:
+            manifest.append({"path": name, "kind": "deleted", "tracked": is_tracked})
+            continue
+        if stat.S_ISLNK(before.st_mode):
+            payload = os.readlink(source).encode()
+            kind = "symlink"
+            size = len(payload)
+            digest = hashlib.sha256(payload).hexdigest()
+        elif stat.S_ISREG(before.st_mode):
+            size = before.st_size
+            if size > MAX_SNAPSHOT_FILE_BYTES or total + size > MAX_SNAPSHOT_BYTES:
+                raise ProjectError("workspace exceeds snapshot byte limit")
+            hasher = hashlib.sha256()
+            # O_NOFOLLOW closes a replacement-to-symlink race between lstat/open.
+            fd = os.open(source, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+            with os.fdopen(fd, "rb") as handle:
+                opened = os.fstat(handle.fileno())
+                if not stat.S_ISREG(opened.st_mode) or (
+                    opened.st_dev,
+                    opened.st_ino,
+                ) != (before.st_dev, before.st_ino):
+                    raise ProjectError("workspace changed during snapshot")
+                count = 0
+                while chunk := handle.read(1024 * 1024):
+                    count += len(chunk)
+                    if (
+                        count > MAX_SNAPSHOT_FILE_BYTES
+                        or total + count > MAX_SNAPSHOT_BYTES
+                    ):
+                        raise ProjectError(
+                            "workspace changed beyond snapshot byte limit"
+                        )
+                    hasher.update(chunk)
+            if count != size:
+                raise ProjectError("workspace changed during snapshot")
+            digest = hasher.hexdigest()
+            kind = "file"
+        else:
+            raise ProjectError(
+                "submodules and special files require an explicit snapshot adapter"
+            )
+        after = source.lstat()
+        signature = lambda value: (
+            value.st_dev,
+            value.st_ino,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+            value.st_mode,
+        )
+        if signature(before) != signature(after):
+            raise ProjectError("workspace changed during snapshot")
+        total += size
+        manifest.append(
+            {
+                "path": name,
+                "kind": kind,
+                "tracked": is_tracked,
+                "bytes": size,
+                "executable": bool(before.st_mode & stat.S_IXUSR),
+                "digest": digest,
+            }
+        )
+    return manifest, excluded
+
+
+def workspace_snapshot(
+    root: Path, *, trusted_sensitive_paths: tuple[str, ...] = ()
+) -> dict[str, Any]:
+    root = root.resolve(strict=True)
+    before = workspace_state(root)
+    manifest, excluded = _entries(root, trusted_sensitive_paths=trusted_sensitive_paths)
+    repeated, repeated_excluded = _entries(
+        root, trusted_sensitive_paths=trusted_sensitive_paths
+    )
+    after = workspace_state(root)
+    if before != after or manifest != repeated or excluded != repeated_excluded:
+        raise ProjectError(
+            "workspace changed during snapshot; retry after editing stops"
+        )
+    material = {
+        "schema_version": 1,
+        "head": before["head"],
+        "branch": before["branch"],
+        "dirty": before["dirty"],
+        "files": manifest,
+        "excluded_untracked": excluded,
+    }
+    return {**material, "digest": canonical_digest(material)}
+
+
+def snapshot_summary(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in snapshot.items() if key != "files"} | {
+        "file_count": len(snapshot["files"])
+    }

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from .external_ledger import EXTERNAL_TASK_MIGRATION
 from .feedback import (
     FEEDBACK_MIGRATION,
     feedback_report,
@@ -23,9 +24,10 @@ from .feedback import (
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
+    19: EXTERNAL_TASK_MIGRATION,
     18: FEEDBACK_MIGRATION,
     1: (
         """
@@ -782,13 +784,27 @@ USAGE_METRIC_KEYS = frozenset(
 
 
 class Store:
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, read_only: bool = False) -> None:
         self.path = path
+        self.read_only = read_only
+        self._atomic_connection: ContextVar[sqlite3.Connection | None] = ContextVar(
+            f"reposteward_atomic_{id(self)}", default=None
+        )
         self._run_lease_context: ContextVar[RunLease | None] = ContextVar(
             f"reposteward_run_lease_{id(self)}", default=None
         )
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._initialize()
+        if read_only:
+            if not self.path.is_file():
+                raise StoreError("local task database does not exist")
+            with self._connection() as connection:
+                version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+                if version != SCHEMA_VERSION:
+                    raise StoreError(
+                        "read-only task access needs the current schema; run an explicit local write to migrate"
+                    )
+        else:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._initialize()
 
     @staticmethod
     def _begin_immediate(connection: sqlite3.Connection) -> None:
@@ -799,8 +815,17 @@ class Store:
     def _connection(
         self, *, guard_bound_lease: bool = True
     ) -> Iterator[sqlite3.Connection]:
-        connection = sqlite3.connect(self.path)
+        shared = self._atomic_connection.get()
+        if shared is not None:
+            yield shared
+            return
+        connection = sqlite3.connect(
+            self.path.resolve().as_uri() + "?mode=ro" if self.read_only else self.path,
+            uri=self.read_only,
+        )
         connection.row_factory = sqlite3.Row
+        if self.read_only:
+            connection.execute("PRAGMA query_only=ON")
         connection.execute("PRAGMA foreign_keys=ON")
         connection.execute("PRAGMA busy_timeout=5000")
         try:
@@ -818,6 +843,22 @@ class Store:
             raise
         finally:
             connection.close()
+
+    @contextmanager
+    def atomic(self) -> Iterator[None]:
+        """Group local ledger updates; never hold this across network or agent work."""
+        if self.read_only:
+            raise StoreError("read-only Store cannot start a write transaction")
+        if self._atomic_connection.get() is not None:
+            yield
+            return
+        with self._connection() as connection:
+            self._begin_immediate(connection)
+            token = self._atomic_connection.set(connection)
+            try:
+                yield
+            finally:
+                self._atomic_connection.reset(token)
 
     def _initialize(self) -> None:
         connection = sqlite3.connect(self.path)
@@ -2530,6 +2571,7 @@ class Store:
             SELECT b.digest, b.size_bytes, b.created_at,
                    e.repository, e.pull_number, e.sequence, e.ingested_at,
                    f.status AS feedback_status,
+                   EXISTS(SELECT 1 FROM external_task_sources t WHERE t.digest=b.digest) AS task_reference,
                    COALESCE(w.watermark_count, 0) AS watermark_count,
                    COALESCE(w.minimum_watermark, 0) AS minimum_watermark
             FROM content_blobs b
@@ -2560,6 +2602,8 @@ class Store:
                     "reasons": set(),
                 },
             )
+            if row["task_reference"]:
+                value["reasons"].add("external_task_source_reference")
             if row["repository"] is None:
                 value["reasons"].add("unreferenced_content_blob")
                 continue

--- a/src/reposteward/task_intake.py
+++ b/src/reposteward/task_intake.py
@@ -1,0 +1,53 @@
+"""Contribution gate facts shared by native and external development entry points."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from .config import AppConfig, RepositoryPolicy
+from .github import GitHubClient
+from .models import Issue
+
+
+def contribution_gate(
+    config: AppConfig,
+    github: GitHubClient,
+    policy: RepositoryPolicy,
+    issue_number: int,
+    *,
+    issue: Issue | None = None,
+) -> dict[str, Any]:
+    issue = issue or github.issue(policy.name, issue_number)
+    assigned = config.github.login.casefold() in {
+        login.casefold() for login in issue.assignees
+    }
+    approval = True
+    if policy.maintainer_approval:
+        approval = github.has_maintainer_approval(
+            policy.name,
+            issue_number,
+            policy.maintainer_approval,
+            policy.allowed_approver_associations,
+        )
+    competing = (
+        github.competing_work(policy.name, issue_number, own_login=config.github.login)
+        if policy.require_no_competing_work
+        else ()
+    )
+    return {
+        "repository": policy.name,
+        "issue": issue_number,
+        "state": issue.state,
+        "assignees": list(issue.assignees),
+        "assignment_required": policy.require_assignment_before_submit,
+        "assigned_to_login": assigned,
+        "approval_command": policy.maintainer_approval,
+        "maintainer_approval": approval,
+        "competing_work_required_absent": policy.require_no_competing_work,
+        "competing_work": [asdict(value) for value in competing],
+        "submission_ready": issue.state == "open"
+        and (not policy.require_assignment_before_submit or assigned)
+        and approval
+        and not competing,
+    }

--- a/tests/test_external_tasks.py
+++ b/tests/test_external_tasks.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import io
+import sqlite3
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing, redirect_stdout
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from test_context import _candidate
+from test_projects import git, repository
+
+from reposteward.cli import main
+from reposteward.config import load_config
+from reposteward.context import portable_bundle
+from reposteward.context_budget import ContextBudgetError
+from reposteward.external_tasks import ExternalTasks, TaskConflict
+from reposteward.policy import PolicyError
+from reposteward.projects import ProjectError
+from reposteward.setup import add_repository, initialize_user_config
+from reposteward.snapshots import workspace_snapshot
+from reposteward.store import Store, StoreError
+
+
+class ExternalTaskTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.repo = repository(
+            self.root / "checkout", remote="git@github.com:owner/repo.git"
+        )
+        git(self.repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+        git(self.repo, "switch", "-c", "owner/feature")
+        user = self.root / "user.toml"
+        policy_file = self.root / "repo.toml"
+        initialize_user_config(path=user, login="owner")
+        add_repository("owner/repo", path=policy_file, mode="maintainer")
+        config = load_config(policy_file, user_path=user)
+        policy = replace(
+            config.repositories["owner/repo"],
+            require_assignment_before_submit=False,
+            require_no_competing_work=False,
+        )
+        self.config = replace(
+            config, state_dir=self.root / "state", repositories={"owner/repo": policy}
+        )
+        self.github = Mock()
+        self.github.authenticated_login.return_value = "owner"
+        self.github.issue.return_value = _candidate().issue
+        self.github.repository.return_value = _candidate().repository
+        self.github.branch_head_sha.return_value = git(self.repo, "rev-parse", "HEAD")
+        self.service = ExternalTasks(self.config, github=self.github)
+        self.service.registry.link(self.repo)
+
+    def start(self) -> dict:
+        return self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+
+    def checkpoint(
+        self,
+        run_id: str,
+        *,
+        revision: int = 0,
+        key: str = "one",
+        payload: dict | None = None,
+    ) -> dict:
+        live = self.service.inspect(run_id, live=True)
+        return self.service.checkpoint(
+            run_id,
+            expected_revision=revision,
+            idempotency_key=key,
+            expected_snapshot=live["current_snapshot"]["digest"],
+            payload=payload
+            or {
+                "completed": ["Agent claims progress"],
+                "remaining": ["Handle empty input"],
+                "next_action": "implement boundary case",
+            },
+        )
+
+    def test_start_freezes_dirty_code_without_starting_pipeline_or_modifying_workspace(
+        self,
+    ) -> None:
+        (self.repo / "source.txt").write_text("dirty before start")
+        (self.repo / "new.py").write_text("x = 1\n")
+        before = workspace_snapshot(self.repo)
+        with patch(
+            "reposteward.cli.Pipeline",
+            side_effect=AssertionError("unexpected Pipeline"),
+        ):
+            result = self.start()
+        self.assertEqual(result["snapshot"]["digest"], before["digest"])
+        self.assertTrue(result["snapshot"]["dirty"])
+        self.assertEqual(workspace_snapshot(self.repo), before)
+        self.assertEqual(result["status"], "running")
+        self.assertEqual(result["revision"], 0)
+        self.assertEqual(
+            result["context_pack"]["provenance"]["harness"], "external-agent"
+        )
+        self.assertEqual(result["claim_trust"], "agent_unverified")
+
+    def test_current_task_is_selected_by_workspace_binding(self) -> None:
+        first = self.start()
+        self.assertEqual(self.service.current(self.repo)["run_id"], first["run_id"])
+        other_repo = repository(
+            self.root / "other", remote="git@github.com:owner/another.git"
+        )
+        self.service.registry.link(other_repo)
+        with self.assertRaisesRegex(KeyError, "no active external task"):
+            self.service.current(other_repo)
+        second = self.start()
+        self.assertEqual(first["work_item_id"], second["work_item_id"])
+        self.assertEqual(self.service.current(self.repo)["run_id"], second["run_id"])
+
+    def test_checkpoint_idempotency_conflicts_and_partial_fields_preserve_open_work(
+        self,
+    ) -> None:
+        result = self.start()
+        run_id = result["run_id"]
+        first = self.checkpoint(run_id)
+        repeated = self.checkpoint(run_id)
+        self.assertEqual(first["checkpoint_id"], repeated["checkpoint_id"])
+        self.assertTrue(repeated["idempotent"])
+        with self.assertRaisesRegex(TaskConflict, "idempotency key"):
+            self.checkpoint(run_id, payload={"next_action": "different"})
+        with self.assertRaisesRegex(TaskConflict, "revision changed"):
+            self.checkpoint(run_id, key="new-key")
+        self.checkpoint(
+            run_id, revision=1, key="two", payload={"next_action": "verify next"}
+        )
+        report = self.service.inspect(run_id)
+        self.assertEqual(report["checkpoint"]["remaining"], ["Handle empty input"])
+        self.assertEqual(report["status"], "running")
+        self.assertEqual(report["checkpoint"]["status"], "running")
+        self.assertEqual(report["revision"], 2)
+
+    def test_concurrent_agents_cannot_overwrite_each_other(self) -> None:
+        run_id = self.start()["run_id"]
+        snapshot = self.service.inspect(run_id)["snapshot"]["digest"]
+
+        def save(key):
+            try:
+                return self.service.checkpoint(
+                    run_id,
+                    expected_revision=0,
+                    idempotency_key=key,
+                    expected_snapshot=snapshot,
+                    payload={"next_action": key},
+                )
+            except TaskConflict:
+                return None
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(save, ("agent-a", "agent-b")))
+        self.assertEqual(sum(value is not None for value in results), 1)
+        self.assertEqual(self.service.inspect(run_id)["revision"], 1)
+
+    def test_changed_snapshot_policy_base_and_binding_are_detected(self) -> None:
+        result = self.start()
+        run_id = result["run_id"]
+        old = result["snapshot"]["digest"]
+        (self.repo / "source.txt").write_text("changed without commit")
+        with self.assertRaisesRegex(TaskConflict, "expected snapshot"):
+            self.service.checkpoint(
+                run_id,
+                expected_revision=0,
+                idempotency_key="one",
+                expected_snapshot=old,
+                payload={"next_action": "verify"},
+            )
+        current = self.service.inspect(run_id, live=True)
+        self.assertIn("workspace_changed_since_checkpoint", current["validity"])
+        self.assertEqual(
+            current["snapshot"]["head"], current["current_snapshot"]["head"]
+        )
+        changed = replace(
+            self.config,
+            repositories={
+                "owner/repo": replace(
+                    self.config.repositories["owner/repo"], min_stars=1
+                )
+            },
+        )
+        other = ExternalTasks(changed)
+        self.assertIn("policy_changed", other.inspect(run_id, live=True)["validity"])
+        git(self.repo, "add", "source.txt")
+        git(self.repo, "commit", "-m", "Advance test base")
+        git(self.repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+        self.assertIn(
+            "base_changed", self.service.inspect(run_id, live=True)["validity"]
+        )
+        with self.assertRaisesRegex(TaskConflict, "baseline"):
+            self.checkpoint(run_id)
+        self.service.registry.unlink(result["binding_id"])
+        with self.assertRaises(ProjectError):
+            self.service.inspect(run_id, live=True)
+
+    def test_read_only_context_works_without_authentication_or_pipeline(self) -> None:
+        result = self.start()
+        self.github.reset_mock()
+        reader = ExternalTasks(self.config)
+        with (
+            patch(
+                "reposteward.external_tasks.GitHubClient",
+                side_effect=AssertionError("unexpected auth"),
+            ),
+            patch(
+                "reposteward.cli.Pipeline",
+                side_effect=AssertionError("unexpected Pipeline"),
+            ),
+            patch("reposteward.cli.load_config", return_value=self.config),
+            redirect_stdout(io.StringIO()) as output,
+        ):
+            self.assertEqual(
+                main(["task", "context", result["run_id"], "--format", "markdown"]), 0
+            )
+        self.assertIn("RepoSteward task handoff", output.getvalue())
+        self.assertEqual(reader.context(result["run_id"])["revision"], 0)
+        self.github.assert_not_called()
+
+    def test_read_only_database_never_creates_or_migrates(self) -> None:
+        missing = self.root / "missing/db.sqlite3"
+        with self.assertRaises(StoreError):
+            Store(missing, read_only=True)
+        self.assertFalse(missing.parent.exists())
+        self.start()
+        with closing(sqlite3.connect(self.service.path)) as db:
+            db.execute("PRAGMA user_version=18")
+        before = self.service.path.read_bytes()
+        with self.assertRaisesRegex(StoreError, "current schema"):
+            Store(self.service.path, read_only=True)
+        self.assertEqual(before, self.service.path.read_bytes())
+
+    def test_failed_registration_and_checkpoint_roll_back_all_native_records(
+        self,
+    ) -> None:
+        with (
+            patch.object(
+                Store, "save_checkpoint", side_effect=RuntimeError("interrupted")
+            ),
+            self.assertRaisesRegex(RuntimeError, "interrupted"),
+        ):
+            self.start()
+        store = Store(self.service.path)
+        with store._connection() as db:
+            self.assertEqual(db.execute("SELECT count(*) FROM runs").fetchone()[0], 0)
+            self.assertEqual(
+                db.execute("SELECT count(*) FROM context_packs").fetchone()[0], 0
+            )
+        run_id = self.start()["run_id"]
+        with (
+            patch.object(Store, "update_run", side_effect=RuntimeError("interrupted")),
+            self.assertRaisesRegex(RuntimeError, "interrupted"),
+        ):
+            self.checkpoint(run_id)
+        self.assertEqual(self.service.inspect(run_id)["revision"], 0)
+        self.assertEqual(self.checkpoint(run_id)["revision"], 1)
+
+    def test_late_import_cannot_replace_current_external_open_items(self) -> None:
+        run_id = self.start()["run_id"]
+        store = Store(self.service.path)
+        old = portable_bundle(store.context_bundle(run_id))
+        self.checkpoint(run_id)
+        store.import_context_bundle(old)
+        self.assertEqual(
+            self.service.context(run_id)["open_work"], ["Handle empty input"]
+        )
+        next_run = self.start()
+        self.assertEqual(next_run["work_item_id"], old["work_item"]["id"])
+        self.assertIn("Handle empty input", next_run["checkpoint"]["remaining"])
+
+    def test_minimum_context_and_authority_claims_fail_explicitly(self) -> None:
+        run_id = self.start()["run_id"]
+        self.checkpoint(
+            run_id,
+            payload={
+                "remaining": ["中英 task condition " * 80] * 40,
+                "next_action": "continue",
+            },
+        )
+        with self.assertRaises(ContextBudgetError):
+            self.service.context(run_id, budget=5000)
+        with self.assertRaisesRegex(ValueError, "authority"):
+            self.checkpoint(
+                run_id,
+                revision=1,
+                key="claim",
+                payload={"next_action": "done", "verified": True},
+            )
+        self.assertEqual(self.service.inspect(run_id)["status"], "running")
+
+    def test_closed_issue_and_default_branch_cannot_start_development(self) -> None:
+        self.github.issue.return_value = replace(
+            self.github.issue.return_value, state="closed"
+        )
+        with self.assertRaises(PolicyError):
+            self.start()
+        self.github.issue.return_value = _candidate().issue
+        git(self.repo, "switch", "main")
+        with self.assertRaisesRegex(PolicyError, "feature branch"):
+            self.start()
+
+    def test_frozen_issue_source_is_retained_by_gc(self) -> None:
+        result = self.start()
+        store = Store(self.service.path)
+        digest = result["context_pack"]["task_contract"]["source_digest"]
+        inventory = store.event_payload_gc_inventory(
+            {"owner/repo": "2099-01-01T00:00:00Z"}
+        )
+        retained = next(
+            value for value in inventory["retained"] if value["digest"] == digest
+        )
+        self.assertIn("external_task_source_reference", retained["reasons"])
+        self.assertEqual(
+            store.delete_event_payloads(
+                (digest,), retention_cutoffs={"owner/repo": "2099-01-01T00:00:00Z"}
+            )["deleted"],
+            [],
+        )
+
+    def test_snapshot_excludes_sensitive_untracked_and_detects_special_files(
+        self,
+    ) -> None:
+        before = workspace_snapshot(self.repo)
+        (self.repo / ".env").write_text("TOKEN=example")
+        after = workspace_snapshot(self.repo)
+        self.assertEqual(before["files"], after["files"])
+        self.assertEqual(after["excluded_untracked"], 1)
+        (self.repo / "escape").symlink_to(self.root, target_is_directory=True)
+        linked = workspace_snapshot(self.repo)
+        self.assertEqual(
+            next(v for v in linked["files"] if v["path"] == "escape")["kind"], "symlink"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #98

Track development in existing coding-agent workspaces using durable tasks, checkpoints and exact snapshots.

---

Create a task before an external agent starts, preserve reviewed Issue sources and portable context, and bind updates to the workspace identity, expected revision and current snapshot. Checkpoint writes are atomic and idempotent; dirty development snapshots are distinct from clean publication eligibility. Reads avoid GitHub or harness initialization and report source drift. An additive ledger migration preserves earlier task and cleanup data.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
