### PR TITLE
feat(overview): aggregate linked project attention with explicit refresh

### DIFF
--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -1034,3 +1034,27 @@ reposteward task context <run-id> --scope-path src --format markdown
 最多十条、每条一千字符；仓库文件里的同名字段不生效。上下文将其标为
 `user_preference`，不与项目经验或测试事实混合；预算不足时记录省略数量。
 项目经验不会自动写入此用户配置。
+
+## 多项目待办
+
+```bash
+reposteward overview show --project-limit 10 --item-limit 10 --format text
+reposteward overview refresh --project-limit 10 --item-limit 10
+reposteward overview show --previous-digest <digest>
+```
+
+默认只读已关联且配置启用的本机项目，展示本地任务与缓存的 PR 状态，不认证 GitHub、
+不启动 Harness。`refresh` 才联网更新缓存。每次最多五十个项目、每项目五十项输出；
+每项目最多检查二十个当前外部任务和五十个远程 PR 详情，未覆盖部分明确计数或标为
+不完整。刷新失败保留上次快照及其时间，同时显示错误；一个项目损坏不会把其他项目
+的待办变成空列表。缺少本地数据库时，show 报告 unknown，不创建或迁移数据库。
+
+视图复用既有 inbox/portfolio 和已审计合并终态规则。外部开发另列 dirty、阻塞、验证
+缺失/失败/未知/陈旧及等待本地审阅。新外部尝试不会遮住同 Issue 已管理的 PR。
+同一工作区、同一任务的接续尝试合并重复展示，并报告数量；变化后的事实重新出现。
+`--previous-digest` 比较事实，读取时间不导致无意义变化，尚未处理的反馈和 unknown
+始终保持可见。查看或刷新不会消耗反馈处理状态或读取水位。
+
+每项附下一步与可用的生命周期 trace、检查点或验证引用。较长下一步文本只展示前
+一千字符并注明省略量，完整记录从检查点证据取回。开发验证成功继续表示本地开发
+证据，仍需审阅余项、形成干净提交并走 adopt；视图不自动提交、发布或合并。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -113,6 +113,18 @@ def _parser() -> argparse.ArgumentParser:
         elif action in {"apply", "revert"}:
             command.add_argument("--plan-digest", required=True)
 
+    overview = subparsers.add_parser(
+        "overview", help="read local attention across linked projects"
+    )
+    overview_commands = overview.add_subparsers(dest="overview_command", required=True)
+    for action in ("show", "refresh"):
+        command = overview_commands.add_parser(action)
+        command.add_argument("--project-limit", type=int, default=10)
+        command.add_argument("--item-limit", type=int, default=10)
+        command.add_argument("--format", choices=("json", "text"), default="json")
+        if action == "show":
+            command.add_argument("--previous-digest", default="")
+
     knowledge = subparsers.add_parser(
         "knowledge", help="review and query evidence-backed project guidance"
     )
@@ -704,6 +716,25 @@ def main(argv: list[str] | None = None) -> int:
                     revert=args.integration_command == "revert",
                 )
             _json(result)
+            return 0
+        if args.command == "overview":
+            from .overview import ProjectOverview, render_overview
+
+            service = ProjectOverview(config)
+            if args.overview_command == "refresh":
+                result = service.refresh(
+                    project_limit=args.project_limit, item_limit=args.item_limit
+                )
+            else:
+                result = service.show(
+                    project_limit=args.project_limit,
+                    item_limit=args.item_limit,
+                    previous_digest=args.previous_digest,
+                )
+            if args.format == "text":
+                print(render_overview(result))
+            else:
+                _json(result)
             return 0
         if args.command == "knowledge":
             from .knowledge import ProjectKnowledge

--- a/src/reposteward/overview.py
+++ b/src/reposteward/overview.py
@@ -1,0 +1,439 @@
+"""Local-first attention across linked projects, with explicit remote refresh."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+from .config import AppConfig
+from .external_tasks import ExternalTasks
+from .external_verification import ExternalVerification
+from .github import GitHubClient
+from .inbox import build_maintainer_inbox
+from .portfolio_fetch import portfolio_from_pulls
+from .projects import ProjectRegistry, canonical_digest
+from .store import Store, utc_now
+
+
+def _age(value: str, now: datetime) -> int | None:
+    try:
+        parsed = datetime.fromisoformat(value)
+        return max(0, int((now - parsed).total_seconds()))
+    except (ValueError, TypeError):
+        return None
+
+
+def _fact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _fact(item)
+            for key, item in value.items()
+            if key
+            not in {"observed_at", "source_age_seconds", "fetched_at", "attempted_at"}
+        }
+    if isinstance(value, list):
+        return [_fact(item) for item in value]
+    return value
+
+
+class ProjectOverview:
+    def __init__(self, config: AppConfig, *, github: GitHubClient | None = None):
+        self.config = config
+        self.registry = ProjectRegistry(config.state_dir / "projects.sqlite3")
+        self.tasks = ExternalTasks(config)
+        self.github = github
+
+    def _projects(self, limit: int) -> dict:
+        if type(limit) is not int or not 1 <= limit <= 50:
+            raise ValueError("project limit must be between 1 and 50")
+        registry = self.registry.list(limit=500)
+        api_host = urlsplit(self.config.github.api_url).hostname
+        host = "github.com" if api_host == "api.github.com" else api_host
+        enabled, excluded = [], 0
+        for project in registry["projects"]:
+            policy = self.config.repositories.get(project["repository"].casefold())
+            if (
+                policy is None
+                or not policy.enabled
+                or not project["workspace_count"]
+                or project["host"] != host
+            ):
+                excluded += 1
+                continue
+            enabled.append(project)
+        return {
+            "projects": enabled[:limit],
+            "omitted": max(0, len(enabled) - limit) + registry["omitted"],
+            "excluded": excluded,
+        }
+
+    def refresh(self, *, project_limit: int = 10, item_limit: int = 10) -> dict:
+        if type(item_limit) is not int or not 1 <= item_limit <= 50:
+            raise ValueError("per-project item limit must be between 1 and 50")
+        selected = self._projects(project_limit)
+        if not selected["projects"]:
+            return self.show(project_limit=project_limit, item_limit=item_limit)
+        store = self.tasks._store(write=True)
+        github = self.github
+        for project in selected["projects"]:
+            attempted = utc_now()
+            try:
+                github = github or GitHubClient(self.config.github)
+                policy = self.config.repositories[project["repository"].casefold()]
+                portfolio = portfolio_from_pulls(
+                    github, policy, github.open_pull_requests(policy.name), max_pulls=50
+                )
+                encoded = json.dumps(portfolio)
+                if len(encoded.encode()) > 2_000_000:
+                    raise ValueError("portfolio exceeds cache size limit")
+                with store._connection() as db:
+                    db.execute(
+                        """INSERT INTO project_inbox_cache VALUES (?,?,?,?,?,'')
+                        ON CONFLICT(project_id) DO UPDATE SET repository=excluded.repository,
+                        portfolio=excluded.portfolio,fetched_at=excluded.fetched_at,attempted_at=excluded.attempted_at,error=''""",
+                        (
+                            project["id"],
+                            policy.name.casefold(),
+                            encoded,
+                            attempted,
+                            attempted,
+                        ),
+                    )
+            except (OSError, ValueError, RuntimeError) as exc:
+                with store._connection() as db:
+                    db.execute(
+                        """INSERT INTO project_inbox_cache(project_id,repository,attempted_at,error) VALUES (?,?,?,?)
+                        ON CONFLICT(project_id) DO UPDATE SET attempted_at=excluded.attempted_at,error=excluded.error""",
+                        (
+                            project["id"],
+                            project["repository"],
+                            attempted,
+                            str(exc)[:500],
+                        ),
+                    )
+        return self.show(project_limit=project_limit, item_limit=item_limit)
+
+    def _external_items(
+        self, store: Store, project: dict
+    ) -> tuple[list[dict], int, int]:
+        with store._connection() as db:
+            rows = db.execute(
+                """WITH ranked AS (
+                SELECT e.*,h.work_item_id,r.issue_number,r.details,
+                    row_number() OVER (PARTITION BY e.binding_id,h.work_item_id ORDER BY e.updated_at DESC,e.created_at DESC,e.rowid DESC) AS rank
+                FROM external_task_runs e JOIN runs r ON r.id=e.run_id JOIN harness_runs h ON h.run_id=e.run_id
+                WHERE e.project_id=? AND r.stage='external' AND r.status='running')
+                SELECT * FROM ranked WHERE rank=1 ORDER BY updated_at DESC,run_id LIMIT 21""",
+                (project["id"],),
+            ).fetchall()
+            total = db.execute(
+                "SELECT count(*) FROM external_task_runs e JOIN runs r ON r.id=e.run_id WHERE e.project_id=? AND r.stage='external' AND r.status='running'",
+                (project["id"],),
+            ).fetchone()[0]
+            unique = db.execute(
+                """SELECT count(*) FROM (
+                SELECT e.binding_id,h.work_item_id FROM external_task_runs e JOIN runs r ON r.id=e.run_id
+                JOIN harness_runs h ON h.run_id=e.run_id WHERE e.project_id=? AND r.stage='external' AND r.status='running'
+                GROUP BY e.binding_id,h.work_item_id)""",
+                (project["id"],),
+            ).fetchone()[0]
+        items = []
+        for row in rows[:20]:
+            item = {
+                "id": "external:" + row["run_id"],
+                "run_id": row["run_id"],
+                "repository": project["repository"],
+                "issue_number": row["issue_number"],
+                "pull_number": 0,
+                "source_updated_at": row["updated_at"],
+                "trace_command": f"reposteward trace {project['repository']} {row['issue_number']}",
+                "next_command": f"reposteward task inspect {row['run_id']} --live",
+            }
+            try:
+                task = self.tasks.inspect(row["run_id"], live=True)
+                checkpoint = task["checkpoint"] or {}
+                item.update(
+                    {
+                        "revision": task["revision"],
+                        "dirty": task["current_snapshot"]["dirty"],
+                        "snapshot_digest": task["current_snapshot"]["digest"],
+                        "open_items": len(checkpoint.get("remaining", [])),
+                        "next_action": checkpoint.get("next_action", "")[:1000],
+                        "next_action_omitted": max(
+                            0, len(checkpoint.get("next_action", "")) - 1000
+                        ),
+                        "checkpoint_evidence_id": f"checkpoint:{row['run_id']}:{task['revision']}",
+                        "validity": task["validity"],
+                    }
+                )
+                if checkpoint.get("blockers"):
+                    code, priority, summary = (
+                        "external_blocked",
+                        95,
+                        "外部开发任务存在阻塞，查看检查点",
+                    )
+                elif any(
+                    value != "workspace_changed_since_checkpoint"
+                    for value in task["validity"]
+                ):
+                    code, priority, summary = (
+                        "external_refresh_required",
+                        85,
+                        "任务绑定的基线或策略变化，需要刷新",
+                    )
+                else:
+                    verification = ExternalVerification(self.config)
+                    evidence = verification.list(row["run_id"], limit=1)["evidence"]
+                    if not evidence:
+                        code, priority, summary = (
+                            "external_verification_required",
+                            45,
+                            "开发任务尚无独立验证证据",
+                        )
+                    else:
+                        latest = verification.inspect(
+                            row["run_id"],
+                            evidence[0]["evidence_id"].split(":")[1],
+                            live=True,
+                        )
+                        item["evidence_id"] = latest["evidence_id"]
+                        item["verification_outcome"] = latest["outcome"]
+                        if latest["outcome"] in {"unknown", "cancelled", "running"}:
+                            code, priority, summary = (
+                                "external_verification_unknown",
+                                85,
+                                "验证未完成或结果未知，需要检查证据",
+                            )
+                        elif latest["outcome"] == "failed":
+                            code, priority, summary = (
+                                "external_verification_failed",
+                                100,
+                                "开发快照验证失败，需要处理",
+                            )
+                        elif latest["current_applicability"] != "matches":
+                            code, priority, summary = (
+                                "external_verification_stale",
+                                75,
+                                "旧验证不再匹配当前开发快照",
+                            )
+                        else:
+                            code, priority, summary = (
+                                "external_review_required",
+                                50,
+                                "开发快照验证通过，待检查余项和干净提交的 adopt",
+                            )
+                item.update(
+                    {
+                        "reason_code": code,
+                        "priority": priority,
+                        "summary": summary,
+                        "complete": True,
+                    }
+                )
+            except (OSError, ValueError, RuntimeError, KeyError, sqlite3.Error) as exc:
+                item.update(
+                    {
+                        "reason_code": "external_state_unknown",
+                        "priority": 110,
+                        "summary": f"本地任务事实无法确认：{str(exc)[:300]}",
+                        "complete": False,
+                    }
+                )
+            items.append(item)
+        return items, max(0, total - unique), max(0, unique - 20)
+
+    def _project(
+        self, store: Store, project: dict, *, limit: int, now: datetime
+    ) -> dict:
+        with store._connection() as db:
+            cache_row = db.execute(
+                "SELECT * FROM project_inbox_cache WHERE project_id=?", (project["id"],)
+            ).fetchone()
+        cache = dict(cache_row) if cache_row else {}
+        portfolio = json.loads(cache["portfolio"]) if cache.get("fetched_at") else None
+        runs = store.latest_runs_for_repository(
+            project["repository"], limit=500, include_external=False
+        )
+        proposals = store.staged_issue_proposals(project["repository"], limit=500)
+        native = build_maintainer_inbox(
+            project["repository"],
+            proposals=proposals,
+            runs=runs,
+            portfolio=portfolio,
+            merge_outcomes=store.latest_merge_outcomes(project["repository"]),
+            observed_at=cache.get("attempted_at", ""),
+            error=cache.get("error", ""),
+            limit=500,
+        )
+        items = list(native["items"])
+        for item in items:
+            if item["run_id"]:
+                item["trace_command"] = (
+                    f"reposteward trace {project['repository']} {item['issue_number']}"
+                )
+        with store._connection() as db:
+            pending = db.execute(
+                """SELECT e.pull_number,count(*) AS count,
+                max(e.ingested_at) AS updated_at,sum(CASE WHEN b.digest IS NULL THEN 1 ELSE 0 END) AS missing
+                FROM feedback_items f JOIN github_pr_events e ON e.sequence=f.event_sequence
+                LEFT JOIN content_blobs b ON b.digest=e.payload_digest
+                WHERE e.repository=? AND f.status IN ('pending','deferred','addressed')
+                GROUP BY e.pull_number ORDER BY e.pull_number LIMIT 501""",
+                (project["repository"],),
+            ).fetchall()
+        for row in pending[:500]:
+            items.append(
+                {
+                    "id": f"feedback:{project['id']}:{row['pull_number']}",
+                    "repository": project["repository"],
+                    "run_id": "",
+                    "issue_number": 0,
+                    "pull_number": row["pull_number"],
+                    "priority": 105 if row["missing"] else 90,
+                    "reason_code": "feedback_evidence_missing"
+                    if row["missing"]
+                    else "review_feedback_required",
+                    "summary": f"PR #{row['pull_number']} 仍有 {row['count']} 条本地未处理反馈",
+                    "pending_feedback": row["count"],
+                    "unknown_payloads": row["missing"],
+                    "source_updated_at": row["updated_at"],
+                    "next_command": "reposteward overview refresh --project-limit 10",
+                    "complete": not row["missing"],
+                }
+            )
+        external, collapsed, external_omitted = self._external_items(store, project)
+        unique = {}
+        for item in [*items, *external]:
+            key = (
+                (item["pull_number"], item["reason_code"])
+                if item["pull_number"]
+                else item["id"]
+            )
+            if key in unique:
+                previous = unique[key]
+                unique[key] = {
+                    **previous,
+                    **item,
+                    "run_id": previous.get("run_id") or item.get("run_id", ""),
+                    "next_command": previous["next_command"],
+                }
+                collapsed += 1
+            else:
+                unique[key] = item
+        ordered = sorted(
+            unique.values(),
+            key=lambda item: (-item["priority"], item["repository"], item["id"]),
+        )
+        for item in ordered:
+            item["source_age_seconds"] = _age(item["source_updated_at"], now)
+        incomplete = (
+            native["omitted_count"]
+            or len(runs) == 500
+            or len(proposals) == 500
+            or len(pending) > 500
+            or external_omitted
+        )
+        return {
+            "project_id": project["id"],
+            "repository": project["repository"],
+            "items": ordered[:limit],
+            "omitted": max(0, len(ordered) - limit)
+            + native["omitted_count"]
+            + external_omitted,
+            "scan_incomplete": bool(incomplete),
+            "duplicates_collapsed": collapsed,
+            "complete": native["complete"]
+            and not incomplete
+            and all(item.get("complete", True) for item in ordered),
+            "sources": {
+                "kind": "local_cache",
+                "fetched_at": cache.get("fetched_at", ""),
+                "attempted_at": cache.get("attempted_at", ""),
+                "source_age_seconds": _age(cache.get("fetched_at", ""), now),
+                "error": cache.get("error", ""),
+                "status": "refresh_failed"
+                if cache.get("error")
+                else "cached"
+                if portfolio is not None
+                else "not_refreshed",
+            },
+        }
+
+    def show(
+        self,
+        *,
+        project_limit: int = 10,
+        item_limit: int = 10,
+        previous_digest: str = "",
+    ) -> dict:
+        if type(item_limit) is not int or not 1 <= item_limit <= 50:
+            raise ValueError("per-project item limit must be between 1 and 50")
+        if previous_digest and not re.fullmatch(r"[0-9a-f]{64}", previous_digest):
+            raise ValueError("previous overview digest must be SHA-256")
+        selected = self._projects(project_limit)
+        now = datetime.now(UTC)
+        projects = []
+        for project in selected["projects"]:
+            try:
+                report = self._project(
+                    self.tasks._store(), project, limit=item_limit, now=now
+                )
+            except (OSError, ValueError, RuntimeError, KeyError, sqlite3.Error) as exc:
+                report = {
+                    "project_id": project["id"],
+                    "repository": project["repository"],
+                    "complete": False,
+                    "items": [
+                        {
+                            "id": f"project:{project['id']}:unknown",
+                            "priority": 110,
+                            "reason_code": "project_state_unknown",
+                            "summary": str(exc)[:300],
+                            "next_command": "reposteward overview refresh",
+                        }
+                    ],
+                    "omitted": 0,
+                    "scan_incomplete": True,
+                    "duplicates_collapsed": 0,
+                    "sources": {"status": "unknown"},
+                }
+            projects.append(report)
+        facts = {
+            "schema_version": 1,
+            "projects": projects,
+            "omitted_projects": selected["omitted"],
+            "excluded_projects": selected["excluded"],
+            "complete": not selected["omitted"]
+            and all(project["complete"] for project in projects),
+            "duplicates_collapsed": sum(
+                project["duplicates_collapsed"] for project in projects
+            ),
+        }
+        digest = canonical_digest(_fact(facts))
+        return {
+            **facts,
+            "overview_digest": digest,
+            "unchanged": digest == previous_digest if previous_digest else None,
+            "observed_at": now.isoformat(),
+            "repeat_policy": "same facts coalesce; new blockers and unresolved feedback remain visible",
+            "harness_invoked": False,
+            "workspace_modified": False,
+            "public_write": False,
+        }
+
+
+def render_overview(result: dict) -> str:
+    lines = [
+        f"Projects: {len(result['projects'])}; omitted: {result['omitted_projects']}"
+    ]
+    for project in result["projects"]:
+        lines.append(f"\n{project['repository']} ({project['sources']['status']})")
+        for item in project["items"]:
+            lines.append(
+                f"P{item['priority']} {item['summary']}\n  {item['next_command']}"
+            )
+    return "\n".join(lines)

--- a/src/reposteward/overview_ledger.py
+++ b/src/reposteward/overview_ledger.py
@@ -1,0 +1,7 @@
+"""Bounded cached remote facts for the explicit multi-project refresh."""
+
+OVERVIEW_MIGRATION = (
+    """CREATE TABLE IF NOT EXISTS project_inbox_cache (
+        project_id TEXT PRIMARY KEY, repository TEXT NOT NULL, portfolio TEXT NOT NULL DEFAULT '{}',
+        fetched_at TEXT NOT NULL DEFAULT '', attempted_at TEXT NOT NULL, error TEXT NOT NULL DEFAULT '')""",
+)

--- a/src/reposteward/pipeline.py
+++ b/src/reposteward/pipeline.py
@@ -74,7 +74,7 @@ from .issues import (
 from .merge import MergeCheck, MergeDecision, MergeSnapshot, evaluate_merge
 from .models import AgentExecution, AgentResult, Candidate
 from .policy import PolicyError, conventional_scope, enforce_change_policy
-from .portfolio import build_portfolio_snapshot
+from .portfolio_fetch import portfolio_from_pulls
 from .prompt_budget import fit_context
 from .protocol import read_context_bundle, validate_context_bundle
 from .repair_prompt import build_budgeted_repair_context_pack
@@ -813,70 +813,9 @@ class Pipeline:
         *,
         expected_digest: str = "",
     ) -> dict[str, Any]:
-        snapshots: list[dict[str, Any]] = []
-        errors: list[dict[str, Any]] = []
-        for pull in pulls:
-            try:
-                snapshot = self.github.pull_request_merge_snapshot(
-                    policy.name, pull.number
-                )
-                if str(snapshot.get("state") or "").casefold() != "open":
-                    errors.append(
-                        {
-                            "pull_number": pull.number,
-                            "message": "pull request changed state during snapshot",
-                        }
-                    )
-                elif pull.head_sha and snapshot.get("head_sha") != pull.head_sha:
-                    errors.append(
-                        {
-                            "pull_number": pull.number,
-                            "message": "pull request head changed during snapshot",
-                        }
-                    )
-                elif pull.base_sha and snapshot.get("base_sha") != pull.base_sha:
-                    errors.append(
-                        {
-                            "pull_number": pull.number,
-                            "message": "pull request base changed during snapshot",
-                        }
-                    )
-                snapshots.append(snapshot)
-            except GitHubError as exc:
-                errors.append({"pull_number": pull.number, "message": str(exc)[:500]})
-                snapshots.append(
-                    {
-                        "repository": policy.name.casefold(),
-                        "pull_number": pull.number,
-                        "title": pull.title,
-                        "url": pull.url,
-                        "state": pull.state,
-                        "draft": pull.draft,
-                        "updated_at": pull.updated_at,
-                        "head_branch": pull.head_branch,
-                        "head_sha": pull.head_sha,
-                        "base_branch": pull.base_branch,
-                        "base_sha": pull.base_sha,
-                        "files": [],
-                        "checks": [],
-                        "files_complete": False,
-                        "conversations_complete": False,
-                        "checks_complete": False,
-                    }
-                )
-        snapshot = build_portfolio_snapshot(policy.name, snapshots, errors=errors)
-        digest = str(snapshot.pop("snapshot_digest"))
-        return {
-            "snapshot_digest": digest,
-            "expected_digest": expected_digest,
-            "matches_expected_digest": (
-                digest == expected_digest if expected_digest else None
-            ),
-            "snapshot": snapshot,
-            "harness_invoked": False,
-            "workspace_modified": False,
-            "public_write": False,
-        }
+        return portfolio_from_pulls(
+            self.github, policy, pulls, expected_digest=expected_digest
+        )
 
     def _dependency_target_states(
         self,

--- a/src/reposteward/portfolio_fetch.py
+++ b/src/reposteward/portfolio_fetch.py
@@ -1,0 +1,89 @@
+"""Shared read-only portfolio collection for Pipeline and local project views."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .config import RepositoryPolicy
+from .github import GitHubClient, GitHubError, PullRequest
+from .portfolio import build_portfolio_snapshot
+
+
+def portfolio_from_pulls(
+    github: GitHubClient,
+    policy: RepositoryPolicy,
+    pulls: tuple[PullRequest, ...],
+    *,
+    expected_digest: str = "",
+    max_pulls: int | None = None,
+) -> dict[str, Any]:
+    snapshots: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    if max_pulls is not None and len(pulls) > max_pulls:
+        errors.append(
+            {
+                "pull_number": 0,
+                "message": f"portfolio omitted {len(pulls) - max_pulls} open PRs",
+            }
+        )
+        pulls = pulls[:max_pulls]
+    for pull in pulls:
+        try:
+            snapshot = github.pull_request_merge_snapshot(policy.name, pull.number)
+            if str(snapshot.get("state") or "").casefold() != "open":
+                errors.append(
+                    {
+                        "pull_number": pull.number,
+                        "message": "pull request changed state during snapshot",
+                    }
+                )
+            elif pull.head_sha and snapshot.get("head_sha") != pull.head_sha:
+                errors.append(
+                    {
+                        "pull_number": pull.number,
+                        "message": "pull request head changed during snapshot",
+                    }
+                )
+            elif pull.base_sha and snapshot.get("base_sha") != pull.base_sha:
+                errors.append(
+                    {
+                        "pull_number": pull.number,
+                        "message": "pull request base changed during snapshot",
+                    }
+                )
+            snapshots.append(snapshot)
+        except GitHubError as exc:
+            errors.append({"pull_number": pull.number, "message": str(exc)[:500]})
+            snapshots.append(
+                {
+                    "repository": policy.name.casefold(),
+                    "pull_number": pull.number,
+                    "title": pull.title,
+                    "url": pull.url,
+                    "state": pull.state,
+                    "draft": pull.draft,
+                    "updated_at": pull.updated_at,
+                    "head_branch": pull.head_branch,
+                    "head_sha": pull.head_sha,
+                    "base_branch": pull.base_branch,
+                    "base_sha": pull.base_sha,
+                    "files": [],
+                    "checks": [],
+                    "files_complete": False,
+                    "conversations_complete": False,
+                    "checks_complete": False,
+                }
+            )
+    snapshot = build_portfolio_snapshot(policy.name, snapshots, errors=errors)
+    digest = str(snapshot.pop("snapshot_digest"))
+    return {
+        "snapshot_digest": digest,
+        "expected_digest": expected_digest,
+        "matches_expected_digest": (
+            digest == expected_digest if expected_digest else None
+        ),
+        "snapshot": snapshot,
+        "harness_invoked": False,
+        "workspace_modified": False,
+        "public_write": False,
+    }

--- a/src/reposteward/store.py
+++ b/src/reposteward/store.py
@@ -23,11 +23,13 @@ from .feedback import (
 )
 from .knowledge_ledger import KNOWLEDGE_MIGRATION
 from .models import Candidate
+from .overview_ledger import OVERVIEW_MIGRATION
 from .protocol import validate_checkpoint, validate_context_pack
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 
 MIGRATIONS: dict[int, tuple[str, ...]] = {
+    22: OVERVIEW_MIGRATION,
     21: KNOWLEDGE_MIGRATION,
     20: EXTERNAL_VERIFICATION_MIGRATION,
     19: EXTERNAL_TASK_MIGRATION,
@@ -4236,7 +4238,7 @@ class Store:
         return result
 
     def latest_runs_for_repository(
-        self, repository: str, *, limit: int = 500
+        self, repository: str, *, limit: int = 500, include_external: bool = True
     ) -> list[dict[str, Any]]:
         """Return one latest run per Issue without N+1 queries."""
         limit = min(max(limit, 1), 1_000)
@@ -4249,7 +4251,7 @@ class Store:
                                PARTITION BY repository, issue_number
                                ORDER BY created_at DESC, r.rowid DESC
                            ) AS run_rank
-                    FROM runs r WHERE repository=?
+                    FROM runs r WHERE repository=? AND (? OR stage<>'external')
                 )
                 SELECT ranked.*, submissions.pr_url AS submission_pr_url
                 FROM ranked
@@ -4259,7 +4261,7 @@ class Store:
                 WHERE run_rank=1
                 ORDER BY updated_at, id LIMIT ?
                 """,
-                (repository.casefold(), limit),
+                (repository.casefold(), include_external, limit),
             ).fetchall()
         result = []
         for row in rows:

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import io
+import sqlite3
+import unittest
+from contextlib import closing, redirect_stdout
+from dataclasses import asdict, replace
+from unittest.mock import Mock, patch
+
+import test_external_verification
+from test_projects import repository
+
+from reposteward.cli import main
+from reposteward.github import GitHubError
+from reposteward.merge import MergeSnapshot, evaluate_merge
+from reposteward.overview import ProjectOverview, render_overview
+from reposteward.store import utc_now
+
+
+class OverviewTests(unittest.TestCase):
+    container_run = test_external_verification.ExternalVerificationTests.container_run
+    request = test_external_verification.ExternalVerificationTests.request
+
+    def setUp(self) -> None:
+        test_external_verification.ExternalVerificationTests.setUp(self)
+        self.remote = Mock()
+        self.remote.open_pull_requests.return_value = ()
+        self.overview = ProjectOverview(self.config, github=self.remote)
+        self.store = self.service._store(write=True)
+
+    def items(self, result: dict) -> list[dict]:
+        return [item for project in result["projects"] for item in project["items"]]
+
+    def add_second_project(self) -> dict:
+        second = repository(
+            self.root / "second", remote="git@github.com:owner/second.git"
+        )
+        linked = self.service.registry.link(second)
+        policy = replace(self.config.repositories["owner/repo"], name="owner/second")
+        self.config = replace(
+            self.config,
+            repositories={**self.config.repositories, "owner/second": policy},
+        )
+        self.overview = ProjectOverview(self.config, github=self.remote)
+        return linked
+
+    def submitted(self, *, issue: int = 7, pull: int = 12) -> str:
+        run_id = self.store.start_run("owner/repo", issue, "pull_request")
+        self.store.update_run(
+            run_id,
+            status="submitted",
+            stage="pull_request",
+            details={"pr_url": f"https://github.com/owner/repo/pull/{pull}"},
+        )
+        return run_id
+
+    def test_default_local_view_and_cli_do_not_authenticate_launch_or_consume_feedback(
+        self,
+    ) -> None:
+        (self.repo / "source.txt").write_text("dirty work\n")
+        with (
+            patch(
+                "reposteward.overview.GitHubClient",
+                side_effect=AssertionError("authentication"),
+            ),
+            patch("reposteward.cli.Pipeline", side_effect=AssertionError("Pipeline")),
+        ):
+            result = self.overview.show()
+            self.assertEqual(
+                result["projects"][0]["sources"]["status"], "not_refreshed"
+            )
+            self.assertTrue(self.items(result)[0]["dirty"])
+            self.assertEqual(
+                self.items(result)[0]["reason_code"], "external_verification_required"
+            )
+            output = io.StringIO()
+            with (
+                patch("reposteward.cli.load_config", return_value=self.config),
+                redirect_stdout(output),
+            ):
+                self.assertEqual(main(["overview", "show", "--format", "text"]), 0)
+            self.assertIn("owner/repo", output.getvalue())
+        self.remote.open_pull_requests.assert_not_called()
+        self.assertFalse(result["public_write"])
+
+    def test_explicit_refresh_caches_facts_and_failed_refresh_preserves_them(
+        self,
+    ) -> None:
+        first = self.overview.refresh()
+        self.assertTrue(first["complete"])
+        fetched = first["projects"][0]["sources"]["fetched_at"]
+        self.remote.open_pull_requests.side_effect = GitHubError(
+            "temporarily unavailable"
+        )
+        failed = self.overview.refresh()
+        self.assertFalse(failed["complete"])
+        self.assertEqual(failed["projects"][0]["sources"]["fetched_at"], fetched)
+        self.assertEqual(failed["projects"][0]["sources"]["status"], "refresh_failed")
+        self.assertIn(
+            "github_refresh_failed",
+            [item["reason_code"] for item in self.items(failed)],
+        )
+        self.assertIn(
+            "external_verification_required",
+            [item["reason_code"] for item in self.items(failed)],
+        )
+
+    def test_multiple_projects_partial_failure_and_limits_are_explicit(self) -> None:
+        second = self.add_second_project()
+        self.overview.refresh()
+        with self.store._connection() as db:
+            db.execute(
+                "UPDATE project_inbox_cache SET portfolio='invalid JSON' WHERE project_id=?",
+                (second["project"]["id"],),
+            )
+        result = self.overview.show()
+        self.assertEqual(len(result["projects"]), 2)
+        self.assertFalse(result["complete"])
+        first, second_result = result["projects"]
+        self.assertTrue(first["complete"])
+        self.assertEqual(
+            second_result["items"][0]["reason_code"], "project_state_unknown"
+        )
+        limited = self.overview.show(project_limit=1, item_limit=1)
+        self.assertEqual(limited["omitted_projects"], 1)
+        self.assertEqual(len(self.items(limited)), 1)
+        self.assertFalse(limited["complete"])
+
+    def test_show_does_not_create_or_migrate_a_ledger(self) -> None:
+        config = replace(self.config, state_dir=self.root / "new-state")
+        overview = ProjectOverview(config)
+        overview.registry.link(self.repo)
+        ledger = config.state_dir / "reposteward.sqlite3"
+        result = overview.show()
+        self.assertFalse(result["complete"])
+        self.assertFalse(ledger.exists())
+        with closing(sqlite3.connect(self.service.path)) as db:
+            db.execute("PRAGMA user_version=21")
+        before = self.service.path.read_bytes()
+        result = self.overview.show()
+        self.assertEqual(self.items(result)[0]["reason_code"], "project_state_unknown")
+        self.assertEqual(self.service.path.read_bytes(), before)
+
+    def test_duplicate_attempts_coalesce_and_fact_digest_is_stable_between_reads(
+        self,
+    ) -> None:
+        self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+        first = self.overview.refresh()
+        self.assertEqual(first["duplicates_collapsed"], 1)
+        self.assertEqual(len(self.items(first)), 1)
+        again = self.overview.show(previous_digest=first["overview_digest"])
+        self.assertTrue(again["unchanged"])
+        current = self.service.current(self.repo)
+        self.service.checkpoint(
+            current["run_id"],
+            expected_revision=0,
+            expected_snapshot=current["current_snapshot"]["digest"],
+            idempotency_key="blocker",
+            payload={
+                "blockers": ["Need a design decision"],
+                "next_action": "review design",
+            },
+        )
+        changed = self.overview.show(previous_digest=again["overview_digest"])
+        self.assertFalse(changed["unchanged"])
+        self.assertEqual(self.items(changed)[0]["reason_code"], "external_blocked")
+        self.assertIn("owner/repo", render_overview(changed))
+
+    def test_existing_pr_is_retained_when_new_external_attempt_starts_for_same_issue(
+        self,
+    ) -> None:
+        submitted = self.submitted()
+        self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+        result = self.overview.show()
+        self.assertIn(submitted, [item.get("run_id") for item in self.items(result)])
+        self.assertIn(
+            "refresh_required", [item["reason_code"] for item in self.items(result)]
+        )
+
+    def test_audited_merge_suppresses_only_with_complete_cached_portfolio(self) -> None:
+        run_id = self.submitted()
+        snapshot = MergeSnapshot(
+            repository="owner/repo",
+            pull_number=12,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            policy_digest="e" * 64,
+            state="OPEN",
+            draft=False,
+            mergeable="MERGEABLE",
+            review_decision="APPROVED",
+            unresolved_conversations=0,
+            files=("source.txt",),
+            additions=1,
+            deletions=0,
+            checks=(),
+        )
+        decision = evaluate_merge(
+            snapshot,
+            expected_head_sha="c" * 40,
+            expected_base_sha="d" * 40,
+            expected_policy_digest="e" * 64,
+            max_files_changed=40,
+            max_diff_lines=2000,
+        )
+        audit = self.store.append_merge_decision(
+            repository="owner/repo",
+            pull_number=12,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            policy_digest="e" * 64,
+            decision={**decision.to_dict(), "snapshot": asdict(snapshot)},
+        )
+        self.store.append_merge_execution(
+            attempt_id="merged",
+            run_id=run_id,
+            decision_id=audit["id"],
+            repository="owner/repo",
+            pull_number=12,
+            actor="owner",
+            merge_method="squash",
+            stage="completed",
+            outcome="merged",
+            reason="observed merged",
+            decision_digest=decision.decision_digest,
+            head_sha="c" * 40,
+            payload={},
+        )
+        before = self.overview.show()
+        self.assertIn(run_id, [item.get("run_id") for item in self.items(before)])
+        after = self.overview.refresh()
+        self.assertNotIn(run_id, [item.get("run_id") for item in self.items(after)])
+
+    def test_pending_feedback_stays_visible_without_advancing_processing_or_watermark(
+        self,
+    ) -> None:
+        run_id = self.submitted()
+        self.store.ingest_github_pr_activity(
+            run_id=run_id,
+            repository="owner/repo",
+            pull_number=12,
+            activity={
+                "pull_request": {"number": 12, "head_sha": "a" * 40},
+                "comments": [],
+                "reviews": [],
+                "checks": [],
+                "review_comments": [
+                    {
+                        "id": 1,
+                        "author": "reviewer",
+                        "body": "Please handle empty input",
+                        "created_at": utc_now(),
+                        "updated_at": utc_now(),
+                    }
+                ],
+            },
+        )
+        before = self.store.pending_feedback("owner/repo", 12)
+        self.overview.refresh()
+        result = self.overview.show()
+        self.assertIn(
+            "review_feedback_required",
+            [item["reason_code"] for item in self.items(result)],
+        )
+        self.assertEqual(self.store.pending_feedback("owner/repo", 12), before)
+        with self.store._connection() as db:
+            self.assertEqual(
+                db.execute(
+                    "SELECT sequence FROM github_pr_watermarks WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_verification_success_becomes_stale_after_code_changes(self) -> None:
+        self.request()
+        result = self.overview.show()
+        self.assertEqual(
+            self.items(result)[0]["reason_code"], "external_review_required"
+        )
+        (self.repo / "source.txt").write_text("new edit")
+        stale = self.overview.show()
+        self.assertEqual(
+            self.items(stale)[0]["reason_code"], "external_verification_stale"
+        )
+        self.assertNotEqual(result["overview_digest"], stale["overview_digest"])
+
+    def test_invalid_refresh_limits_do_not_make_remote_requests(self) -> None:
+        with self.assertRaises(ValueError):
+            self.overview.refresh(item_limit=0)
+        with self.assertRaises(ValueError):
+            self.overview.refresh(project_limit=51)
+        self.remote.open_pull_requests.assert_not_called()


### PR DESCRIPTION
Closes #103

Aggregate actionable attention across linked projects with explicit online refresh.

---

Use local workspace bindings, task state and bounded portfolio snapshots to build a deterministic multi-project view. Report stale or incomplete facts and preserve prior data on refresh failure. Ordinary display does not contact GitHub, and changed-only views distinguish removed items from incomplete scans. Keep external-task ledgers separate from managed run selection.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
