### PR TITLE
feat(knowledge): retain scoped guidance with review and invalidation evidence

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -991,3 +991,46 @@ reposteward verification evidence <run-id> log:<id>:0 --offset 0 --limit 8000
 查询限制在所选任务，正文按字符分页；来源可用 `source:<digest>`、检查点可用
 `checkpoint:<run-id>:<revision>` 取回。日志摘要记录完整输出摘要及已保留日志摘要，
 截断与缺失分别报告；正文被修改或丢失时返回 unknown。查询不调用模型或 GitHub。
+
+## 保存可以重验的项目经验
+
+经验先作为 `candidate` 保存，须指明适用路径、直接来源证据和可选条件。条件目前
+支持 `branch` 和 `verification_profile`，不执行模型提供的判断代码。候选不进入任务
+提示，MCP 也不提供晋升或修改规则文件的工具。
+
+```json
+{"statement":"修改此模块时应覆盖空输入", "scope_paths":["src/parser.py"],
+ "evidence_ids":["checkpoint:<run-id>:0"], "conditions":{"verification_profile":"test"}}
+```
+
+```bash
+reposteward knowledge propose <run-id> --input knowledge.json
+reposteward knowledge promote <run-id> <knowledge-id> --reviewed-by your-login \
+  --basis verification_evidence --verification-id verification:<id> --rationale "说明哪些测试支持这条经验"
+reposteward knowledge list <run-id> --scope-path src --limit 5
+reposteward knowledge inspect <run-id> <knowledge-id> --live
+reposteward task context <run-id> --scope-path src --format markdown
+```
+
+审阅后状态为 `reviewed`，依据始终明确区分 `human_confirmation` 和
+`verification_evidence`。前者是人工确认，后者要求当前快照的测试证据通过，另由审阅人
+说明证据与结论的关系；测试通过本身不会自动证明模型的任意总结。
+
+依赖摘要覆盖所声明路径中的文件。路径内代码或引用来源变化、条件不符、验证配置
+变化后，条目显示 `stale` 并从默认提示中移除；路径之外的编辑不自动使其失效。
+声明路径也承担重验范围，需要审阅人确认依赖范围完整。查询只核对本地证据，线上
+来源是否更新仍需明确刷新。`--all` 可查看候选、过期与被替代条目。
+
+更新经验时在新提案中设置 `supersedes`，新提案审阅通过后才原子替代旧条目，保留
+历史关系。重复提案和相同审阅幂等。跨项目查询隔离，不自动把业务经验升级为通用
+偏好，不复制原生聊天或改写项目的 AGENTS/CLAUDE/skills 文件。
+
+任务仅在显式提供 `--scope-path` 时选择最多五条有效经验。
+预算不足先省略可取回的经验，并记录数量、来源与摘要；需求、
+开放项与决定继续保留。正文可通过 `verification evidence <run-id> knowledge:<id>`
+有界取回。此流程沿用 #82/PR #84 的证据回顾思路，规则文件的最终变更仍需目标项目审阅。
+
+通用偏好单独放在用户配置的顶层 `guidance_preferences = ["偏好简短说明"]` 中，
+最多十条、每条一千字符；仓库文件里的同名字段不生效。上下文将其标为
+`user_preference`，不与项目经验或测试事实混合；预算不足时记录省略数量。
+项目经验不会自动写入此用户配置。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -113,6 +113,35 @@ def _parser() -> argparse.ArgumentParser:
         elif action in {"apply", "revert"}:
             command.add_argument("--plan-digest", required=True)
 
+    knowledge = subparsers.add_parser(
+        "knowledge", help="review and query evidence-backed project guidance"
+    )
+    knowledge_commands = knowledge.add_subparsers(
+        dest="knowledge_command", required=True
+    )
+    for action in ("propose", "promote", "inspect", "list"):
+        command = knowledge_commands.add_parser(action)
+        command.add_argument("run_id")
+        if action == "propose":
+            command.add_argument("--input", type=Path, required=True)
+        elif action == "promote":
+            command.add_argument("knowledge_id")
+            command.add_argument("--reviewed-by", required=True)
+            command.add_argument(
+                "--basis",
+                choices=("human_confirmation", "verification_evidence"),
+                required=True,
+            )
+            command.add_argument("--rationale", required=True)
+            command.add_argument("--verification-id", default="")
+        elif action == "inspect":
+            command.add_argument("knowledge_id")
+            command.add_argument("--live", action="store_true")
+        else:
+            command.add_argument("--scope-path", action="append", default=[])
+            command.add_argument("--limit", type=int, default=5)
+            command.add_argument("--all", action="store_true")
+
     task = subparsers.add_parser(
         "task", help="assist coding agents in linked local projects"
     )
@@ -135,12 +164,14 @@ def _parser() -> argparse.ArgumentParser:
     task_context.add_argument("run_id")
     task_context.add_argument("--budget", type=int, default=24_000)
     task_context.add_argument("--live", action="store_true")
+    task_context.add_argument("--scope-path", action="append", default=[])
     task_context.add_argument("--format", choices=("json", "markdown"), default="json")
     task_current = task_commands.add_parser(
         "current", help="get the current task for a linked workspace"
     )
     task_current.add_argument("path", type=Path, nargs="?", default=Path.cwd())
     task_current.add_argument("--budget", type=int, default=24_000)
+    task_current.add_argument("--scope-path", action="append", default=[])
     task_current.add_argument("--format", choices=("json", "markdown"), default="json")
     task_checkpoint = task_commands.add_parser(
         "checkpoint", help="save unverified Agent claims with revision checks"
@@ -674,6 +705,36 @@ def main(argv: list[str] | None = None) -> int:
                 )
             _json(result)
             return 0
+        if args.command == "knowledge":
+            from .knowledge import ProjectKnowledge
+
+            service = ProjectKnowledge(config)
+            if args.knowledge_command == "propose":
+                with args.input.open("rb") as handle:
+                    raw = handle.read(100_001)
+                if len(raw) > 100_000:
+                    raise ValueError("knowledge input exceeds 100000 bytes")
+                result = service.propose(args.run_id, json.loads(raw))
+            elif args.knowledge_command == "promote":
+                result = service.promote(
+                    args.run_id,
+                    args.knowledge_id,
+                    reviewed_by=args.reviewed_by,
+                    basis=args.basis,
+                    rationale=args.rationale,
+                    verification_id=args.verification_id,
+                )
+            elif args.knowledge_command == "inspect":
+                result = service.inspect(args.run_id, args.knowledge_id, live=args.live)
+            else:
+                result = service.list(
+                    args.run_id,
+                    scope_paths=tuple(args.scope_path) or (".",),
+                    limit=args.limit,
+                    include_inactive=args.all,
+                )
+            _json(result)
+            return 0
         if args.command == "verification":
             from .external_verification import ExternalVerification
 
@@ -733,10 +794,15 @@ def main(argv: list[str] | None = None) -> int:
             elif args.task_command == "inspect":
                 result = service.inspect(args.run_id, live=args.live)
             elif args.task_command == "current":
-                result = service.current(args.path, budget=args.budget)
+                result = service.current(
+                    args.path, budget=args.budget, scope_paths=tuple(args.scope_path)
+                )
             elif args.task_command == "context":
                 result = service.context(
-                    args.run_id, budget=args.budget, live=args.live
+                    args.run_id,
+                    budget=args.budget,
+                    live=args.live,
+                    scope_paths=tuple(args.scope_path),
                 )
             else:
                 result = service.checkpoint(

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -217,6 +217,7 @@ class AppConfig:
     observability: ObservabilityConfig
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
     verification_profiles: tuple[VerificationProfile, ...] = ()
+    guidance_preferences: tuple[str, ...] = ()
 
 
 def _tuple(value: Any, default: tuple[str, ...] = ()) -> tuple[str, ...]:
@@ -1090,6 +1091,14 @@ def load_config(
             VerificationProfile(repository.casefold(), name, commands, bootstrap)
         )
 
+    preferences = _tuple(user_raw.get("guidance_preferences"))
+    if len(preferences) > 10 or any(
+        not value.strip() or len(value) > 1000 for value in preferences
+    ):
+        raise ConfigError(
+            "guidance_preferences supports at most 10 nonempty values of 1000 characters"
+        )
+
     return AppConfig(
         config_version=version_value or CONFIG_VERSION,
         path=config_path,
@@ -1107,4 +1116,5 @@ def load_config(
         observability=observability,
         repositories=repositories,
         verification_profiles=tuple(profiles),
+        guidance_preferences=preferences,
     )

--- a/src/reposteward/external_tasks.py
+++ b/src/reposteward/external_tasks.py
@@ -515,7 +515,12 @@ class ExternalTasks:
         }
 
     def context(
-        self, run_id: str, *, budget: int = 24_000, live: bool = False
+        self,
+        run_id: str,
+        *,
+        budget: int = 24_000,
+        live: bool = False,
+        scope_paths: tuple[str, ...] = (),
     ) -> dict[str, Any]:
         if type(budget) is not int or not 512 <= budget <= 100_000:
             raise ValueError("context budget must be between 512 and 100000")
@@ -545,6 +550,29 @@ class ExternalTasks:
             )
         pack = report.pop("context_pack")
         checkpoint = report.pop("checkpoint")
+        knowledge = {"entries": [], "selection": "scope_not_requested"}
+        if scope_paths:
+            from .knowledge import ProjectKnowledge
+
+            guidance = ProjectKnowledge(self.config).list(
+                run_id, scope_paths=scope_paths
+            )
+            knowledge = {
+                **guidance,
+                "entries": [
+                    {
+                        "evidence_id": "knowledge:" + entry["id"],
+                        "statement": entry["statement"],
+                        "scope_paths": entry["scope_paths"],
+                        "conditions": entry["conditions"],
+                        "basis": entry["review"]["basis"],
+                        "trust": entry["review"]["trust"],
+                        "source_evidence": entry["evidence"],
+                    }
+                    for entry in guidance["entries"]
+                ],
+                "selection": "explicit_scope",
+            }
         # Open work and decisions come directly from the current ledger, never from a summary of a summary.
         mandatory = {
             **report,
@@ -560,6 +588,12 @@ class ExternalTasks:
             "verification": {
                 "items": verification_items,
                 "omitted": verification["omitted"],
+            },
+            "knowledge": knowledge,
+            "preferences": {
+                "source": "user_config",
+                "kind": "user_preference",
+                "values": list(self.config.guidance_preferences),
             },
             "agent_claims": {
                 "completed": checkpoint.get("completed", []) if checkpoint else [],
@@ -580,6 +614,34 @@ class ExternalTasks:
             if mandatory["estimated_tokens"] == size:
                 break
             mandatory["estimated_tokens"] = size
+        for field, key, locator in (
+            ("knowledge", "entries", "knowledge list " + run_id),
+            ("preferences", "values", "user_config:guidance_preferences"),
+        ):
+            optional = mandatory[field]
+            if estimate_tokens(mandatory) <= budget or not optional[key]:
+                continue
+            omitted = optional[key]
+            mandatory[field] = {
+                **optional,
+                key: [],
+                "omitted": optional.get("omitted", 0) + len(omitted),
+            }
+            mandatory["coverage"].append(
+                {
+                    "field": f"{field}.{key}",
+                    "reason": "context_budget",
+                    "unit": "items",
+                    "omitted": len(omitted),
+                    "locator": locator,
+                    "digest": canonical_digest(omitted),
+                }
+            )
+            for _ in range(8):
+                size = estimate_tokens(mandatory)
+                if mandatory["estimated_tokens"] == size:
+                    break
+                mandatory["estimated_tokens"] = size
         if estimate_tokens(mandatory) > budget:
             claims = mandatory["agent_claims"]
             count = len(json.dumps(claims, ensure_ascii=False, sort_keys=True))
@@ -609,7 +671,9 @@ class ExternalTasks:
             )
         return mandatory
 
-    def current(self, path: Path, *, budget: int = 24_000) -> dict[str, Any]:
+    def current(
+        self, path: Path, *, budget: int = 24_000, scope_paths: tuple[str, ...] = ()
+    ) -> dict[str, Any]:
         linked = self.registry.inspect(path)
         store = self._store()
         with store._connection() as db:
@@ -623,4 +687,6 @@ class ExternalTasks:
             raise KeyError(
                 "no active external task; start a reviewed Issue in this workspace"
             )
-        return self.context(row["run_id"], budget=budget, live=True)
+        return self.context(
+            row["run_id"], budget=budget, live=True, scope_paths=scope_paths
+        )

--- a/src/reposteward/external_verification.py
+++ b/src/reposteward/external_verification.py
@@ -441,7 +441,15 @@ class ExternalVerification:
         raw = None
         digest = ""
         complete = True
-        if len(parts) == 2 and parts[0] == "verification":
+        if len(parts) == 2 and parts[0] == "knowledge":
+            from .knowledge import ProjectKnowledge
+
+            raw = json.dumps(
+                ProjectKnowledge(self.config).inspect(run_id, parts[1]),
+                ensure_ascii=False,
+                sort_keys=True,
+            ).encode()
+        elif len(parts) == 2 and parts[0] == "verification":
             raw = json.dumps(
                 self.inspect(run_id, parts[1]), ensure_ascii=False, sort_keys=True
             ).encode()

--- a/src/reposteward/knowledge.py
+++ b/src/reposteward/knowledge.py
@@ -1,0 +1,416 @@
+"""Project guidance with explicit review basis, scoped sources and invalidation."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .config import AppConfig
+from .context import repository_policy_digest
+from .external_tasks import ExternalTasks, TaskConflict
+from .external_verification import ExternalVerification
+from .policy import PolicyError
+from .projects import canonical_digest
+from .store import utc_now
+
+
+def _paths(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple)) or not 1 <= len(values) <= 12:
+        raise ValueError("knowledge needs between 1 and 12 relative scope paths")
+    paths = []
+    for value in values:
+        if (
+            not isinstance(value, str)
+            or len(value) > 512
+            or not value
+            or any(ord(c) < 32 for c in value)
+        ):
+            raise ValueError("invalid knowledge scope path")
+        path = Path(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("knowledge scope must stay inside the project")
+        paths.append(path.as_posix())
+    return tuple(sorted(set(paths)))
+
+
+def _matches(name: str, prefix: str) -> bool:
+    return prefix == "." or name == prefix or name.startswith(prefix + "/")
+
+
+def _dependencies(snapshot: dict, paths: tuple[str, ...]) -> str:
+    return canonical_digest(
+        [
+            entry
+            for entry in snapshot["files"]
+            if any(_matches(entry["path"], path) for path in paths)
+        ]
+    )
+
+
+class ProjectKnowledge:
+    def __init__(self, config: AppConfig):
+        self.config = config
+        self.tasks = ExternalTasks(config)
+        self.verification = ExternalVerification(config)
+
+    def _task(self, run_id: str, *, write: bool = False):
+        store = self.tasks._store(write=write)
+        record = self.tasks._record(store, run_id)
+        current = self.tasks.inspect(run_id, live=True)
+        if any(
+            value != "workspace_changed_since_checkpoint"
+            for value in current["validity"]
+        ):
+            raise TaskConflict(
+                "task authority changed; refresh before managing project knowledge"
+            )
+        return store, record
+
+    @staticmethod
+    def _row(store, project_id: str, identifier: str) -> dict:
+        if not re.fullmatch(r"[0-9a-f]{32}", identifier):
+            raise ValueError("invalid knowledge ID")
+        with store._connection() as db:
+            row = db.execute(
+                "SELECT * FROM project_knowledge WHERE project_id=? AND id=?",
+                (project_id, identifier),
+            ).fetchone()
+        if row is None:
+            raise KeyError("knowledge not found in this project")
+        value = dict(row)
+        for field in ("scope_paths", "conditions", "evidence", "review"):
+            value[field] = json.loads(value[field])
+        return value
+
+    def propose(self, run_id: str, payload: dict) -> dict:
+        if not isinstance(payload, dict) or set(payload) - {
+            "statement",
+            "scope_paths",
+            "conditions",
+            "evidence_ids",
+            "supersedes",
+        }:
+            raise ValueError("unsupported knowledge proposal fields")
+        statement = payload.get("statement", "")
+        if (
+            not isinstance(statement, str)
+            or not statement.strip()
+            or len(statement) > 2000
+        ):
+            raise ValueError("knowledge statement must contain 1 to 2000 characters")
+        paths = _paths(payload.get("scope_paths", []))
+        conditions = payload.get("conditions", {})
+        if (
+            not isinstance(conditions, dict)
+            or set(conditions) - {"branch", "verification_profile"}
+            or any(
+                not isinstance(value, str) or not value or len(value) > 256
+                for value in conditions.values()
+            )
+        ):
+            raise ValueError(
+                "knowledge conditions support only branch and verification_profile"
+            )
+        evidence_ids = payload.get("evidence_ids", [])
+        if (
+            not isinstance(evidence_ids, list)
+            or not 1 <= len(evidence_ids) <= 8
+            or any(
+                not isinstance(value, str) or len(value) > 180 for value in evidence_ids
+            )
+        ):
+            raise ValueError("knowledge requires 1 to 8 scoped evidence IDs")
+        store, record = self._task(run_id, write=True)
+        if payload.get("supersedes"):
+            self._row(store, record["project_id"], payload["supersedes"])
+        sources = []
+        for identifier in sorted(set(evidence_ids)):
+            if identifier.split(":")[0] not in {
+                "source",
+                "checkpoint",
+                "verification",
+                "log",
+            }:
+                raise ValueError(
+                    "knowledge proposals require direct source, checkpoint or verification evidence"
+                )
+            evidence = self.verification.evidence(run_id, identifier, limit=1)
+            if evidence["availability"] != "available":
+                raise ValueError(
+                    "knowledge evidence is unavailable or failed integrity checks"
+                )
+            sources.append(
+                {
+                    "run_id": run_id,
+                    "evidence_id": identifier,
+                    "digest": evidence["digest"],
+                }
+            )
+        snapshot = self.tasks._snapshot(
+            Path(record["workspace_root"]), store.run(run_id)["repository"]
+        )
+        material = {
+            "project_id": record["project_id"],
+            "statement": statement.strip(),
+            "scope_paths": list(paths),
+            "conditions": conditions,
+            "evidence": sources,
+            "dependencies_digest": _dependencies(snapshot, paths),
+            "supersedes": payload.get("supersedes", ""),
+        }
+        identifier = canonical_digest(material)[:32]
+        now = utc_now()
+        with store._connection() as db:
+            db.execute(
+                """INSERT OR IGNORE INTO project_knowledge
+                (id,project_id,origin_run_id,status,statement,scope_paths,conditions,evidence,dependencies_digest,supersedes,created_at,updated_at)
+                VALUES (?,?,?,'candidate',?,?,?,?,?,?,?,?)""",
+                (
+                    identifier,
+                    record["project_id"],
+                    run_id,
+                    material["statement"],
+                    json.dumps(paths),
+                    json.dumps(conditions),
+                    json.dumps(sources),
+                    material["dependencies_digest"],
+                    material["supersedes"],
+                    now,
+                    now,
+                ),
+            )
+        return {
+            **self._row(store, record["project_id"], identifier),
+            "public_write": False,
+        }
+
+    def _validity(self, entry: dict, snapshot: dict, repository: str) -> list[str]:
+        reasons = []
+        if (
+            _dependencies(snapshot, tuple(entry["scope_paths"]))
+            != entry["dependencies_digest"]
+        ):
+            reasons.append("scoped_code_changed")
+        if entry["conditions"].get("branch", snapshot["branch"]) != snapshot["branch"]:
+            reasons.append("branch_condition_not_met")
+        profiles = {
+            profile.name: profile
+            for profile in self.config.verification_profiles
+            if profile.repository == repository.casefold()
+        }
+        required = entry["conditions"].get("verification_profile")
+        if required and required not in profiles:
+            reasons.append("profile_condition_not_met")
+        review = entry["review"]
+        if review.get("policy_digest") and review[
+            "policy_digest"
+        ] != repository_policy_digest(self.tasks._policy(repository)):
+            reasons.append("verification_policy_changed")
+        if review.get("profile"):
+            profile = profiles.get(review["profile"])
+            if (
+                profile is None
+                or self.verification._profile_digest(profile)
+                != review["profile_digest"]
+            ):
+                reasons.append("verification_profile_changed")
+        for source in entry["evidence"]:
+            try:
+                evidence = self.verification.evidence(
+                    source["run_id"], source["evidence_id"], limit=1
+                )
+                if (
+                    evidence["availability"] != "available"
+                    or evidence["digest"] != source["digest"]
+                ):
+                    reasons.append("source_evidence_changed_or_missing")
+            except (OSError, ValueError, RuntimeError, KeyError):
+                reasons.append("source_evidence_unavailable")
+        if review.get("verification_id"):
+            try:
+                proof = self.verification.evidence(
+                    review["run_id"], review["verification_id"], limit=1
+                )
+                if (
+                    proof["availability"] != "available"
+                    or proof["digest"] != review["verification_digest"]
+                ):
+                    reasons.append("review_evidence_changed_or_missing")
+            except (OSError, ValueError, RuntimeError, KeyError):
+                reasons.append("review_evidence_unavailable")
+        return sorted(set(reasons))
+
+    def promote(
+        self,
+        run_id: str,
+        identifier: str,
+        *,
+        reviewed_by: str,
+        basis: str,
+        rationale: str,
+        verification_id: str = "",
+    ) -> dict:
+        if (
+            not reviewed_by
+            or reviewed_by.casefold() != self.config.github.login.casefold()
+        ):
+            raise PolicyError(
+                "knowledge reviewer must match the configured GitHub login"
+            )
+        if (
+            basis not in {"human_confirmation", "verification_evidence"}
+            or not rationale.strip()
+            or len(rationale) > 2000
+        ):
+            raise ValueError(
+                "knowledge review requires an explicit basis and bounded rationale"
+            )
+        store, record = self._task(run_id, write=True)
+        repository = store.run(run_id)["repository"]
+        with store.atomic():
+            entry = self._row(store, record["project_id"], identifier)
+            snapshot = self.tasks._snapshot(Path(record["workspace_root"]), repository)
+            if self._validity(entry, snapshot, repository):
+                raise TaskConflict(
+                    "knowledge sources, conditions or scoped code changed; propose updated evidence"
+                )
+            if entry["status"] == "replaced":
+                raise TaskConflict("replaced knowledge cannot be promoted again")
+            review = {
+                "reviewed_by": reviewed_by,
+                "basis": basis,
+                "rationale": rationale,
+                "trust": "human_attested"
+                if basis == "human_confirmation"
+                else "reviewed_with_test_evidence",
+            }
+            if basis == "verification_evidence":
+                proof = self.verification.inspect(
+                    run_id, verification_id.removeprefix("verification:"), live=True
+                )
+                if (
+                    proof["outcome"] != "passed"
+                    or proof["current_applicability"] != "matches"
+                ):
+                    raise TaskConflict(
+                        "knowledge promotion requires current passed verification evidence"
+                    )
+                evidence = self.verification.evidence(
+                    run_id, proof["evidence_id"], limit=1
+                )
+                if evidence["availability"] != "available":
+                    raise TaskConflict("review evidence is unavailable")
+                review.update(
+                    {
+                        "run_id": run_id,
+                        "verification_id": proof["evidence_id"],
+                        "verification_digest": evidence["digest"],
+                        "profile": proof["profile"],
+                        "profile_digest": proof["profile_digest"],
+                        "policy_digest": proof["policy_digest"],
+                        "snapshot_digest": proof["snapshot"]["digest"],
+                    }
+                )
+            elif verification_id:
+                raise ValueError(
+                    "human confirmation must not masquerade as verification evidence"
+                )
+            if entry["status"] == "reviewed":
+                if entry["review"] != review:
+                    raise TaskConflict(
+                        "knowledge already has a different review; use a replacement"
+                    )
+                return {**entry, "idempotent": True, "public_write": False}
+            with store._connection() as db:
+                if entry["supersedes"]:
+                    previous = self._row(
+                        store, record["project_id"], entry["supersedes"]
+                    )
+                    if previous["successor"] and previous["successor"] != identifier:
+                        raise TaskConflict("knowledge already has another replacement")
+                    db.execute(
+                        "UPDATE project_knowledge SET status='replaced',successor=?,updated_at=? WHERE id=?",
+                        (identifier, utc_now(), previous["id"]),
+                    )
+                db.execute(
+                    "UPDATE project_knowledge SET status='reviewed',review=?,updated_at=? WHERE id=?",
+                    (json.dumps(review), utc_now(), identifier),
+                )
+        return {
+            **self._row(store, record["project_id"], identifier),
+            "idempotent": False,
+            "public_write": False,
+        }
+
+    def inspect(self, run_id: str, identifier: str, *, live: bool = False) -> dict:
+        store = self.tasks._store()
+        record = self.tasks._record(store, run_id)
+        entry = self._row(store, record["project_id"], identifier)
+        reasons = []
+        if live:
+            store, record = self._task(run_id)
+            repository = store.run(run_id)["repository"]
+            snapshot = self.tasks._snapshot(Path(record["workspace_root"]), repository)
+            reasons = self._validity(entry, snapshot, repository)
+        return {
+            **entry,
+            "invalidations": reasons,
+            "effective_status": "stale"
+            if reasons and entry["status"] == "reviewed"
+            else entry["status"],
+            "freshness": "local_checked" if live else "not_checked",
+            "public_write": False,
+        }
+
+    def list(
+        self,
+        run_id: str,
+        *,
+        scope_paths: tuple[str, ...] = (".",),
+        limit: int = 5,
+        include_inactive: bool = False,
+    ) -> dict:
+        paths = _paths(scope_paths)
+        if type(limit) is not int or not 1 <= limit <= 50:
+            raise ValueError("knowledge limit must be between 1 and 50")
+        store, record = self._task(run_id)
+        repository = store.run(run_id)["repository"]
+        snapshot = self.tasks._snapshot(Path(record["workspace_root"]), repository)
+        with store._connection() as db:
+            rows = db.execute(
+                "SELECT id FROM project_knowledge WHERE project_id=? ORDER BY updated_at DESC,id LIMIT 201",
+                (record["project_id"],),
+            ).fetchall()
+        entries, suppressed = [], 0
+        for row in rows[:200]:
+            entry = self._row(store, record["project_id"], row["id"])
+            if not any(
+                _matches(left, right) or _matches(right, left)
+                for left in paths
+                for right in entry["scope_paths"]
+            ):
+                suppressed += 1
+                continue
+            reasons = self._validity(entry, snapshot, repository)
+            entry["effective_status"] = (
+                "stale"
+                if reasons and entry["status"] == "reviewed"
+                else entry["status"]
+            )
+            entry["invalidations"] = reasons
+            if not include_inactive and (entry["status"] != "reviewed" or reasons):
+                suppressed += 1
+                continue
+            entries.append(entry)
+        return {
+            "project_id": record["project_id"],
+            "entries": entries[:limit],
+            "omitted": max(0, len(entries) - limit),
+            "suppressed": suppressed,
+            "scan_incomplete": len(rows) > 200,
+            "scope_paths": list(paths),
+            "remote_freshness": "not_refreshed",
+            "public_write": False,
+        }

--- a/src/reposteward/knowledge_ledger.py
+++ b/src/reposteward/knowledge_ledger.py
@@ -1,0 +1,11 @@
+"""Versioned storage for reviewed project guidance."""
+
+KNOWLEDGE_MIGRATION = (
+    """CREATE TABLE IF NOT EXISTS project_knowledge (
+        id TEXT PRIMARY KEY, project_id TEXT NOT NULL, origin_run_id TEXT NOT NULL REFERENCES runs(id),
+        status TEXT NOT NULL, statement TEXT NOT NULL, scope_paths TEXT NOT NULL, conditions TEXT NOT NULL,
+        evidence TEXT NOT NULL, dependencies_digest TEXT NOT NULL, supersedes TEXT NOT NULL DEFAULT '',
+        successor TEXT NOT NULL DEFAULT '', review TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL)""",
+    """CREATE INDEX IF NOT EXISTS knowledge_project ON project_knowledge(project_id,status,updated_at)""",
+)

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -21,12 +21,14 @@ from .feedback import (
     sync_feedback,
     verify_feedback,
 )
+from .knowledge_ledger import KNOWLEDGE_MIGRATION
 from .models import Candidate
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
+    21: KNOWLEDGE_MIGRATION,
     20: EXTERNAL_VERIFICATION_MIGRATION,
     19: EXTERNAL_TASK_MIGRATION,
     18: FEEDBACK_MIGRATION,

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from dataclasses import replace
+from unittest.mock import patch
+
+import test_external_verification
+
+from reposteward.cli import main
+from reposteward.config import load_config
+from reposteward.external_tasks import TaskConflict
+from reposteward.knowledge import ProjectKnowledge
+from reposteward.policy import PolicyError
+
+
+class KnowledgeTests(unittest.TestCase):
+    container_run = test_external_verification.ExternalVerificationTests.container_run
+    request = test_external_verification.ExternalVerificationTests.request
+
+    def setUp(self) -> None:
+        test_external_verification.ExternalVerificationTests.setUp(self)
+        self.knowledge = ProjectKnowledge(self.config)
+        self.run_id = self.task["run_id"]
+
+    def propose(
+        self, *, statement: str = "Keep the source format stable", supersedes: str = ""
+    ) -> dict:
+        return self.knowledge.propose(
+            self.run_id,
+            {
+                "statement": statement,
+                "scope_paths": ["source.txt"],
+                "evidence_ids": [f"checkpoint:{self.run_id}:0"],
+                "supersedes": supersedes,
+            },
+        )
+
+    def promote(self, identifier: str, *, proof: str = "") -> dict:
+        return self.knowledge.promote(
+            self.run_id,
+            identifier,
+            reviewed_by="owner",
+            basis="verification_evidence" if proof else "human_confirmation",
+            rationale="Reviewed the statement against its source and scope",
+            verification_id=proof,
+        )
+
+    def test_candidates_do_not_enter_context_and_human_confirmation_is_not_test_evidence(
+        self,
+    ) -> None:
+        entry = self.propose()
+        self.assertEqual(entry["status"], "candidate")
+        self.assertEqual(entry["id"], self.propose()["id"])
+        self.assertEqual(self.knowledge.list(self.run_id)["entries"], [])
+        before = self.service.context(self.run_id, scope_paths=("source.txt",))
+        self.assertEqual(before["knowledge"]["entries"], [])
+        reviewed = self.promote(entry["id"])
+        self.assertEqual(reviewed["review"]["trust"], "human_attested")
+        context = self.service.context(self.run_id, scope_paths=("source.txt",))
+        self.assertEqual(
+            context["knowledge"]["entries"][0]["basis"], "human_confirmation"
+        )
+        self.assertEqual(context["claim_trust"], "agent_unverified")
+        self.assertEqual(
+            self.service.context(self.run_id)["knowledge"]["selection"],
+            "scope_not_requested",
+        )
+        self.assertTrue(self.promote(entry["id"])["idempotent"])
+
+    def test_verification_promotion_requires_current_passed_evidence(self) -> None:
+        entry = self.propose()
+        with self.assertRaises(KeyError):
+            self.promote(entry["id"], proof="verification:" + "f" * 32)
+        passed = self.request()
+        reviewed = self.promote(entry["id"], proof=passed["evidence_id"])
+        self.assertEqual(reviewed["review"]["trust"], "reviewed_with_test_evidence")
+        self.assertIn("verification_digest", reviewed["review"])
+        second = self.propose(statement="Another scoped observation")
+        (self.repo / "source.txt").write_text("changed after test")
+        with self.assertRaises(TaskConflict):
+            self.promote(second["id"], proof=passed["evidence_id"])
+        report = self.knowledge.list(self.run_id, include_inactive=True)
+        previous = next(item for item in report["entries"] if item["id"] == entry["id"])
+        self.assertEqual(previous["effective_status"], "stale")
+        self.assertIn("scoped_code_changed", previous["invalidations"])
+        self.assertEqual(self.knowledge.list(self.run_id)["entries"], [])
+
+    def test_scope_selection_and_changes_outside_dependency_paths(self) -> None:
+        entry = self.propose()
+        self.promote(entry["id"])
+        (self.repo / "unrelated.py").write_text("x = 1\n")
+        self.assertEqual(
+            len(
+                self.knowledge.list(self.run_id, scope_paths=("source.txt",))["entries"]
+            ),
+            1,
+        )
+        self.assertEqual(
+            self.knowledge.list(self.run_id, scope_paths=("unrelated.py",))["entries"],
+            [],
+        )
+        (self.repo / "source.txt").write_text("changed dependency")
+        self.assertEqual(
+            self.knowledge.inspect(self.run_id, entry["id"], live=True)[
+                "effective_status"
+            ],
+            "stale",
+        )
+        self.assertEqual(
+            self.knowledge.inspect(self.run_id, entry["id"])["freshness"], "not_checked"
+        )
+
+    def test_replacement_is_atomic_and_keeps_history(self) -> None:
+        first = self.propose()
+        self.promote(first["id"])
+        replacement = self.propose(
+            statement="Use the updated format rule", supersedes=first["id"]
+        )
+        self.assertEqual(
+            self.knowledge.inspect(self.run_id, first["id"])["status"], "reviewed"
+        )
+        self.promote(replacement["id"])
+        previous = self.knowledge.inspect(self.run_id, first["id"])
+        self.assertEqual(previous["status"], "replaced")
+        self.assertEqual(previous["successor"], replacement["id"])
+        self.assertEqual(
+            [item["id"] for item in self.knowledge.list(self.run_id)["entries"]],
+            [replacement["id"]],
+        )
+        with self.assertRaisesRegex(TaskConflict, "replaced"):
+            self.promote(first["id"])
+        competing = self.propose(
+            statement="Competing replacement", supersedes=first["id"]
+        )
+        with self.assertRaisesRegex(TaskConflict, "another replacement"):
+            self.promote(competing["id"])
+        self.assertEqual(
+            self.knowledge.inspect(self.run_id, competing["id"])["status"], "candidate"
+        )
+
+    def test_missing_sources_and_changed_profiles_invalidate_reviewed_guidance(
+        self,
+    ) -> None:
+        entry = self.propose()
+        passed = self.request()
+        self.promote(entry["id"], proof=passed["evidence_id"])
+        changed = replace(self.config, verification_profiles=())
+        report = ProjectKnowledge(changed).list(self.run_id, include_inactive=True)
+        self.assertIn(
+            "verification_profile_changed", report["entries"][0]["invalidations"]
+        )
+        with self.service._store(write=True)._connection() as db:
+            db.execute(
+                "UPDATE checkpoints SET payload=replace(payload,'investigate','changed') WHERE run_id=?",
+                (self.run_id,),
+            )
+            db.execute(
+                "UPDATE external_verifications SET outcome='unknown' WHERE run_id=?",
+                (self.run_id,),
+            )
+        report = self.knowledge.list(self.run_id, include_inactive=True)
+        self.assertIn(
+            "review_evidence_changed_or_missing", report["entries"][0]["invalidations"]
+        )
+        self.assertEqual(self.knowledge.list(self.run_id)["entries"], [])
+
+    def test_review_is_scoped_and_cannot_be_inferred_from_agent_claims(self) -> None:
+        entry = self.propose()
+        with self.assertRaises(PolicyError):
+            self.knowledge.promote(
+                self.run_id,
+                entry["id"],
+                reviewed_by="another",
+                basis="human_confirmation",
+                rationale="review",
+            )
+        with self.assertRaises(ValueError):
+            self.knowledge.promote(
+                self.run_id,
+                entry["id"],
+                reviewed_by="owner",
+                basis="agent_says_done",
+                rationale="review",
+            )
+        with self.service._store(write=True)._connection() as db:
+            db.execute(
+                "UPDATE project_knowledge SET project_id='another-project' WHERE id=?",
+                (entry["id"],),
+            )
+        with self.assertRaises(KeyError):
+            self.knowledge.inspect(self.run_id, entry["id"])
+        self.assertEqual(self.knowledge.list(self.run_id)["entries"], [])
+
+    def test_context_budget_omits_optional_guidance_with_retrievable_evidence(
+        self,
+    ) -> None:
+        for index in range(5):
+            entry = self.propose(statement=f"Guidance {index}: " + "x" * 1950)
+            self.promote(entry["id"])
+        full = self.service.context(self.run_id, scope_paths=("source.txt",))
+        self.assertEqual(len(full["knowledge"]["entries"]), 5)
+        budget = self.service.context(self.run_id)["estimated_tokens"] + 1500
+        bounded = self.service.context(
+            self.run_id, scope_paths=("source.txt",), budget=budget
+        )
+        self.assertEqual(bounded["knowledge"]["entries"], [])
+        self.assertEqual(bounded["knowledge"]["omitted"], 5)
+        self.assertLessEqual(bounded["estimated_tokens"], budget)
+        self.assertEqual(bounded["open_work"], full["open_work"])
+        self.assertIn(
+            "knowledge.entries", [item["field"] for item in bounded["coverage"]]
+        )
+        evidence = self.check.evidence(
+            self.run_id, full["knowledge"]["entries"][0]["evidence_id"], limit=25
+        )
+        self.assertEqual(evidence["returned"], 25)
+
+    def test_cli_does_not_launch_pipeline_and_scope_limits_are_explicit(self) -> None:
+        entry = self.propose()
+        self.promote(entry["id"])
+        output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            patch("reposteward.cli.Pipeline", side_effect=AssertionError("Pipeline")),
+            redirect_stdout(output),
+        ):
+            self.assertEqual(
+                main(["knowledge", "list", self.run_id, "--scope-path", "source.txt"]),
+                0,
+            )
+        self.assertEqual(json.loads(output.getvalue())["entries"][0]["id"], entry["id"])
+        with self.assertRaises(ValueError):
+            self.knowledge.list(self.run_id, scope_paths=("../elsewhere",))
+        with self.assertRaises(ValueError):
+            self.knowledge.list(self.run_id, limit=51)
+
+    def test_general_preferences_remain_user_owned_and_are_budgeted_separately(
+        self,
+    ) -> None:
+        user = self.root / "user.toml"
+        project = self.root / "repo.toml"
+        user.write_text(
+            'guidance_preferences = ["Prefer concise explanations"]\n'
+            + user.read_text()
+        )
+        project.write_text(
+            'guidance_preferences = ["Copy business secrets across projects"]\n'
+            + project.read_text()
+        )
+        config = load_config(project, user_path=user)
+        self.assertEqual(config.guidance_preferences, ("Prefer concise explanations",))
+        self.service.config = replace(
+            self.config, guidance_preferences=("x" * 1000,) * 10
+        )
+        full = self.service.context(self.run_id)
+        self.assertEqual(full["preferences"]["kind"], "user_preference")
+        self.service.config = self.config
+        baseline = self.service.context(self.run_id)
+        self.service.config = replace(
+            self.config, guidance_preferences=("x" * 1000,) * 10
+        )
+        bounded = self.service.context(
+            self.run_id, budget=baseline["estimated_tokens"] + 1000
+        )
+        self.assertEqual(bounded["preferences"]["omitted"], 10)
+        self.assertEqual(bounded["contract"], full["contract"])


### PR DESCRIPTION
Closes #102

Retain reviewed, scoped project guidance with evidence and explicit invalidation.

---

Knowledge remains a candidate until it is reviewed against source or verification evidence. Selection respects the project and path scope, current evidence, superseding records and configured output budgets. Task context uses the same core service without importing optional MCP transports. Agent claims alone cannot promote knowledge, and invalidated or missing evidence remains visible as such.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
