### PR TITLE
test(assistance): evaluate durable handoff and record actual client pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,5 @@ uv build
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a change. Report vulnerabilities
 through [SECURITY.md](SECURITY.md), not a public Issue.
+
+For using RepoSteward with existing coding agents, see the [assistance guide (中文)](docs/coding-agent-assistance.zh-CN.md) and [actual client pilot](docs/handoff-pilot-2026-09-05.zh-CN.md).

--- a/docs/coding-agent-assistance.zh-CN.md
+++ b/docs/coding-agent-assistance.zh-CN.md
@@ -1,0 +1,76 @@
+# 用 RepoSteward 辅助已有 Coding Agent
+
+RepoSteward 负责把项目、任务目标、未完成事项、决定与验证证据连接起来。日常编码继续使用自己的 Codex、Claude Code 或 Copilot；完成一段工作后留下检查点，换客户端时重新读取当前任务。
+
+## 关联已有项目
+
+先按项目自己的方式 clone，再在 RepoSteward 的用户配置添加对应仓库的 maintainer 策略。`project link` 只建立本地关联，不 clone、不改动目标代码。相同 remote 的多个 worktree 属于同一个项目，但各有独立的工作区绑定。
+
+```sh
+reposteward repo add owner/project --mode maintainer
+reposteward project link /absolute/path/project
+reposteward project inspect /absolute/path/project
+reposteward project list
+```
+
+开发任务必须来自已审阅的开放 Issue，并在 feature branch 上开始。`task start` 会重新检查 Issue、贡献策略及本地 origin 基线；需要在开始前按项目方式 fetch。
+
+```sh
+reposteward task start /absolute/path/project --issue 123 --reviewed-by YOUR_GITHUB_LOGIN
+reposteward task current /absolute/path/project
+reposteward task inspect RUN_ID --live
+reposteward task context RUN_ID --budget 24000 --scope-path src/module.py
+```
+
+上下文中的 contract 保留完整源要求，或使用显式审阅的精简契约；超出预算的强制要求会报错。未完成事项和当前决定来自台账。可选描述、经验和偏好被裁减时，coverage 给出遗漏及取回线索。Agent 所称“已完成”和“测试通过”始终是待核验声明。
+
+## 文件与 MCP 接入
+
+文件与 CLI 接续可独立使用。MCP 入口需要安装包含该扩展的 RepoSteward 版本；若当前版本未提供 `mcp` 命令，请先使用文件/CLI 方式。下方的 MCP 实机记录来自已验证的完整集成版本。
+
+`integration plan` 先生成可审阅 diff 和摘要，`apply` 必须使用该摘要。接入保留原有 AGENTS.md、CLAUDE.md 与 Copilot 指令；撤销只移除自己管理的片段。普通文件不会保存机器路径或认证信息。
+
+MCP 是可选依赖：在运行 RepoSteward 的 Python 环境安装 `reposteward[mcp]`。`mcp config PATH --client codex|claude-code|copilot-vscode` 输出本机配置预览，不自动写客户端配置。服务每次只绑定一个具体工作区，提供 project、context、evidence、checkpoint、verification 五类工具。MCP 服务启动后持有当时的用户配置；修改策略或验证 profile 后应重启服务。
+
+Codex 可以通过用户 `config.toml` 配置 STDIO MCP；Claude Code 可使用临时配置文件及 `--mcp-config`；VS Code 使用用户 MCP 设置。命令路径和本地配置保存在用户目录。[Codex MCP 配置](https://learn.chatgpt.com/docs/extend/mcp?surface=cli)、[Claude Code MCP](https://code.claude.com/docs/en/mcp)。
+
+如果客户端没有 MCP，使用 `task current` 的 CLI 输出和受管理指令文件继续工作；切换前保存 checkpoint。不要将旧会话文字当成当前验证结果。旧包晚导入不会覆盖较新的本地外部任务检查点。
+
+## 验证、知识与多项目视图
+
+在用户拥有的配置中设置 `[[verification_profiles]]`，列出 repository、name、commands 和 bootstrap_commands。Agent 只能选择已有 profile；不能通过仓库文件临时指定任意验证命令。验证在隔离副本和加固容器中执行；开发目录有未提交代码也可验证，但结果只对应当时 revision、代码快照、基线和策略。编辑代码后，旧结果作为历史保留，并明确不再适用于当前快照。
+
+通过验证的开发任务仍需整理为干净提交，再走 adopt、精确本地审阅和独立 submit。MCP 不提供发布与合并工具。
+
+可复用经验先 propose 为 candidate，再由维护者 promote；记录适用路径、来源和审阅理由。即使有测试证据，也不把任意经验断言当成已被测试证明。只有调用 context 时显式指定路径，才选取适用经验；代码或证据变化时过期条目不进入建议。
+
+```sh
+reposteward overview show --format text
+reposteward overview refresh --format text
+```
+
+show 默认仅查看本地事实。refresh 显式拉取 GitHub，缓存有时间与错误状态；一个项目刷新失败不妨碍查看其他项目。未处理反馈、未知验证与新增阻塞持续可见。
+
+## 评测与适用范围
+
+现有 `benchmark run` 增加七个固定 golden 场景：长正文末尾要求、超预算反馈、决定替代、旧包晚导入、dirty 快照、过期证据和中断重试。预期事实位于 `handoff-gold-v1.json`，报告标明这是离线控制面评测。注入的 verifier 仅测试证据失效语义，不是实际测试通过的证明。
+
+在加固验证容器内运行 benchmark，输出 JSON 可沿用 #90 的独立 CI 归档流程。本变更不修改 workflow，不启动模型、联网或发布。报告 schema 继续为 v1，benchmark_version 为 0.2.0，原有场景 ID 保持兼容。
+
+真实客户端试点单独记录版本、同一任务 ID、读取事实、检查点与实际验证。人工接续分钟、重复解释和返工若没有人工观测，标为未知。一次任务不能支持百分比效率提升结论。
+
+## 2026-09-05 实际能力表
+
+| 入口 | 实现与验证 | 实际限制 |
+| --- | --- | --- |
+| 项目关联、任务 CLI | 容器回归覆盖，RepoSteward #104 已实际创建任务 | 开发任务仍需已审阅开放 GitHub Issue 与 feature branch |
+| AGENTS / CLAUDE / Copilot 文件 | 管理片段、冲突、恢复与撤销已通过容器测试 | 本轮未实测各客户端的文件自动加载优先级 |
+| MCP 服务 | 五类工具、真实 STDIO、官方 SDK、新旧协议及取消已通过容器测试 | 本地工作区范围；配置修改后重启 |
+| Codex CLI 0.153.0 | 真实模型通过 MCP 读取原始 Issue，保存并回读 revision 1 → 2 | 此次证明上下文接续；未让客户端编码或执行测试 |
+| Claude Code 2.1.81 | 已启动真实客户端；服务返回 429 配额耗尽 | 双客户端接续尚未完成，恢复现有服务额度后重试 |
+| Copilot | 文件适配及 VS Code MCP 配置预览可用 | 本机未安装 CLI/扩展，实机未验证 |
+| HarnessRunner | 既有 Codex CLI/SDK 路径保留并回归 | Claude/Copilot 托管适配器为条件阶段，未实现 |
+
+#105 hooks 的实施条件是手动检查点有明显遗漏；本轮 Codex 保存与回读成功，尚无该证据。#106/#107 托管 Runner 还需要实际委派需求、客户端能力与收益数据。本轮保留这些开放 Issue，不启用自动路径。
+
+详细试点结果见 [2026-09-05 接续记录](handoff-pilot-2026-09-05.zh-CN.md)。

--- a/docs/handoff-pilot-2026-09-05.zh-CN.md
+++ b/docs/handoff-pilot-2026-09-05.zh-CN.md
@@ -1,0 +1,31 @@
+# RepoSteward 自身的接续试点 · 2026-09-05
+
+用户选择 RepoSteward 自身，任务为已审阅开放 [Issue #104](https://github.com/tiammomo/RepoSteward/issues/104)。这是同一开发任务的上下文恢复实验，没有让两个客户端各自实现功能。独立任务台账保留原始 Issue、三项未完成工作、一项决定及开发快照。
+
+| 观测 | Codex CLI 0.153.0 | Claude Code 2.1.81 |
+| --- | --- | --- |
+| 真实会话 | 成功退出，125.557 秒墙钟耗时 | 195.432 秒后退出 1 |
+| 原始 Issue | 从 source 证据取回六项验收要求 | 未执行模型调用 |
+| MCP 操作 | context → evidence → checkpoint → context，四次完成 | 未取得成功调用证据 |
+| 检查点 | revision 1 → 2 | 没有新检查点 |
+| 未完成事项 | 三项全部保留，台账回读相同 | 未验证 |
+| 决定 | 使用 RepoSteward 自身试点，理由和来源保留 | 未验证 |
+| 后继客户端读取前任说明 | Codex 留下了接续说明 | 被服务端 429 阻断 |
+| 客户端执行测试 | 没有 | 没有 |
+| 公开写入 | 没有 | 没有 |
+
+Codex 从完整源正文恢复了验收要求；该任务 contract 为 source_bound，因此结构化 acceptance_criteria 数组为空并不表示没有验收条件。下一客户端必须读取完整 source_requirements 或原始证据。
+
+Claude Code 使用机器现有供应商与模型配置，服务返回“已达到 Token Plan 用量上限”（429，2056）。结果带有 is_error=true；外层 subtype 虽为 success，也不能据此判为成功。没有静默更换模型或服务。恢复现有服务额度后，需要重新读取同一任务的当前 revision，再继续保存和回读，不能重放旧 snapshot 身份。
+
+人工接续分钟、重复解释次数、人工返工、配置分钟均未测量，记为未知。客户端墙钟耗时包含等待，不能当成人工时间。新增试点配置为独立的用户配置、项目策略和 Claude MCP 文件三份；Codex 的 MCP 配置经启动参数传入。初始化时用户状态目录覆盖了临时项目设置，已将试点记录迁出、恢复日常台账 schema 17，并核对完整性及既有业务表摘要；后续从用户层指定隔离目录，启动前检查生效路径。
+
+离线 benchmark 首轮暴露两处新 fixture 接口误用（反馈 report 与 events 混用、VerificationResult 位置参数顺序），修订后须以容器结果验收。这属于评测脚手架修正，不能统计成产品带来的返工节省。真实代码验证结果单独保存在版本绑定的 verifier 证据中，不采用客户端自述。
+
+本轮证明了 Codex 经 MCP 读取、保存与回读的链路，以及模型用量异常能够明确暴露。双客户端接续与人工维护收益尚未得到完整验证；不得据此宣称效率提升百分比、Claude 实机通过或 Copilot 已验证。
+
+原始模型输出仅保存在操作者本地，摘要如下，便于对照证据：
+
+- Codex stdout SHA-256：`cd6c8f6417e2d84fe263da1ec44258bc55488e9790015423cd4497a5ee5a7af7`
+- Claude stdout SHA-256：`fa81dfeb217be89ad8d50cf7d18d42c118a7e0197b5e4363062bbf84db699796`
+- 任务：`2912b3eba72c472989f787b1a07dc61e`，试点 HEAD：`da3599ae0ed8b18d74f0338d47dac5abd2dfa297`；dirty 快照：`bfe71c7a64354f6109dda3da0817894940f8ffff559a9b4af71a5df5662d1adc`。

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -1058,3 +1058,5 @@ reposteward overview show --previous-digest <digest>
 每项附下一步与可用的生命周期 trace、检查点或验证引用。较长下一步文本只展示前
 一千字符并注明省略量，完整记录从检查点证据取回。开发验证成功继续表示本地开发
 证据，仍需审阅余项、形成干净提交并走 adopt；视图不自动提交、发布或合并。
+
+已有 Coding Agent 的项目关联、接续、独立验证与当前能力限制见[使用指南](coding-agent-assistance.zh-CN.md)。

--- a/src/reposteward/benchmark.py
+++ b/src/reposteward/benchmark.py
@@ -24,6 +24,7 @@ from .dependencies import (
     build_dependency_plan,
     parse_dependency_declarations,
 )
+from .handoff_benchmark import OBSERVERS, observe_handoff
 from .inbox import build_maintainer_inbox, render_inbox_text
 from .store import Store, StoreError
 
@@ -723,6 +724,15 @@ _SCENARIOS: dict[str, Scenario] = {
     "scale.inbox_1000_bounded": _scenario_inbox_1000_bounded,
     "scale.dependency_chain_1000": _scenario_dependency_chain_1000,
 }
+
+
+_SCENARIOS.update(
+    {
+        f"{category}.handoff_{case}": (lambda selected=case: observe_handoff(selected))
+        for case in OBSERVERS
+        for category in ("recovery" if case == "interrupted_checkpoint" else "context",)
+    }
+)
 
 
 def _git_sha() -> str:

--- a/src/reposteward/data/benchmark-scenarios-v1.json
+++ b/src/reposteward/data/benchmark-scenarios-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "suite_id": "repostewardbench-v0",
-  "benchmark_version": "0.1.0",
+  "benchmark_version": "0.2.0",
   "categories": [
     "safety",
     "context",
@@ -142,6 +142,132 @@
       "assertions": [
         {"metric": "ordered_pull_requests", "operator": "eq", "value": 1000},
         {"metric": "cycles", "operator": "eq", "value": 0}
+      ]
+    },
+    {
+      "id": "context.handoff_tail_acceptance",
+      "category": "context",
+      "critical": true,
+      "description": "Observe tail acceptance against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 3
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "context.handoff_feedback_overflow",
+      "category": "context",
+      "critical": true,
+      "description": "Observe feedback overflow against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 4
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "context.handoff_decision_replacement",
+      "category": "context",
+      "critical": true,
+      "description": "Observe decision replacement against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 4
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "context.handoff_late_bundle",
+      "category": "context",
+      "critical": true,
+      "description": "Observe late bundle against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 2
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "context.handoff_dirty_snapshot",
+      "category": "context",
+      "critical": true,
+      "description": "Observe dirty snapshot against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 4
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "context.handoff_stale_evidence",
+      "category": "context",
+      "critical": true,
+      "description": "Observe stale evidence against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 5
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "id": "recovery.handoff_interrupted_checkpoint",
+      "category": "recovery",
+      "critical": true,
+      "description": "Observe interrupted checkpoint against versioned handoff gold facts.",
+      "assertions": [
+        {
+          "metric": "gold_facts_matched",
+          "operator": "eq",
+          "value": 5
+        },
+        {
+          "metric": "gold_facts_missing",
+          "operator": "eq",
+          "value": 0
+        }
       ]
     }
   ]

--- a/src/reposteward/data/handoff-gold-v1.json
+++ b/src/reposteward/data/handoff-gold-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "annotation_basis": "Reviewed Issue #104 acceptance criteria; fixed expectations before executing the scenarios",
+  "cases": {
+    "tail_acceptance": {"tail_retained": true, "description_trimmed": true, "contract_review": "source_bound"},
+    "feedback_overflow": {"pending_items": 20, "pending_unchanged": true, "context_omits_feedback": true, "bounded": true},
+    "decision_replacement": {"current_decisions": ["Keep current open work and bounded evidence pages"], "replacement_explained": true, "previous_decision_retrievable": true, "revision_advanced": true},
+    "late_bundle": {"open_work": ["Handle empty input", "Preserve legacy output"], "revision": 1},
+    "dirty_snapshot": {"same_head": true, "different_snapshot": true, "dirty": true, "old_snapshot_rejected": true},
+    "stale_evidence": {"initial_applicability": "matches", "historical_outcome": "passed", "current_applicability": "not_verified", "publication_eligible": false, "verification_backend": "injected_fixture"},
+    "interrupted_checkpoint": {"interrupted_write_rolled_back": true, "revision": 1, "retry_same_checkpoint": true, "retry_idempotent": true, "open_work": ["Handle empty input"]}
+  }
+}

--- a/src/reposteward/handoff_benchmark.py
+++ b/src/reposteward/handoff_benchmark.py
@@ -1,0 +1,386 @@
+"""Offline handoff observations compared with independently versioned gold facts.
+
+Fixture repositories and injected verification results exercise control-plane
+semantics. They are not measurements of a model or evidence of real tests passing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.resources
+import json
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from .agent import build_harness_prompt
+from .config import VerificationProfile, load_config
+from .context import build_context_pack, portable_bundle
+from .context_budget import build_follow_up_context
+from .external_tasks import ExternalTasks, TaskConflict
+from .external_verification import ExternalVerification
+from .models import Candidate, Issue, RepositoryInfo, VerificationResult
+from .prompt_budget import fit_context
+from .store import Store
+from .workspace import sanitized_environment
+
+
+def handoff_gold() -> dict:
+    value = json.loads(
+        importlib.resources.files("reposteward")
+        .joinpath("data", "handoff-gold-v1.json")
+        .read_text(encoding="utf-8")
+    )
+    if value.get("schema_version") != 1 or set(value["cases"]) != set(OBSERVERS):
+        raise ValueError("unsupported handoff gold fixture")
+    return value
+
+
+def _issue(body: str = "Handle empty input without changing legacy output") -> Issue:
+    return Issue(
+        repository="owner/repo",
+        number=7,
+        node_id=8,
+        title="Fix the edge case",
+        body=body,
+        url="https://github.com/owner/repo/issues/7",
+        labels=("bug",),
+        comments=0,
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-02T00:00:00Z",
+        author_login="reporter",
+        author_association="NONE",
+    )
+
+
+class _FixtureGitHub:
+    """No transport, credential discovery, or public mutation implementation."""
+
+    def __init__(self, head: str):
+        self.head = head
+
+    def authenticated_login(self):
+        return "owner"
+
+    def issue(self, *_):
+        return _issue()
+
+    def repository(self, *_):
+        return RepositoryInfo(
+            "owner/repo", "main", 1000, 20, 5, "2026-01-02T00:00:00Z", False, False
+        )
+
+    def branch_head_sha(self, *_):
+        return self.head
+
+
+@contextmanager
+def _task():
+    with tempfile.TemporaryDirectory(prefix="reposteward-handoff-") as directory:
+        root = Path(directory)
+        repo = root / "repo"
+        repo.mkdir()
+        env = sanitized_environment(keep_codex_credentials=False)
+        env.update(GIT_CONFIG_NOSYSTEM="1", GIT_CONFIG_GLOBAL="/dev/null")
+
+        def git(*args):
+            return subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-c",
+                    "user.name=Fixture",
+                    "-c",
+                    "user.email=fixture@example.test",
+                    *args,
+                ],
+                cwd=repo,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            ).stdout.strip()
+
+        git("init", "-b", "main")
+        (repo / "source.txt").write_text("original\n")
+        git("add", "source.txt")
+        git("commit", "-m", "Fixture baseline")
+        git("remote", "add", "origin", "git@github.com:owner/repo.git")
+        git("update-ref", "refs/remotes/origin/main", "HEAD")
+        git("switch", "-c", "fixture/handoff")
+        config_path = root / "config.toml"
+        config_path.write_text(
+            '[github]\nlogin="owner"\n[repositories."owner/repo"]\nmode="maintainer"\n'
+        )
+        config = load_config(config_path, include_user=False)
+        policy = replace(
+            config.repositories["owner/repo"],
+            min_stars=0,
+            require_assignment_before_submit=False,
+            require_no_competing_work=False,
+            verification_prefixes=("python ",),
+            required_verification_markers=(),
+        )
+        config = replace(
+            config,
+            state_dir=root / "state",
+            repositories={"owner/repo": policy},
+            verification_profiles=(
+                VerificationProfile(
+                    "owner/repo", "fixture", ("python -m unittest",), ()
+                ),
+            ),
+        )
+        service = ExternalTasks(config, github=_FixtureGitHub(git("rev-parse", "HEAD")))
+        service.registry.link(repo)
+        run = service.start(repo, issue_number=7, reviewed_by="owner")
+        yield service, repo, run["run_id"]
+
+
+def _checkpoint(service, run_id, payload, *, key="checkpoint"):
+    current = service.inspect(run_id, live=True)
+    return service.checkpoint(
+        run_id,
+        expected_revision=current["revision"],
+        expected_snapshot=current["current_snapshot"]["digest"],
+        idempotency_key=key,
+        payload=payload,
+    )
+
+
+def _tail():
+    tail = "TAIL-AC: preserve the legacy empty-input output."
+    with _task() as (service, repo, _):
+        candidate = Candidate(
+            _issue("background " * 2500 + tail), _FixtureGitHub("").repository(), 50
+        )
+        pack = build_context_pack(
+            candidate,
+            service.config.repositories["owner/repo"],
+            work_item_id="work",
+            run_id="run",
+            worktree=repo,
+            base_commit="a" * 40,
+            harness="external",
+            model="",
+            task_description_max_bytes=500,
+        )
+        fitted, _ = fit_context(pack, 40000)
+        return {
+            "tail_retained": tail in build_harness_prompt(fitted),
+            "description_trimmed": tail not in fitted.task.description,
+            "contract_review": fitted.task_contract.review_status,
+        }
+
+
+def _feedback():
+    with _task() as (service, _, run_id):
+        store = Store(service.path)
+        comments = [
+            {
+                "id": n,
+                "author": "reviewer",
+                "body": f"AC-{n}: " + "detail " * 400,
+                "updated_at": "2026-01-02T00:00:00Z",
+            }
+            for n in range(1, 21)
+        ]
+        activity = {
+            "pull_request": {"number": 12, "head_sha": "a" * 40},
+            "comments": [],
+            "reviews": [],
+            "review_comments": comments,
+            "checks": [],
+        }
+        store.ingest_github_pr_activity(
+            run_id=run_id, repository="owner/repo", pull_number=12, activity=activity
+        )
+        pending = store.pending_feedback("owner/repo", 12)
+        plan = build_follow_up_context(
+            activity=activity, events=pending["events"], budget_tokens=5000
+        )
+        after = store.pending_feedback("owner/repo", 12)
+        return {
+            "pending_items": len(after["events"]),
+            "pending_unchanged": pending == after,
+            "context_omits_feedback": plan["stats"]["retained_events"]
+            < len(pending["events"]),
+            "bounded": plan["estimated_tokens"] <= 5000,
+        }
+
+
+def _decisions():
+    with _task() as (service, _, run_id):
+        old = {
+            "statement": "Use an unbounded history",
+            "rationale": "initial proposal",
+            "evidence": [],
+        }
+        first = _checkpoint(
+            service, run_id, {"next_action": "review choice", "decisions": [old]}
+        )
+        new = {
+            "statement": "Keep current open work and bounded evidence pages",
+            "rationale": "Explicitly replaces the unbounded history proposal",
+            "evidence": [f"checkpoint:{run_id}:1"],
+        }
+        _checkpoint(
+            service,
+            run_id,
+            {"next_action": "verify pagination", "decisions": [new]},
+            key="replacement",
+        )
+        result = service.context(run_id)
+        historical = ExternalVerification(service.config).evidence(
+            run_id, f"checkpoint:{run_id}:1"
+        )
+        return {
+            "current_decisions": [d["statement"] for d in result["decisions"]],
+            "replacement_explained": result["decisions"][0]["rationale"]
+            == new["rationale"],
+            "previous_decision_retrievable": old["statement"] in json.dumps(historical),
+            "revision_advanced": result["revision"] == first["revision"] + 1,
+        }
+
+
+def _late_bundle():
+    with _task() as (service, _, run_id):
+        store = Store(service.path)
+        old = portable_bundle(store.context_bundle(run_id))
+        _checkpoint(
+            service,
+            run_id,
+            {
+                "remaining": ["Handle empty input", "Preserve legacy output"],
+                "next_action": "verify both acceptance criteria",
+            },
+        )
+        store.import_context_bundle(old)
+        return {
+            "open_work": service.context(run_id)["open_work"],
+            "revision": service.inspect(run_id)["revision"],
+        }
+
+
+def _dirty():
+    with _task() as (service, repo, run_id):
+        before = service.inspect(run_id, live=True)
+        (repo / "source.txt").write_text("uncommitted change\n")
+        after = service.inspect(run_id, live=True)
+        rejected = False
+        try:
+            service.checkpoint(
+                run_id,
+                expected_revision=0,
+                expected_snapshot=before["current_snapshot"]["digest"],
+                idempotency_key="old",
+                payload={"next_action": "continue"},
+            )
+        except TaskConflict:
+            rejected = True
+        return {
+            "same_head": before["current_snapshot"]["head"]
+            == after["current_snapshot"]["head"],
+            "different_snapshot": before["current_snapshot"]["digest"]
+            != after["current_snapshot"]["digest"],
+            "dirty": after["current_snapshot"]["dirty"],
+            "old_snapshot_rejected": rejected,
+        }
+
+
+class _FixtureVerifier:
+    def verify(self, *_, **__):
+        return VerificationResult(
+            True, (), "injected fixture result; no tests executed"
+        )
+
+
+def _stale():
+    with _task() as (service, repo, run_id):
+        verification = ExternalVerification(service.config, verifier=_FixtureVerifier())
+        current = service.inspect(run_id, live=True)
+        first = verification.request(
+            run_id,
+            profile="fixture",
+            expected_revision=0,
+            expected_snapshot=current["current_snapshot"]["digest"],
+            idempotency_key="fixture",
+        )
+        (repo / "source.txt").write_text("later change\n")
+        after = verification.inspect(
+            run_id, first["evidence_id"].split(":")[1], live=True
+        )
+        return {
+            "initial_applicability": first["current_applicability"],
+            "historical_outcome": after["outcome"],
+            "current_applicability": after["current_applicability"],
+            "publication_eligible": after["publication_eligible"],
+            "verification_backend": "injected_fixture",
+        }
+
+
+def _recovery():
+    with _task() as (service, _, run_id):
+        current = service.inspect(run_id, live=True)
+        args = {
+            "expected_revision": 0,
+            "expected_snapshot": current["current_snapshot"]["digest"],
+            "idempotency_key": "retry",
+            "payload": {"remaining": ["Handle empty input"], "next_action": "verify"},
+        }
+        try:
+            with patch.object(
+                Store, "update_run", side_effect=RuntimeError("injected interruption")
+            ):
+                service.checkpoint(run_id, **args)
+        except RuntimeError:
+            pass
+        rolled_back = service.inspect(run_id)["revision"] == 0
+        first = service.checkpoint(run_id, **args)
+        retry = service.checkpoint(run_id, **args)
+        return {
+            "interrupted_write_rolled_back": rolled_back,
+            "revision": service.inspect(run_id)["revision"],
+            "retry_same_checkpoint": first["checkpoint_id"] == retry["checkpoint_id"],
+            "retry_idempotent": retry["idempotent"],
+            "open_work": service.context(run_id)["open_work"],
+        }
+
+
+OBSERVERS = {
+    "tail_acceptance": _tail,
+    "feedback_overflow": _feedback,
+    "decision_replacement": _decisions,
+    "late_bundle": _late_bundle,
+    "dirty_snapshot": _dirty,
+    "stale_evidence": _stale,
+    "interrupted_checkpoint": _recovery,
+}
+
+
+def observe_handoff(case: str) -> dict:
+    gold = handoff_gold()
+    actual = OBSERVERS[case]()
+    expected = gold["cases"][case]
+    if actual != expected:
+        raise AssertionError(
+            f"handoff {case}: observed {actual!r}; expected {expected!r}"
+        )
+    return {
+        "metrics": {"gold_facts_matched": len(expected), "gold_facts_missing": 0},
+        "facts": {
+            "gold_version": gold["schema_version"],
+            "gold_sha256": hashlib.sha256(
+                json.dumps(gold, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest(),
+            "observations": actual,
+            "measurement": "offline_control_plane",
+            "human_handoff_minutes": None,
+            "model_quality_measured": False,
+        },
+    }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stdout
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from reposteward.benchmark import (
     BENCHMARK_CATEGORIES,
@@ -16,6 +17,7 @@ from reposteward.benchmark import (
     validate_benchmark_report,
 )
 from reposteward.cli import main
+from reposteward.handoff_benchmark import handoff_gold, observe_handoff
 
 
 class RepoStewardBenchTests(unittest.TestCase):
@@ -23,8 +25,12 @@ class RepoStewardBenchTests(unittest.TestCase):
         report = run_benchmark()
 
         validate_benchmark_report(report)
-        self.assertEqual(report["summary"]["scenario_count"], 13)
-        self.assertEqual(report["summary"]["failed"], 0)
+        self.assertEqual(report["summary"]["scenario_count"], 20)
+        self.assertEqual(
+            report["summary"]["failed"],
+            0,
+            [row for row in report["scenarios"] if not row["passed"]],
+        )
         self.assertTrue(report["summary"]["hard_gate_pass"])
         self.assertTrue(report["summary"]["deterministic"])
         self.assertEqual(
@@ -110,6 +116,20 @@ class RepoStewardBenchTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "public_write"):
             validate_benchmark_report(report)
+
+    def test_handoff_gold_rejects_lost_work_even_if_observer_claims_success(
+        self,
+    ) -> None:
+        wrong = deepcopy(handoff_gold()["cases"]["late_bundle"])
+        wrong["open_work"] = []
+        with (
+            patch.dict(
+                "reposteward.handoff_benchmark.OBSERVERS",
+                {"late_bundle": lambda: wrong},
+            ),
+            self.assertRaisesRegex(AssertionError, "open_work"),
+        ):
+            observe_handoff("late_bundle")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #104

Evaluate durable agent handoff with independent golden cases and document the actual client pilot.

---

Add seven semantic handoff scenarios to the existing deterministic benchmark and verify their independent golden data. Record the observed Codex MCP continuation and the Claude provider quota failure without claiming cross-client quality or human-time gains. Document the common CLI/MCP workflow, recovery boundaries and conditional future integrations. The CLI and file workflow runs independently; the documented MCP client observations come from the complete integration build. Keep the outstanding two-client acceptance tracked on Issue #104 while the existing Claude service quota is unavailable.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
