### PR TITLE
feat(verification): bind external evidence to exact isolated snapshots

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -954,3 +954,40 @@ Copilot 此处专指 VS Code：生成仓库指引，并提供显式 `#file:` 引
 参考 [Codex 项目指引](https://learn.chatgpt.com/docs/agent-configuration/agents-md)、
 [Claude Code memory](https://code.claude.com/docs/en/memory) 和
 [GitHub Copilot customization](https://docs.github.com/en/copilot/reference/customization-cheat-sheet)。
+
+## 验证外部开发快照和取回证据
+
+外部 Agent 只能选择用户配置中的验证方案，不能提交任意命令。将方案放在用户自己的
+`~/.config/reposteward/config.toml`；项目文件中同名配置不生效：
+
+```toml
+[[verification_profiles]]
+repository = "owner/repo"
+name = "test"
+bootstrap_commands = ["uv sync --locked"]
+commands = ["uv run python -m unittest discover -s tests -v"]
+```
+
+命令仍需满足仓库允许前缀及必须验证标记。bootstrap 使用网络安装依赖，正式验证禁用
+网络，沿用加固 Docker 容器。运行前核对实际副本的文件、内容及可执行标记；bootstrap
+和验证后再次核对原有代码与源工作区，变化会使结果成为 unknown。开发期间可以验证
+未提交快照；这份证据不会把任务改为 ready，最终仍走干净提交的 adopt 和独立审阅。
+
+```bash
+reposteward verification profiles <run-id>
+reposteward task inspect <run-id> --live
+reposteward verification request <run-id> --profile test --expected-revision 0 \
+  --expected-snapshot <current-snapshot-digest> --idempotency-key test-1
+reposteward verification list <run-id> --limit 20
+reposteward verification inspect <run-id> verification:<id> --live
+reposteward verification evidence <run-id> log:<id>:0 --offset 0 --limit 8000
+```
+
+证据绑定 run、检查点版本、HEAD、base、策略、验证方案和实际源码快照。相同 key
+只返回原请求；输入不同则冲突。已完成的历史 passed 保留，但代码、检查点或配置
+改变后 `current_applicability` 不再匹配。失败为 failed，操作人中断为 cancelled，超时
+或缺少终态记录为 unknown；中断请求不自动复用成功，也不自动再次执行。
+
+查询限制在所选任务，正文按字符分页；来源可用 `source:<digest>`、检查点可用
+`checkpoint:<run-id>:<revision>` 取回。日志摘要记录完整输出摘要及已保留日志摘要，
+截断与缺失分别报告；正文被修改或丢失时返回 unknown。查询不调用模型或 GitHub。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -151,6 +151,30 @@ def _parser() -> argparse.ArgumentParser:
     task_checkpoint.add_argument("--idempotency-key", required=True)
     task_checkpoint.add_argument("--input", type=Path, required=True)
 
+    verification = subparsers.add_parser(
+        "verification", help="verify and query exact external task snapshots"
+    )
+    verification_commands = verification.add_subparsers(
+        dest="verification_command", required=True
+    )
+    for action in ("profiles", "request", "inspect", "list", "evidence"):
+        command = verification_commands.add_parser(action)
+        command.add_argument("run_id")
+        if action == "request":
+            command.add_argument("--profile", required=True)
+            command.add_argument("--expected-revision", type=int, required=True)
+            command.add_argument("--expected-snapshot", required=True)
+            command.add_argument("--idempotency-key", required=True)
+        elif action == "inspect":
+            command.add_argument("evidence_id")
+            command.add_argument("--live", action="store_true")
+        elif action == "list":
+            command.add_argument("--limit", type=int, default=20)
+        elif action == "evidence":
+            command.add_argument("evidence_id")
+            command.add_argument("--offset", type=int, default=0)
+            command.add_argument("--limit", type=int, default=8000)
+
     issue = subparsers.add_parser("issue", help="prepare local issue drafts")
     issue_commands = issue.add_subparsers(dest="issue_command", required=True)
     issue_draft = issue_commands.add_parser(
@@ -650,6 +674,40 @@ def main(argv: list[str] | None = None) -> int:
                 )
             _json(result)
             return 0
+        if args.command == "verification":
+            from .external_verification import ExternalVerification
+
+            service = ExternalVerification(config)
+            if args.verification_command == "profiles":
+                result = service.profiles(args.run_id)
+            elif args.verification_command == "request":
+                result = service.request(
+                    args.run_id,
+                    profile=args.profile,
+                    expected_revision=args.expected_revision,
+                    expected_snapshot=args.expected_snapshot,
+                    idempotency_key=args.idempotency_key,
+                )
+            elif args.verification_command == "inspect":
+                result = service.inspect(
+                    args.run_id,
+                    args.evidence_id.removeprefix("verification:"),
+                    live=args.live,
+                )
+            elif args.verification_command == "list":
+                result = service.list(args.run_id, limit=args.limit)
+            else:
+                result = service.evidence(
+                    args.run_id, args.evidence_id, offset=args.offset, limit=args.limit
+                )
+            _json(result)
+            return (
+                1
+                if isinstance(result, dict)
+                and args.verification_command == "request"
+                and result["outcome"] != "passed"
+                else 0
+            )
         if args.command == "task":
             from .external_tasks import ExternalTasks
 

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -192,6 +192,14 @@ class RepositoryPolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class VerificationProfile:
+    repository: str
+    name: str
+    commands: tuple[str, ...]
+    bootstrap_commands: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class AppConfig:
     config_version: int
     path: Path
@@ -208,6 +216,7 @@ class AppConfig:
     context: ContextConfig
     observability: ObservabilityConfig
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
+    verification_profiles: tuple[VerificationProfile, ...] = ()
 
 
 def _tuple(value: Any, default: tuple[str, ...] = ()) -> tuple[str, ...]:
@@ -1037,6 +1046,50 @@ def load_config(
                 f"{repository.name} event_payload_retention_days must be positive"
             )
 
+    profiles = []
+    # Execution requests from an Agent may only select commands owned by the user.
+    # Never merge profiles from repository-local configuration, even without a user file.
+    profile_values = user_raw.get("verification_profiles", [])
+    if not isinstance(profile_values, list) or len(profile_values) > 100:
+        raise ConfigError("verification_profiles must contain at most 100 tables")
+    profile_keys = set()
+    for value in profile_values:
+        if not isinstance(value, dict) or set(value) - {
+            "repository",
+            "name",
+            "commands",
+            "bootstrap_commands",
+        }:
+            raise ConfigError("unsupported verification profile fields")
+        repository = value.get("repository", "")
+        name = value.get("name", "")
+        if not isinstance(repository, str) or not REPOSITORY_NAME.fullmatch(repository):
+            raise ConfigError("verification profile needs owner/repository")
+        if not isinstance(name, str) or not re.fullmatch(
+            r"[a-z][a-z0-9_-]{0,63}", name
+        ):
+            raise ConfigError("invalid verification profile name")
+        commands = _tuple(value.get("commands"))
+        bootstrap = _tuple(value.get("bootstrap_commands"))
+        if (
+            not 1 <= len(commands) <= 12
+            or len(bootstrap) > 12
+            or any(
+                not command.strip()
+                or len(command) > 4000
+                or any(ord(c) < 32 for c in command)
+                for command in (*commands, *bootstrap)
+            )
+        ):
+            raise ConfigError("verification profile commands exceed limits")
+        key = (repository.casefold(), name)
+        if key in profile_keys:
+            raise ConfigError("duplicate verification profile")
+        profile_keys.add(key)
+        profiles.append(
+            VerificationProfile(repository.casefold(), name, commands, bootstrap)
+        )
+
     return AppConfig(
         config_version=version_value or CONFIG_VERSION,
         path=config_path,
@@ -1053,4 +1106,5 @@ def load_config(
         context=context,
         observability=observability,
         repositories=repositories,
+        verification_profiles=tuple(profiles),
     )

--- a/src/reposteward/external_ledger.py
+++ b/src/reposteward/external_ledger.py
@@ -21,3 +21,15 @@ EXTERNAL_TASK_MIGRATION = (
         digest TEXT NOT NULL REFERENCES content_blobs(digest),
         PRIMARY KEY(run_id,kind))""",
 )
+
+EXTERNAL_VERIFICATION_MIGRATION = (
+    """CREATE TABLE IF NOT EXISTS external_verifications (
+        id TEXT PRIMARY KEY, run_id TEXT NOT NULL REFERENCES external_task_runs(run_id),
+        project_id TEXT NOT NULL, revision INTEGER NOT NULL, idempotency_key TEXT NOT NULL,
+        request_digest TEXT NOT NULL, profile TEXT NOT NULL, profile_digest TEXT NOT NULL,
+        policy_digest TEXT NOT NULL, base_commit TEXT NOT NULL, snapshot TEXT NOT NULL,
+        outcome TEXT NOT NULL, reason TEXT NOT NULL DEFAULT '', result TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        UNIQUE(run_id,idempotency_key))""",
+    """CREATE INDEX IF NOT EXISTS external_verification_runs ON external_verifications(run_id,created_at)""",
+)

--- a/src/reposteward/external_tasks.py
+++ b/src/reposteward/external_tasks.py
@@ -287,6 +287,14 @@ class ExternalTasks:
         run = store.run(run_id)
         if bundle is None or run is None:
             raise TaskConflict("external task context is unavailable")
+        with store._connection() as db:
+            source_evidence = [
+                {"kind": row["kind"], "evidence_id": "source:" + row["digest"]}
+                for row in db.execute(
+                    "SELECT kind,digest FROM external_task_sources WHERE run_id=? ORDER BY kind",
+                    (run_id,),
+                )
+            ]
         validity = []
         current = None
         if live:
@@ -325,6 +333,7 @@ class ExternalTasks:
             "claim_trust": "agent_unverified",
             "context_pack": bundle["context_pack"],
             "checkpoint": bundle["checkpoint"],
+            "source_evidence": source_evidence,
             "public_write": False,
         }
 
@@ -511,6 +520,29 @@ class ExternalTasks:
         if type(budget) is not int or not 512 <= budget <= 100_000:
             raise ValueError("context budget must be between 512 and 100000")
         report = self.inspect(run_id, live=live)
+        from .external_verification import ExternalVerification
+
+        verifier = ExternalVerification(self.config)
+        verification = verifier.list(run_id, limit=3)
+        verification_items = []
+        for entry in verification["evidence"]:
+            if live:
+                entry = verifier.inspect(
+                    run_id, entry["evidence_id"].split(":")[1], live=True
+                )
+            verification_items.append(
+                {
+                    key: entry[key]
+                    for key in (
+                        "evidence_id",
+                        "revision",
+                        "outcome",
+                        "current_applicability",
+                        "validity",
+                        "snapshot",
+                    )
+                }
+            )
         pack = report.pop("context_pack")
         checkpoint = report.pop("checkpoint")
         # Open work and decisions come directly from the current ledger, never from a summary of a summary.
@@ -525,6 +557,10 @@ class ExternalTasks:
             "next_action": checkpoint.get("next_action", "") if checkpoint else "",
             "blockers": checkpoint.get("blockers", []) if checkpoint else [],
             "evidence": checkpoint.get("evidence", []) if checkpoint else [],
+            "verification": {
+                "items": verification_items,
+                "omitted": verification["omitted"],
+            },
             "agent_claims": {
                 "completed": checkpoint.get("completed", []) if checkpoint else [],
                 "notes": checkpoint.get("implementation_notes", "")

--- a/src/reposteward/external_verification.py
+++ b/src/reposteward/external_verification.py
@@ -1,0 +1,528 @@
+"""Scoped evidence for exact external-development snapshots; no publication authority."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict, replace
+from pathlib import Path
+from threading import Event
+from typing import Any
+
+from .config import AppConfig, VerificationProfile
+from .external_tasks import ExternalTasks, TaskConflict
+from .models import AgentResult
+from .projects import canonical_digest
+from .snapshots import snapshot_summary, verify_snapshot_copy
+from .store import Store, utc_now
+from .verifier import DockerVerifier, VerificationCancelled, VerificationError
+
+
+class ExternalVerification:
+    def __init__(self, config: AppConfig, *, verifier: DockerVerifier | None = None):
+        self.config = config
+        self.tasks = ExternalTasks(config)
+        self.verifier = verifier or DockerVerifier(config)
+
+    def profiles(self, run_id: str) -> list[dict[str, Any]]:
+        store = self.tasks._store()
+        self.tasks._record(store, run_id)
+        repository = store.run(run_id)["repository"]
+        return [
+            {
+                "name": profile.name,
+                "commands": list(profile.commands),
+                "bootstrap_commands": list(profile.bootstrap_commands),
+            }
+            for profile in self.config.verification_profiles
+            if profile.repository == repository.casefold()
+        ]
+
+    def _profile(self, repository: str, name: str) -> VerificationProfile:
+        for profile in self.config.verification_profiles:
+            if (profile.repository, profile.name) == (repository.casefold(), name):
+                return profile
+        raise VerificationError(
+            "profile is not configured for this repository in user-owned configuration"
+        )
+
+    def _profile_digest(self, profile: VerificationProfile) -> str:
+        return canonical_digest(
+            {
+                "profile": asdict(profile),
+                "runner": asdict(self.config.runner),
+                "trusted_sensitive_paths": self.config.safety.tracked_sensitive_paths_for(
+                    profile.repository
+                ),
+            }
+        )
+
+    def _directory(self, identifier: str) -> Path:
+        if not re.fullmatch(r"[0-9a-f]{32}", identifier):
+            raise ValueError("invalid verification evidence ID")
+        return self.config.state_dir / "external-verification" / identifier
+
+    def _active(self, identifier: str) -> bool:
+        try:
+            descriptor = os.open(
+                self._directory(identifier) / "lease", os.O_RDONLY | os.O_NOFOLLOW
+            )
+        except FileNotFoundError:
+            return False
+        with os.fdopen(descriptor, "r") as handle:
+            try:
+                fcntl.flock(handle, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return True
+        return False
+
+    def _row(self, store: Store, run_id: str, identifier: str) -> dict[str, Any]:
+        self.tasks._record(store, run_id)
+        self._directory(identifier)
+        with store._connection() as db:
+            row = db.execute(
+                "SELECT * FROM external_verifications WHERE id=? AND run_id=?",
+                (identifier, run_id),
+            ).fetchone()
+        if row is None:
+            raise KeyError("verification evidence not found in this task")
+        return {
+            **dict(row),
+            "snapshot": json.loads(row["snapshot"]),
+            "result": json.loads(row["result"]),
+        }
+
+    def inspect(
+        self, run_id: str, identifier: str, *, live: bool = False
+    ) -> dict[str, Any]:
+        store = self.tasks._store()
+        row = self._row(store, run_id, identifier)
+        outcome = row["outcome"]
+        reason = row["reason"]
+        if outcome == "running" and not self._active(identifier):
+            outcome, reason = (
+                "unknown",
+                "execution interrupted without a terminal record",
+            )
+        validity = []
+        if live:
+            current = self.tasks.inspect(run_id, live=True)
+            validity = [
+                value
+                for value in current["validity"]
+                if value != "workspace_changed_since_checkpoint"
+            ]
+            if current["revision"] != row["revision"]:
+                validity.append("checkpoint_revision_changed")
+            if current["current_snapshot"]["digest"] != row["snapshot"]["digest"]:
+                validity.append("workspace_changed_since_verification")
+            try:
+                profile = self._profile(store.run(run_id)["repository"], row["profile"])
+                if self._profile_digest(profile) != row["profile_digest"]:
+                    validity.append("verification_profile_changed")
+            except VerificationError:
+                validity.append("verification_profile_unavailable")
+        return {
+            "evidence_id": f"verification:{identifier}",
+            "run_id": run_id,
+            "project_id": row["project_id"],
+            "revision": row["revision"],
+            "profile": row["profile"],
+            "profile_digest": row["profile_digest"],
+            "policy_digest": row["policy_digest"],
+            "base_commit": row["base_commit"],
+            "snapshot": snapshot_summary(row["snapshot"]),
+            "outcome": outcome,
+            "reason": reason,
+            "result": row["result"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "validity": validity,
+            "current_applicability": "not_checked"
+            if not live
+            else "matches"
+            if outcome == "passed" and not validity
+            else "not_verified",
+            "evidence_kind": "development_snapshot",
+            "publication_eligible": False,
+            "public_write": False,
+        }
+
+    def list(self, run_id: str, *, limit: int = 20) -> dict[str, Any]:
+        if type(limit) is not int or not 1 <= limit <= 100:
+            raise ValueError("evidence limit must be between 1 and 100")
+        store = self.tasks._store()
+        self.tasks._record(store, run_id)
+        with store._connection() as db:
+            rows = db.execute(
+                "SELECT id FROM external_verifications WHERE run_id=? ORDER BY created_at DESC,id LIMIT ?",
+                (run_id, limit),
+            ).fetchall()
+            total = db.execute(
+                "SELECT count(*) FROM external_verifications WHERE run_id=?", (run_id,)
+            ).fetchone()[0]
+        return {
+            "run_id": run_id,
+            "evidence": [self.inspect(run_id, row["id"]) for row in rows],
+            "omitted": max(0, total - limit),
+            "public_write": False,
+        }
+
+    def request(
+        self,
+        run_id: str,
+        *,
+        profile: str,
+        expected_revision: int,
+        expected_snapshot: str,
+        idempotency_key: str,
+        cancel_event: Event | None = None,
+    ) -> dict[str, Any]:
+        if (
+            type(expected_revision) is not int
+            or expected_revision < 0
+            or not re.fullmatch(r"[0-9a-f]{64}", expected_snapshot)
+        ):
+            raise ValueError("verification needs an exact revision and snapshot digest")
+        if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,128}", idempotency_key):
+            raise ValueError("invalid verification idempotency key")
+        store = self.tasks._store(write=True)
+        record = self.tasks._record(store, run_id)
+        run = store.run(run_id)
+        selected = self._profile(run["repository"], profile)
+        profile_digest = self._profile_digest(selected)
+        request_digest = canonical_digest(
+            {
+                "run_id": run_id,
+                "profile_digest": profile_digest,
+                "revision": expected_revision,
+                "snapshot": expected_snapshot,
+            }
+        )
+        identifier = canonical_digest(
+            {"run_id": run_id, "idempotency_key": idempotency_key}
+        )[:32]
+        with store._connection() as db:
+            existing = db.execute(
+                "SELECT request_digest FROM external_verifications WHERE id=?",
+                (identifier,),
+            ).fetchone()
+        if existing:
+            if existing["request_digest"] != request_digest:
+                raise TaskConflict(
+                    "verification idempotency key was used for different input"
+                )
+            return {**self.inspect(run_id, identifier, live=True), "idempotent": True}
+        directory = self._directory(identifier)
+        directory.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(
+            directory / "lease", os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600
+        )
+        with os.fdopen(descriptor, "w") as lease:
+            try:
+                fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise TaskConflict(
+                    "verification request is already starting; query its evidence ID"
+                ) from exc
+            with store.atomic():
+                with store._connection() as db:
+                    if db.execute(
+                        "SELECT 1 FROM external_verifications WHERE id=?", (identifier,)
+                    ).fetchone():
+                        raise TaskConflict(
+                            "verification request started concurrently; query its evidence ID"
+                        )
+                current = self.tasks.inspect(run_id, live=True)
+                fresh_run = store.run(run_id)
+                if fresh_run["status"] != "running" or fresh_run["stage"] != "external":
+                    raise TaskConflict("external task is no longer running")
+                if current["revision"] != expected_revision:
+                    raise TaskConflict(
+                        "checkpoint revision changed before verification"
+                    )
+                if any(
+                    value != "workspace_changed_since_checkpoint"
+                    for value in current["validity"]
+                ):
+                    raise TaskConflict(
+                        "task policy or base changed before verification"
+                    )
+                snapshot = self.tasks._snapshot(
+                    Path(record["workspace_root"]), run["repository"]
+                )
+                if snapshot["digest"] != expected_snapshot:
+                    raise TaskConflict("workspace changed before verification")
+                now = utc_now()
+                with store._connection() as db:
+                    db.execute(
+                        """INSERT INTO external_verifications
+                        (id,run_id,project_id,revision,idempotency_key,request_digest,profile,profile_digest,
+                        policy_digest,base_commit,snapshot,outcome,created_at,updated_at)
+                        VALUES (?,?,?,?,?,?,?,?,?,?,?,'running',?,?)""",
+                        (
+                            identifier,
+                            run_id,
+                            record["project_id"],
+                            expected_revision,
+                            idempotency_key,
+                            request_digest,
+                            profile,
+                            profile_digest,
+                            record["policy_digest"],
+                            record["base_commit"],
+                            json.dumps(snapshot),
+                            now,
+                            now,
+                        ),
+                    )
+            outcome, reason, result = "unknown", "verification did not finish", {}
+            try:
+                policy = replace(
+                    self.tasks._policy(run["repository"]),
+                    bootstrap_commands=selected.bootstrap_commands,
+                )
+
+                def guard(copy: Path, phase: str) -> None:
+                    if cancel_event is not None and cancel_event.is_set():
+                        raise VerificationCancelled("verification cancelled by client")
+                    verify_snapshot_copy(
+                        copy,
+                        snapshot,
+                        exact=phase == "copied",
+                        trusted_sensitive_paths=self.config.safety.tracked_sensitive_paths_for(
+                            policy.name
+                        ),
+                    )
+                    observed = self.tasks.inspect(run_id, live=True)
+                    if (
+                        any(
+                            value != "workspace_changed_since_checkpoint"
+                            for value in observed["validity"]
+                        )
+                        or observed["current_snapshot"]["digest"] != snapshot["digest"]
+                    ):
+                        raise TaskConflict(
+                            "source workspace or authority changed during verification"
+                        )
+
+                verification = self.verifier.verify(
+                    Path(record["workspace_root"]),
+                    policy,
+                    AgentResult("external verification", "", "", selected.commands),
+                    run_dir=directory,
+                    snapshot_guard=guard,
+                    **(
+                        {"cancel_event": cancel_event}
+                        if cancel_event is not None
+                        else {}
+                    ),
+                )
+                result = self._result(verification, directory)
+                outcome = "passed" if verification.passed else "failed"
+                reason = verification.reason
+                if any(command.exit_code == 124 for command in verification.commands):
+                    outcome, reason = "unknown", "verification timed out"
+            except (KeyboardInterrupt, VerificationCancelled):
+                outcome, reason = "cancelled", "verification cancelled by operator"
+            except (
+                OSError,
+                RuntimeError,
+                ValueError,
+                subprocess.SubprocessError,
+            ) as exc:
+                outcome, reason = (
+                    "unknown",
+                    f"verification interrupted: {type(exc).__name__}: {str(exc)[:500]}",
+                )
+            finally:
+                if not result:
+                    result = self._partial_result(directory, selected)
+                with store._connection() as db:
+                    db.execute(
+                        "UPDATE external_verifications SET outcome=?,reason=?,result=?,updated_at=? WHERE id=?",
+                        (outcome, reason, json.dumps(result), utc_now(), identifier),
+                    )
+        return {**self.inspect(run_id, identifier, live=True), "idempotent": False}
+
+    @staticmethod
+    def _partial_result(
+        directory: Path, profile: VerificationProfile
+    ) -> dict[str, Any]:
+        commands = []
+        planned = (
+            [("00-bootstrap.log", " && ".join(profile.bootstrap_commands))]
+            if profile.bootstrap_commands
+            else []
+        ) + [
+            (f"{index:02d}-command.log", command)
+            for index, command in enumerate(profile.commands, 1)
+        ]
+        for filename, command in planned:
+            path = directory / "verification" / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            with path.open("rb") as handle:
+                raw = handle.read(8_000_001)
+            if len(raw) > 8_000_000:
+                continue
+            commands.append(
+                {
+                    "command": command,
+                    "exit_code": None,
+                    "output": raw.decode("utf-8", errors="replace")[-2000:],
+                    "output_truncated": True,
+                    "log": {
+                        "index": len(commands),
+                        "path": f"verification/{filename}",
+                        "stored_digest": hashlib.sha256(raw).hexdigest(),
+                        "stored_bytes": len(raw),
+                        "complete": False,
+                    },
+                }
+            )
+        return {
+            "passed": False,
+            "commands": commands,
+            "integrity": "partial",
+            "reason": "execution did not establish a terminal test result",
+        }
+
+    @staticmethod
+    def _result(verification, directory: Path) -> dict[str, Any]:
+        commands = []
+        for index, command in enumerate(verification.commands):
+            value = asdict(command)
+            log_path = value.pop("log_path")
+            value["output"] = value["output"][-2000:]
+            value["output_truncated"] = (
+                command.output_truncated or len(command.output) > 2000
+            )
+            if log_path:
+                path = Path(log_path)
+                if path.is_symlink() or not path.resolve().is_relative_to(
+                    directory.resolve()
+                ):
+                    raise VerificationError("verification log escaped evidence storage")
+                raw = path.read_bytes()
+                value["log"] = {
+                    "index": index,
+                    "path": str(path.relative_to(directory)),
+                    "stored_digest": hashlib.sha256(raw).hexdigest(),
+                    "stored_bytes": len(raw),
+                    "complete": not command.log_truncated,
+                }
+            commands.append(value)
+        return {
+            "passed": verification.passed,
+            "commands": commands,
+            "reason": verification.reason,
+        }
+
+    def evidence(
+        self, run_id: str, evidence_id: str, *, offset: int = 0, limit: int = 8000
+    ) -> dict[str, Any]:
+        if (
+            type(offset) is not int
+            or offset < 0
+            or type(limit) is not int
+            or not 1 <= limit <= 16000
+        ):
+            raise ValueError(
+                "evidence needs a nonnegative offset and limit between 1 and 16000"
+            )
+        store = self.tasks._store()
+        self.tasks._record(store, run_id)
+        parts = evidence_id.split(":")
+        raw = None
+        digest = ""
+        complete = True
+        if len(parts) == 2 and parts[0] == "verification":
+            raw = json.dumps(
+                self.inspect(run_id, parts[1]), ensure_ascii=False, sort_keys=True
+            ).encode()
+        elif len(parts) == 3 and parts[0] == "log" and parts[2].isdigit():
+            row = self._row(store, run_id, parts[1])
+            index = int(parts[2])
+            commands = row["result"].get("commands", [])
+            if index >= len(commands) or not commands[index].get("log"):
+                raise KeyError("verification log is unavailable")
+            log = commands[index]["log"]
+            directory = self._directory(parts[1])
+            relative = Path(log["path"])
+            if relative.is_absolute() or ".." in relative.parts:
+                raise VerificationError("invalid evidence log path")
+            target = directory / relative
+            if any(
+                parent.is_symlink()
+                for parent in [target, *target.parents]
+                if parent != directory.parent
+            ):
+                raise VerificationError("evidence log path must not contain symlinks")
+            try:
+                descriptor = os.open(
+                    target, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+                )
+                with os.fdopen(descriptor, "rb") as handle:
+                    raw = handle.read(8_000_001)
+            except FileNotFoundError:
+                raw = None
+            digest = log["stored_digest"]
+            complete = log["complete"]
+        elif len(parts) == 2 and parts[0] == "source":
+            with store._connection() as db:
+                row = db.execute(
+                    "SELECT digest FROM external_task_sources WHERE run_id=? AND digest=?",
+                    (run_id, parts[1]),
+                ).fetchone()
+            if row is None:
+                raise KeyError("source evidence not found in this task")
+            digest = row["digest"]
+            raw = store.content_blob(digest)
+        elif (
+            len(parts) == 3
+            and parts[0] == "checkpoint"
+            and parts[1] == run_id
+            and parts[2].isdigit()
+        ):
+            with store._connection() as db:
+                row = db.execute(
+                    """SELECT c.payload FROM external_task_checkpoints e JOIN checkpoints c ON c.id=e.checkpoint_id
+                    WHERE e.run_id=? AND e.revision=?""",
+                    (run_id, int(parts[2])),
+                ).fetchone()
+            raw = row["payload"].encode() if row else None
+        else:
+            raise KeyError("unsupported or out-of-scope evidence ID")
+        if raw is None:
+            return {
+                "evidence_id": evidence_id,
+                "availability": "unknown",
+                "reason": "evidence payload unavailable",
+            }
+        if len(raw) > 8_000_000 or digest and hashlib.sha256(raw).hexdigest() != digest:
+            return {
+                "evidence_id": evidence_id,
+                "availability": "unknown",
+                "reason": "evidence integrity check failed",
+            }
+        content = raw.decode("utf-8", errors="replace")
+        end = min(len(content), offset + limit)
+        return {
+            "evidence_id": evidence_id,
+            "run_id": run_id,
+            "availability": "available",
+            "digest": hashlib.sha256(raw).hexdigest(),
+            "complete": complete,
+            "text": content[offset:end],
+            "offset": offset,
+            "returned": len(content[offset:end]),
+            "total": len(content),
+            "unit": "characters",
+            "next_offset": end if end < len(content) else None,
+            "public_write": False,
+        }

--- a/src/reposteward/snapshots.py
+++ b/src/reposteward/snapshots.py
@@ -17,16 +17,20 @@ MAX_SNAPSHOT_BYTES = 200_000_000
 
 
 def _entries(
-    root: Path, *, trusted_sensitive_paths: tuple[str, ...]
+    root: Path,
+    *,
+    trusted_sensitive_paths: tuple[str, ...],
+    names: dict[str, bool] | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
-    tracked = local_git(root, "ls-files", "--cached", "-z").split("\0")
-    untracked = local_git(
-        root, "ls-files", "--others", "--exclude-standard", "-z"
-    ).split("\0")
-    names = {name: True for name in tracked if name}
-    for name in untracked:
-        if name:
-            names.setdefault(name, False)
+    if names is None:
+        tracked = local_git(root, "ls-files", "--cached", "-z").split("\0")
+        untracked = local_git(
+            root, "ls-files", "--others", "--exclude-standard", "-z"
+        ).split("\0")
+        names = {name: True for name in tracked if name}
+        for name in untracked:
+            if name:
+                names.setdefault(name, False)
     if len(names) > MAX_SNAPSHOT_FILES:
         raise ProjectError("workspace exceeds snapshot file limit")
     manifest, total, excluded = [], 0, 0
@@ -167,3 +171,37 @@ def snapshot_summary(snapshot: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in snapshot.items() if key != "files"} | {
         "file_count": len(snapshot["files"])
     }
+
+
+def verify_snapshot_copy(
+    root: Path,
+    snapshot: dict[str, Any],
+    *,
+    exact: bool,
+    trusted_sensitive_paths: tuple[str, ...] = (),
+) -> None:
+    """Compare the actual sandbox bytes with the frozen source manifest, without Git."""
+    expected = snapshot["files"]
+    names = {entry["path"]: entry["tracked"] for entry in expected}
+    actual, _ = _entries(
+        root, trusted_sensitive_paths=trusted_sensitive_paths, names=names
+    )
+    if actual != expected:
+        raise ProjectError("verification copy differs from the requested code snapshot")
+    if exact:
+        copied = set()
+        for directory, directories, files in os.walk(root, followlinks=False):
+            for name in tuple(directories):
+                if (Path(directory) / name).is_symlink():
+                    files.append(name)
+                    directories.remove(name)
+            for name in files:
+                relative = (Path(directory) / name).relative_to(root).as_posix()
+                if relative != ".git":
+                    copied.add(relative)
+                if len(copied) > MAX_SNAPSHOT_FILES:
+                    raise ProjectError("verification copy exceeds snapshot file limit")
+        if copied != {
+            entry["path"] for entry in expected if entry["kind"] != "deleted"
+        }:
+            raise ProjectError("verification copy contains unexpected or missing files")

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from .external_ledger import EXTERNAL_TASK_MIGRATION
+from .external_ledger import EXTERNAL_TASK_MIGRATION, EXTERNAL_VERIFICATION_MIGRATION
 from .feedback import (
     FEEDBACK_MIGRATION,
     feedback_report,
@@ -24,9 +24,10 @@ from .feedback import (
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
+    20: EXTERNAL_VERIFICATION_MIGRATION,
     19: EXTERNAL_TASK_MIGRATION,
     18: FEEDBACK_MIGRATION,
     1: (

--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -9,10 +9,11 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from itertools import chain
 from pathlib import Path
+from threading import Event
 
 from .config import AppConfig, RepositoryPolicy
 from .models import AgentResult, CommandResult, VerificationResult
@@ -63,6 +64,10 @@ class VerificationError(RuntimeError):
     """Verification could not be run safely."""
 
 
+class VerificationCancelled(VerificationError):
+    """The requesting client cancelled an isolated verification."""
+
+
 def _output_text(value: str | bytes | None) -> str:
     if value is None:
         return ""
@@ -81,6 +86,7 @@ class DockerVerifier:
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env={"PATH": os.environ.get("PATH", "")},
         )
         return result.returncode == 0
 
@@ -91,6 +97,8 @@ class DockerVerifier:
         agent_result: AgentResult,
         *,
         run_dir: Path | None = None,
+        snapshot_guard: Callable[[Path, str], None] | None = None,
+        cancel_event: Event | None = None,
     ) -> VerificationResult:
         if not self.image_available():
             raise VerificationError(
@@ -122,10 +130,15 @@ class DockerVerifier:
 
         verification_dir = run_dir / "verification" if run_dir is not None else None
         results: list[CommandResult] = []
+        cancellation = (
+            {"cancel_event": cancel_event} if cancel_event is not None else {}
+        )
         with self._verification_sandbox(
             worktree, verification_dir, policy=policy
         ) as sandbox:
             sandbox_worktree, environment_dir, git_dir = sandbox
+            if snapshot_guard is not None:
+                snapshot_guard(sandbox_worktree, "copied")
             if policy.bootstrap_commands:
                 bootstrap = " && ".join(policy.bootstrap_commands)
                 result = self._run_container(
@@ -139,12 +152,15 @@ class DockerVerifier:
                     ),
                     environment_dir=environment_dir,
                     git_dir=git_dir,
+                    **cancellation,
                 )
                 results.append(result)
                 if result.exit_code:
                     return VerificationResult(
                         False, tuple(results), "dependency bootstrap failed"
                     )
+            if snapshot_guard is not None:
+                snapshot_guard(sandbox_worktree, "bootstrapped")
             for index, command in enumerate(commands, start=1):
                 result = self._run_container(
                     sandbox_worktree,
@@ -157,8 +173,11 @@ class DockerVerifier:
                     ),
                     environment_dir=environment_dir,
                     git_dir=git_dir,
+                    **cancellation,
                 )
                 results.append(result)
+                if snapshot_guard is not None:
+                    snapshot_guard(sandbox_worktree, "command_finished")
                 if result.exit_code:
                     return VerificationResult(
                         False, tuple(results), f"verification failed: {command}"
@@ -472,14 +491,18 @@ class DockerVerifier:
         log_path: Path | None = None,
         environment_dir: Path | None = None,
         git_dir: Path | None = None,
+        cancel_event: Event | None = None,
     ) -> CommandResult:
         runner = self.config.runner
         environment_dir = environment_dir or worktree
         shell_command = f'mkdir -p "$HOME" && {command}'
+        container_name = f"reposteward-verify-{uuid.uuid4().hex}"
         docker_command = [
             "docker",
             "run",
             "--rm",
+            "--name",
+            container_name,
             "--network",
             "bridge" if network else "none",
             "--cpus",
@@ -528,19 +551,28 @@ class DockerVerifier:
         docker_command.extend([runner.image, "bash", "-lc", shell_command])
         start = time.monotonic()
         try:
-            result = subprocess.run(
-                docker_command,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=runner.timeout_seconds,
-                env={"PATH": os.environ.get("PATH", "")},
-            )
+            if cancel_event is None:
+                result = subprocess.run(
+                    docker_command,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=runner.timeout_seconds,
+                    env={"PATH": os.environ.get("PATH", "")},
+                )
+            else:
+                result = self._cancellable_command(
+                    docker_command, cancel_event, runner.timeout_seconds
+                )
             full_output = result.stdout + result.stderr
             exit_code = result.returncode
         except subprocess.TimeoutExpired as exc:
+            self._remove_container(container_name)
             full_output = _output_text(exc.stdout) + _output_text(exc.stderr)
             exit_code = 124
+        except BaseException:
+            self._remove_container(container_name)
+            raise
         encoded_output = full_output.encode("utf-8", errors="replace")
         log_truncated = len(full_output) > runner.max_log_chars
         if log_path is not None:
@@ -570,3 +602,53 @@ class DockerVerifier:
             output_truncated=len(full_output) > output_limit,
             log_truncated=log_truncated,
         )
+
+    @staticmethod
+    def _cancellable_command(
+        command: list[str], cancelled: Event, timeout: int
+    ) -> subprocess.CompletedProcess:
+        if cancelled.is_set():
+            raise VerificationCancelled("verification cancelled before container start")
+        started = time.monotonic()
+        with subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={"PATH": os.environ.get("PATH", "")},
+        ) as process:
+            try:
+                while True:
+                    if cancelled.is_set():
+                        raise VerificationCancelled("verification cancelled by client")
+                    try:
+                        stdout, stderr = process.communicate(timeout=0.2)
+                        return subprocess.CompletedProcess(
+                            command, process.returncode, stdout, stderr
+                        )
+                    except subprocess.TimeoutExpired:
+                        if time.monotonic() - started >= timeout:
+                            process.kill()
+                            stdout, stderr = process.communicate()
+                            raise subprocess.TimeoutExpired(
+                                command, timeout, output=stdout, stderr=stderr
+                            ) from None
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.communicate()
+
+    @staticmethod
+    def _remove_container(name: str) -> None:
+        # Killing the Docker client does not reliably stop its container.
+        try:
+            subprocess.run(
+                ["docker", "rm", "--force", name],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=15,
+                env={"PATH": os.environ.get("PATH", "")},
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass  # No success evidence is emitted after interruption.

--- a/tests/test_external_verification.py
+++ b/tests/test_external_verification.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from dataclasses import replace
+from pathlib import Path
+from threading import Event, Timer
+from unittest.mock import patch
+
+import test_external_tasks
+
+from reposteward.cli import main
+from reposteward.config import ConfigError, VerificationProfile, load_config
+from reposteward.external_tasks import TaskConflict
+from reposteward.external_verification import ExternalVerification
+from reposteward.models import CommandResult
+from reposteward.verifier import (
+    DockerVerifier,
+    VerificationCancelled,
+    VerificationError,
+)
+
+
+class ExternalVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        test_external_tasks.ExternalTaskTests.setUp(self)
+        policy = replace(
+            self.config.repositories["owner/repo"],
+            verification_prefixes=("python ",),
+            required_verification_markers=(),
+        )
+        self.config = replace(
+            self.config,
+            repositories={"owner/repo": policy},
+            verification_profiles=(
+                VerificationProfile(
+                    "owner/repo",
+                    "test",
+                    ("python -m unittest",),
+                    ("python -m pip --version",),
+                ),
+            ),
+        )
+        self.service.config = self.config
+        self.task = self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+        self.verifier = DockerVerifier(self.config)
+        self.check = ExternalVerification(self.config, verifier=self.verifier)
+        self.calls = []
+        self.image = patch.object(self.verifier, "image_available", return_value=True)
+        self.image.start()
+        self.addCleanup(self.image.stop)
+        self.container = patch.object(
+            self.verifier, "_run_container", side_effect=self.container_run
+        )
+        self.mock_container = self.container.start()
+        self.addCleanup(self.container.stop)
+
+    def container_run(
+        self, snapshot: Path, command: str, *, network: bool, log_path: Path, **kwargs
+    ) -> CommandResult:
+        self.calls.append((snapshot, command, network))
+        self.assertNotEqual(snapshot, self.repo)
+        self.assertEqual(
+            (snapshot / "source.txt").read_text(),
+            (self.repo / "source.txt").read_text(),
+        )
+        output = "verification output\n" * 300
+        log_path.write_text(output)
+        return CommandResult(
+            command,
+            0,
+            output[-2000:],
+            0.1,
+            str(log_path),
+            len(output),
+            len(output),
+            hashlib.sha256(output.encode()).hexdigest(),
+            True,
+            False,
+        )
+
+    def request(self, *, key: str = "one", revision: int = 0) -> dict:
+        current = self.service.inspect(self.task["run_id"], live=True)
+        return self.check.request(
+            self.task["run_id"],
+            profile="test",
+            expected_revision=revision,
+            expected_snapshot=current["current_snapshot"]["digest"],
+            idempotency_key=key,
+        )
+
+    def test_dirty_snapshot_is_verified_in_actual_copy_and_remains_unpublishable(
+        self,
+    ) -> None:
+        (self.repo / "source.txt").write_text("dirty code\n")
+        (self.repo / "untracked.py").write_text("print('new')\n")
+        result = self.request()
+        self.assertEqual(result["outcome"], "passed")
+        self.assertEqual(result["current_applicability"], "matches")
+        self.assertTrue(result["snapshot"]["dirty"])
+        self.assertFalse(result["publication_eligible"])
+        self.assertEqual([call[2] for call in self.calls], [True, False])
+        self.assertTrue(all(not call[0].exists() for call in self.calls))
+        self.assertEqual(self.service.inspect(self.task["run_id"])["status"], "running")
+        retry = self.request()
+        self.assertTrue(retry["idempotent"])
+        self.assertEqual(len(self.calls), 2)
+        (self.repo / "source.txt").write_text("later edit\n")
+        inspection = self.check.inspect(
+            self.task["run_id"], result["evidence_id"].split(":")[1], live=True
+        )
+        self.assertEqual(inspection["outcome"], "passed")
+        self.assertEqual(inspection["current_applicability"], "not_verified")
+        self.assertIn("workspace_changed_since_verification", inspection["validity"])
+        with self.assertRaisesRegex(TaskConflict, "different input"):
+            self.request()
+
+    def test_copy_corruption_is_detected_before_any_container_execution(self) -> None:
+        original = self.verifier._copy_workspace
+
+        def corrupted(source, target, **kwargs):
+            copied = original(source, target, **kwargs)
+            (target / "source.txt").write_text("corrupt copy")
+            return copied
+
+        with patch.object(self.verifier, "_copy_workspace", side_effect=corrupted):
+            result = self.request()
+        self.assertEqual(result["outcome"], "unknown")
+        self.assertIn("differs", result["reason"])
+        self.assertEqual(self.calls, [])
+
+    def test_source_and_bootstrap_mutations_cannot_produce_success_evidence(
+        self,
+    ) -> None:
+        def edit_source(snapshot, command, **kwargs):
+            result = self.container_run(snapshot, command, **kwargs)
+            (self.repo / "source.txt").write_text("edited while container ran")
+            return result
+
+        self.mock_container.side_effect = edit_source
+        result = self.request()
+        self.assertEqual(result["outcome"], "unknown")
+        self.assertIn("changed during verification", result["reason"])
+        self.assertEqual(len(self.calls), 1)
+        self.calls.clear()
+
+        def edit_copy(snapshot, command, **kwargs):
+            result = self.container_run(snapshot, command, **kwargs)
+            (snapshot / "source.txt").write_text("bootstrap replaced code")
+            return result
+
+        self.mock_container.side_effect = edit_copy
+        result = self.request(key="two")
+        self.assertEqual(result["outcome"], "unknown")
+        self.assertEqual(len(self.calls), 1)
+
+    def test_failures_cancellation_timeout_and_lost_terminal_record_are_distinct(
+        self,
+    ) -> None:
+        def failed(snapshot, command, **kwargs):
+            return replace(self.container_run(snapshot, command, **kwargs), exit_code=1)
+
+        self.mock_container.side_effect = failed
+        self.assertEqual(self.request()["outcome"], "failed")
+        self.mock_container.side_effect = KeyboardInterrupt
+        self.assertEqual(self.request(key="cancel")["outcome"], "cancelled")
+
+        def timeout(snapshot, command, **kwargs):
+            return replace(
+                self.container_run(snapshot, command, **kwargs), exit_code=124
+            )
+
+        self.mock_container.side_effect = timeout
+        result = self.request(key="timeout")
+        self.assertEqual(result["outcome"], "unknown")
+        self.assertIn("timed out", result["reason"])
+        identifier = result["evidence_id"].split(":")[1]
+        with self.service._store(write=True)._connection() as db:
+            db.execute(
+                "UPDATE external_verifications SET outcome='running' WHERE id=?",
+                (identifier,),
+            )
+        self.assertEqual(
+            self.check.inspect(self.task["run_id"], identifier)["outcome"], "unknown"
+        )
+        count = len(self.calls)
+        self.assertEqual(self.request(key="timeout")["outcome"], "unknown")
+        self.assertEqual(len(self.calls), count)
+
+    def test_profile_revision_base_and_request_scope_are_rechecked(self) -> None:
+        with self.assertRaisesRegex(TaskConflict, "revision"):
+            self.request(revision=1)
+        with self.assertRaisesRegex(VerificationError, "user-owned"):
+            self.check.request(
+                self.task["run_id"],
+                profile="python -c arbitrary",
+                expected_revision=0,
+                expected_snapshot=self.task["snapshot"]["digest"],
+                idempotency_key="bad",
+            )
+        result = self.request()
+        identifier = result["evidence_id"].split(":")[1]
+        changed = replace(
+            self.config,
+            verification_profiles=(
+                VerificationProfile("owner/repo", "test", ("python -m unittest -v",)),
+            ),
+        )
+        self.assertIn(
+            "verification_profile_changed",
+            ExternalVerification(changed).inspect(
+                self.task["run_id"], identifier, live=True
+            )["validity"],
+        )
+        other = self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+        with self.assertRaises(KeyError):
+            self.check.inspect(other["run_id"], identifier)
+        with self.assertRaises(KeyError):
+            self.check.evidence(other["run_id"], f"log:{identifier}:0")
+        current = self.service.inspect(self.task["run_id"], live=True)
+        self.service.checkpoint(
+            self.task["run_id"],
+            expected_revision=0,
+            expected_snapshot=current["current_snapshot"]["digest"],
+            idempotency_key="cp",
+            payload={"next_action": "continue"},
+        )
+        self.assertIn(
+            "checkpoint_revision_changed",
+            self.check.inspect(self.task["run_id"], identifier, live=True)["validity"],
+        )
+
+    def test_bounded_logs_source_lookup_missing_and_tampered_evidence(self) -> None:
+        result = self.request()
+        run_id = self.task["run_id"]
+        identifier = result["evidence_id"].split(":")[1]
+        report = self.check.evidence(run_id, f"log:{identifier}:0", limit=32)
+        self.assertEqual(report["returned"], 32)
+        self.assertEqual(report["next_offset"], 32)
+        log = (
+            self.check._directory(identifier)
+            / result["result"]["commands"][0]["log"]["path"]
+        )
+        log.write_text("tampered")
+        self.assertEqual(
+            self.check.evidence(run_id, f"log:{identifier}:0")["availability"],
+            "unknown",
+        )
+        log.unlink()
+        self.assertEqual(
+            self.check.evidence(run_id, f"log:{identifier}:0")["availability"],
+            "unknown",
+        )
+        with self.service._store()._connection() as db:
+            digest = db.execute(
+                "SELECT digest FROM external_task_sources WHERE run_id=?", (run_id,)
+            ).fetchone()[0]
+        self.assertEqual(
+            self.check.evidence(run_id, f"source:{digest}")["availability"], "available"
+        )
+        self.assertEqual(
+            self.check.evidence(run_id, f"checkpoint:{run_id}:0")["availability"],
+            "available",
+        )
+        with self.assertRaises(KeyError):
+            self.check.evidence(run_id, "source:" + "f" * 64)
+        with self.assertRaises(ValueError):
+            self.check.evidence(run_id, result["evidence_id"], limit=16001)
+        self.assertEqual(self.check.list(run_id, limit=1)["omitted"], 0)
+
+    def test_trusted_profile_config_ignores_repository_override(self) -> None:
+        user = self.root / "user.toml"
+        project = self.root / "repo.toml"
+        stanza = '\n[[verification_profiles]]\nrepository="owner/repo"\nname="test"\ncommands=["python -m unittest"]\n'
+        user.write_text(user.read_text() + stanza)
+        project.write_text(
+            project.read_text() + stanza.replace("python -m unittest", "python evil.py")
+        )
+        config = load_config(project, user_path=user)
+        self.assertEqual(
+            config.verification_profiles[0].commands, ("python -m unittest",)
+        )
+        standalone = self.root / "standalone.toml"
+        standalone.write_text(project.read_text() + '\n[github]\nlogin="owner"\n')
+        self.assertEqual(load_config(standalone).verification_profiles, ())
+        user.write_text(user.read_text() + stanza)
+        with self.assertRaisesRegex(ConfigError, "duplicate"):
+            load_config(project, user_path=user)
+
+    def test_read_only_cli_does_not_start_pipeline_or_harness(self) -> None:
+        self.request()
+        output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            patch("reposteward.cli.Pipeline", side_effect=AssertionError("Pipeline")),
+            redirect_stdout(output),
+        ):
+            self.assertEqual(main(["verification", "list", self.task["run_id"]]), 0)
+        self.assertEqual(
+            json.loads(output.getvalue())["evidence"][0]["outcome"], "passed"
+        )
+
+    def test_timeout_removes_exact_docker_container_with_minimal_environment(
+        self,
+    ) -> None:
+        self.container.stop()
+        self.addCleanup(lambda: None)
+        timeout = subprocess.TimeoutExpired(["docker"], 1, output=b"partial")
+        with (
+            patch(
+                "reposteward.verifier.subprocess.run",
+                side_effect=[timeout, subprocess.CompletedProcess([], 0)],
+            ) as run,
+            patch.dict(os.environ, {"GITHUB_TOKEN": "sentinel-never-forward"}),
+        ):
+            result = self.verifier._run_container(
+                self.repo, "python -m unittest", network=False
+            )
+        self.assertEqual(result.exit_code, 124)
+        first, second = run.call_args_list
+        docker = first.args[0]
+        self.assertEqual(
+            second.args[0],
+            ["docker", "rm", "--force", docker[docker.index("--name") + 1]],
+        )
+        self.assertNotIn("GITHUB_TOKEN", first.kwargs["env"])
+        self.assertNotIn("GITHUB_TOKEN", second.kwargs["env"])
+
+    def test_cancel_event_stops_before_execution_and_persists_cancelled_evidence(
+        self,
+    ) -> None:
+        cancelled = Event()
+        cancelled.set()
+        result = self.check.request(
+            self.task["run_id"],
+            profile="test",
+            expected_revision=0,
+            expected_snapshot=self.task["snapshot"]["digest"],
+            idempotency_key="client-cancel",
+            cancel_event=cancelled,
+        )
+        self.assertEqual(result["outcome"], "cancelled")
+        self.assertEqual(self.calls, [])
+
+    def test_cancellable_process_is_reaped_when_client_disconnects(self) -> None:
+        cancelled = Event()
+        timer = Timer(0.1, cancelled.set)
+        timer.start()
+        try:
+            with self.assertRaises(VerificationCancelled):
+                self.verifier._cancellable_command(
+                    [sys.executable, "-c", "import time; time.sleep(30)"], cancelled, 1
+                )
+        finally:
+            timer.cancel()
+            timer.join()


### PR DESCRIPTION
Closes #100

Verify exact external development snapshots and expose bounded task-scoped evidence.

---

Users configure named verification profiles in trusted configuration; agents choose a profile rather than arbitrary commands. Reuse the hardened no-network verifier after credential-free dependency bootstrap. Bind evidence to task revision, head/base, source snapshot, policy and verification profile; detect source drift before and after execution. Passed historical results do not imply current applicability, and interrupted requests remain unknown until reconciled. Verification evidence does not grant publication eligibility.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
