### PR TITLE
feat(mcp): serve bounded workspace-scoped coding assistance

### DIFF
--- a/docs/coding-agent-assistance.zh-CN.md
+++ b/docs/coding-agent-assistance.zh-CN.md
@@ -26,8 +26,6 @@ reposteward task context RUN_ID --budget 24000 --scope-path src/module.py
 
 ## 文件与 MCP 接入
 
-文件与 CLI 接续可独立使用。MCP 入口需要安装包含该扩展的 RepoSteward 版本；若当前版本未提供 `mcp` 命令，请先使用文件/CLI 方式。下方的 MCP 实机记录来自已验证的完整集成版本。
-
 `integration plan` 先生成可审阅 diff 和摘要，`apply` 必须使用该摘要。接入保留原有 AGENTS.md、CLAUDE.md 与 Copilot 指令；撤销只移除自己管理的片段。普通文件不会保存机器路径或认证信息。
 
 MCP 是可选依赖：在运行 RepoSteward 的 Python 环境安装 `reposteward[mcp]`。`mcp config PATH --client codex|claude-code|copilot-vscode` 输出本机配置预览，不自动写客户端配置。服务每次只绑定一个具体工作区，提供 project、context、evidence、checkpoint、verification 五类工具。MCP 服务启动后持有当时的用户配置；修改策略或验证 profile 后应重启服务。

--- a/docs/operator-guide.zh-CN.md
+++ b/docs/operator-guide.zh-CN.md
@@ -992,6 +992,39 @@ reposteward verification evidence <run-id> log:<id>:0 --offset 0 --limit 8000
 `checkpoint:<run-id>:<revision>` 取回。日志摘要记录完整输出摘要及已保留日志摘要，
 截断与缺失分别报告；正文被修改或丢失时返回 unknown。查询不调用模型或 GitHub。
 
+## 本地 MCP 辅助服务
+
+MCP 是已有 Coding Agent 会话的辅助入口。安装可选依赖后，在本机客户端中注册
+STDIO 服务；它只服务启动时绑定的一个工作区：
+
+```bash
+uv sync --extra mcp
+reposteward mcp config /path/to/project --client codex
+reposteward mcp serve /path/to/project
+```
+
+`config` 为 Codex、Claude Code 或 Copilot VS Code 输出各自的配置片段，不写客户端
+文件。输出包含当前 Python 和项目的本机路径，应放入用户自己的本地设置。
+客户端与服务必须在能访问该工作区的同一台机器上；云端托管 Agent 不因此获得本机访问。
+缺少 MCP 扩展或客户端能力时，继续使用 `integration` 生成的文件和 CLI 指引。
+
+工具固定为 `project`、`context`、`evidence`、`checkpoint`、`verification`。
+任务必须属于所绑定工作区；同一仓库的其他 clone/worktree 也不自动授权。
+解绑后访问失效。工具不提供任意路径、shell、GitHub 写入或 Agent 启动入口。
+输入按 JSON Schema 严格核验，单帧最多 120000 字节，结果最多 300000 字节；超过
+结果限制时需减少预算或条数，超大输入帧关闭连接。最多同时运行四个工具调用。
+
+MCP 与 CLI 调用相同的任务和验证服务，检查点同样要求 revision、snapshot 和幂等键。
+取消验证会通知执行线程、清理具体容器并保存 cancelled；进程突然退出且无终态记录
+时，可按原证据 ID 查询 unknown。STDIO 的 stdout 只用于协议，诊断进入 stderr。
+
+实现锁定官方 Python SDK 2.1.1，测试分别覆盖 2025-11-25 初始化握手和
+2026-07-28 每请求版本声明。客户端实机结果在接续试点中单独记录，协议测试通过
+不代表任意版本客户端均已验证。
+参考 [SDK v2](https://py.sdk.modelcontextprotocol.io/get-started/installation/)、
+[协议版本](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)
+和 [STDIO](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/stdio)。
+
 ## 保存可以重验的项目经验
 
 经验先作为 `candidate` 保存，须指明适用路径、直接来源证据和可选条件。条件目前
@@ -1025,8 +1058,8 @@ reposteward task context <run-id> --scope-path src --format markdown
 历史关系。重复提案和相同审阅幂等。跨项目查询隔离，不自动把业务经验升级为通用
 偏好，不复制原生聊天或改写项目的 AGENTS/CLAUDE/skills 文件。
 
-任务仅在显式提供 `--scope-path` 时选择最多五条有效经验。
-预算不足先省略可取回的经验，并记录数量、来源与摘要；需求、
+任务仅在显式提供 `--scope-path` 时选择最多五条有效经验；MCP 的 `context` 对应
+参数为 `scope_paths`。预算不足先省略可取回的经验，并记录数量、来源与摘要；需求、
 开放项与决定继续保留。正文可通过 `verification evidence <run-id> knowledge:<id>`
 有界取回。此流程沿用 #82/PR #84 的证据回顾思路，规则文件的最终变更仍需目标项目审阅。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ Issues = "https://github.com/tiammomo/RepoSteward/issues"
 
 [project.optional-dependencies]
 codex-sdk = ["openai-codex>=0.147,<0.148"]
+mcp = [
+    "mcp>=2.1.1,<3",
+]
+
+[dependency-groups]
+dev = ["mcp>=2.1.1,<3"]
 
 [project.scripts]
 reposteward = "reposteward.cli:main"

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -188,6 +188,20 @@ def _parser() -> argparse.ArgumentParser:
             command.add_argument("--limit", type=int, default=5)
             command.add_argument("--all", action="store_true")
 
+    mcp = subparsers.add_parser(
+        "mcp", help="serve scoped local task assistance to existing clients"
+    )
+    mcp_commands = mcp.add_subparsers(dest="mcp_command", required=True)
+    mcp_serve = mcp_commands.add_parser("serve", help="run the local STDIO server")
+    mcp_serve.add_argument("path", type=Path)
+    mcp_config = mcp_commands.add_parser(
+        "config", help="preview local client configuration"
+    )
+    mcp_config.add_argument("path", type=Path)
+    mcp_config.add_argument(
+        "--client", choices=("codex", "claude-code", "copilot-vscode"), required=True
+    )
+
     task = subparsers.add_parser(
         "task", help="assist coding agents in linked local projects"
     )
@@ -841,6 +855,16 @@ def main(argv: list[str] | None = None) -> int:
                     include_inactive=args.all,
                 )
             _json(result)
+            return 0
+        if args.command == "mcp":
+            if args.mcp_command == "serve":
+                from .mcp_bridge import serve
+
+                serve(config, args.path)
+            else:
+                from .mcp_config import client_config
+
+                _json(client_config(config, args.path, client=args.client))
             return 0
         if args.command == "verification":
             from .external_verification import ExternalVerification

--- a/src/reposteward/mcp_bridge.py
+++ b/src/reposteward/mcp_bridge.py
@@ -1,0 +1,459 @@
+"""Thin, workspace-scoped MCP transport over the same local application services."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Event
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from .config import AppConfig
+from .external_tasks import ExternalTasks, TaskConflict
+from .projects import ProjectError
+
+MAX_REQUEST_BYTES = 120_000
+MAX_RESPONSE_BYTES = 300_000
+RUN = {"type": "string", "pattern": "^[0-9a-f]{32}$"}
+DIGEST = {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+REVISION = {"type": "integer", "minimum": 0}
+KEY = {"type": "string", "pattern": "^[A-Za-z0-9_.:-]{1,128}$"}
+TEXT = {"type": "string", "maxLength": 2000}
+TEXT_LIST = {"type": "array", "maxItems": 128, "items": TEXT}
+
+
+def _object(properties: dict, required: tuple[str, ...] = ()) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+SCHEMAS = {
+    "project": _object({}),
+    "context": _object(
+        {
+            "run_id": RUN,
+            "budget": {"type": "integer", "minimum": 512, "maximum": 64000},
+            "live": {"type": "boolean"},
+            "scope_paths": {
+                "type": "array",
+                "maxItems": 12,
+                "items": {"type": "string", "maxLength": 512},
+            },
+        }
+    ),
+    "evidence": {
+        "type": "object",
+        "oneOf": [
+            _object(
+                {
+                    "run_id": RUN,
+                    "action": {"const": "list"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 20},
+                },
+                ("run_id", "action"),
+            ),
+            _object(
+                {
+                    "run_id": RUN,
+                    "action": {"const": "get"},
+                    "evidence_id": {"type": "string", "maxLength": 180},
+                    "offset": REVISION,
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 16000},
+                },
+                ("run_id", "action", "evidence_id"),
+            ),
+        ],
+    },
+    "understanding": {
+        "type": "object",
+        "oneOf": [
+            _object(
+                {
+                    "action": {"enum": ["guide", "query"]},
+                    "mode": {"enum": ["maintainer", "contributor"]},
+                    "focus": TEXT,
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 20},
+                },
+                ("action",),
+            ),
+            _object(
+                {
+                    "action": {"const": "evidence"},
+                    "evidence_id": {"type": "string", "pattern": "^code:[0-9a-f]{64}$"},
+                    "start_line": {"type": "integer", "minimum": 1},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 120},
+                },
+                ("action", "evidence_id"),
+            ),
+        ],
+    },
+    "checkpoint": _object(
+        {
+            "run_id": RUN,
+            "expected_revision": REVISION,
+            "expected_snapshot": DIGEST,
+            "idempotency_key": KEY,
+            "payload": _object(
+                {
+                    **{
+                        field: TEXT_LIST
+                        for field in (
+                            "completed",
+                            "remaining",
+                            "blockers",
+                            "tests_observed",
+                            "risks",
+                        )
+                    },
+                    "decisions": {
+                        "type": "array",
+                        "maxItems": 128,
+                        "items": _object(
+                            {
+                                "statement": TEXT,
+                                "rationale": TEXT,
+                                "evidence": TEXT_LIST,
+                            },
+                            ("statement",),
+                        ),
+                    },
+                    "next_action": TEXT,
+                    "notes": TEXT,
+                },
+                ("next_action",),
+            ),
+        },
+        (
+            "run_id",
+            "expected_revision",
+            "expected_snapshot",
+            "idempotency_key",
+            "payload",
+        ),
+    ),
+    "verification": {
+        "type": "object",
+        "oneOf": [
+            _object(
+                {"run_id": RUN, "action": {"const": "profiles"}}, ("run_id", "action")
+            ),
+            _object(
+                {
+                    "run_id": RUN,
+                    "action": {"const": "inspect"},
+                    "evidence_id": {
+                        "type": "string",
+                        "pattern": "^verification:[0-9a-f]{32}$",
+                    },
+                    "live": {"type": "boolean"},
+                },
+                ("run_id", "action", "evidence_id"),
+            ),
+            _object(
+                {
+                    "run_id": RUN,
+                    "action": {"const": "request"},
+                    "profile": {"type": "string", "pattern": "^[a-z][a-z0-9_-]{0,63}$"},
+                    "expected_revision": REVISION,
+                    "expected_snapshot": DIGEST,
+                    "idempotency_key": KEY,
+                },
+                (
+                    "run_id",
+                    "action",
+                    "profile",
+                    "expected_revision",
+                    "expected_snapshot",
+                    "idempotency_key",
+                ),
+            ),
+        ],
+    },
+}
+DESCRIPTIONS = {
+    "understanding": "Read project overview, question-focused implementation/test reading routes and cited source lines. Static facts and repository declarations are distinct. Requires an explicit CLI scan; never scans, executes project code or writes from MCP.",
+    "project": "Inspect the one workspace explicitly bound to this local server.",
+    "context": "Read the current task contract, open work, decisions and verification references within a budget.",
+    "evidence": "List task evidence or retrieve bounded text by its scoped evidence ID.",
+    "checkpoint": "Save unverified Agent claims with exact revision and snapshot checks; grants no publication authority.",
+    "verification": "Inspect evidence or request a user-configured verification profile for an exact task snapshot.",
+}
+
+
+class ScopedBridge:
+    def __init__(self, config: AppConfig, workspace: Path):
+        self.config = config
+        self.tasks = ExternalTasks(config)
+        self.bound = self.tasks.registry.inspect(workspace)
+        self.root = Path(self.bound["binding"]["root"])
+        self.tasks._policy(self.bound["project"]["repository"])
+
+    def _scope(self, run_id: str | None = None) -> dict:
+        current = self.tasks.registry.inspect(self.root)
+        if any(
+            current[section][field] != self.bound[section][field]
+            for section, field in (
+                ("project", "id"),
+                ("binding", "id"),
+                ("binding", "fingerprint"),
+            )
+        ):
+            raise ProjectError(
+                "server workspace binding changed; restart after explicit reconfiguration"
+            )
+        self.tasks._policy(current["project"]["repository"])
+        if run_id:
+            record = self.tasks._record(self.tasks._store(), run_id)
+            if (
+                record["project_id"] != current["project"]["id"]
+                or record["binding_id"] != current["binding"]["id"]
+            ):
+                raise ProjectError("task is outside this server's workspace scope")
+        return current
+
+    def call(
+        self, name: str, arguments: dict[str, Any], *, cancel_event: Event | None = None
+    ) -> dict:
+        if name not in SCHEMAS:
+            raise ValueError("unknown RepoSteward tool")
+        if len(json.dumps(arguments, ensure_ascii=False).encode()) > MAX_REQUEST_BYTES:
+            raise ValueError("tool input exceeds the request limit")
+        try:
+            Draft202012Validator(SCHEMAS[name]).validate(arguments)
+        except ValidationError as exc:
+            # Do not echo arbitrary rejected input back into another context.
+            raise ValueError("tool arguments do not match the declared schema") from exc
+        linked = self._scope(arguments.get("run_id"))
+        if name == "project":
+            result = {
+                "project": linked["project"],
+                "binding_id": linked["binding"]["id"],
+                "workspace": linked["workspace"],
+                "public_write": False,
+            }
+        elif name == "context":
+            if arguments.get("run_id"):
+                result = self.tasks.context(
+                    arguments["run_id"],
+                    budget=arguments.get("budget", 24000),
+                    live=arguments.get("live", True),
+                    scope_paths=tuple(arguments.get("scope_paths", [])),
+                )
+            else:
+                result = self.tasks.current(
+                    self.root,
+                    budget=arguments.get("budget", 24000),
+                    scope_paths=tuple(arguments.get("scope_paths", [])),
+                )
+        elif name == "understanding":
+            from .understanding import Understanding
+
+            service = Understanding(self.config.state_dir / "understanding")
+            if arguments["action"] == "evidence":
+                result = service.evidence(
+                    self.root,
+                    arguments["evidence_id"],
+                    start_line=arguments.get("start_line", 1),
+                    limit=arguments.get("limit", 80),
+                )
+            else:
+                result = service.guide(
+                    self.root,
+                    mode=arguments.get("mode", "maintainer"),
+                    focus=arguments.get("focus", ""),
+                    limit=arguments.get("limit", 12),
+                )
+        elif name == "checkpoint":
+            result = self.tasks.checkpoint(**arguments)
+        else:
+            from .external_verification import ExternalVerification
+
+            verification = ExternalVerification(self.config)
+            run_id = arguments["run_id"]
+            if name == "evidence":
+                if arguments["action"] == "get":
+                    result = verification.evidence(
+                        run_id,
+                        arguments["evidence_id"],
+                        offset=arguments.get("offset", 0),
+                        limit=arguments.get("limit", 8000),
+                    )
+                else:
+                    task = self.tasks.inspect(run_id)
+                    result = {
+                        **verification.list(run_id, limit=arguments.get("limit", 3)),
+                        "sources": task["source_evidence"],
+                        "checkpoint": f"checkpoint:{run_id}:{task['revision']}",
+                    }
+            elif arguments["action"] == "profiles":
+                result = {
+                    "run_id": run_id,
+                    "profiles": verification.profiles(run_id),
+                    "public_write": False,
+                }
+            elif arguments["action"] == "inspect":
+                result = verification.inspect(
+                    run_id,
+                    arguments["evidence_id"].split(":")[1],
+                    live=arguments.get("live", True),
+                )
+            else:
+                result = verification.request(
+                    **{
+                        key: value
+                        for key, value in arguments.items()
+                        if key != "action"
+                    },
+                    cancel_event=cancel_event,
+                )
+        if len(json.dumps(result, ensure_ascii=False).encode()) > MAX_RESPONSE_BYTES:
+            raise ValueError(
+                "tool result exceeds response limit; reduce the requested budget or limit"
+            )
+        return result
+
+
+def error_result(exc: BaseException) -> dict:
+    code = (
+        "conflict"
+        if isinstance(exc, TaskConflict)
+        else "scope_or_policy"
+        if isinstance(exc, ProjectError)
+        else "not_found"
+        if isinstance(exc, KeyError)
+        else "invalid_request"
+        if isinstance(exc, ValueError)
+        else "unavailable"
+    )
+    return {
+        "error": {"code": code, "message": str(exc)[:1000], "cli_exit_code": 2},
+        "public_write": False,
+    }
+
+
+def create_server(config: AppConfig, workspace: Path):
+    try:
+        import anyio
+        from mcp import types
+        from mcp.server.lowlevel import Server
+    except ImportError as exc:
+        raise RuntimeError(
+            "MCP support requires reposteward[mcp]; use the file/CLI handoff until installed"
+        ) from exc
+    bridge = ScopedBridge(config, workspace)
+    limiter = anyio.CapacityLimiter(4)
+
+    async def list_tools(_context, params):
+        if params is not None and params.cursor:
+            raise ValueError("this tool list has no next page")
+        return types.ListToolsResult(
+            tools=[
+                types.Tool(
+                    name=name,
+                    description=DESCRIPTIONS[name],
+                    input_schema=schema,
+                    annotations=types.ToolAnnotations(
+                        read_only_hint=name
+                        in {"project", "context", "evidence", "understanding"},
+                        destructive_hint=False,
+                        open_world_hint=False,
+                    ),
+                )
+                for name, schema in SCHEMAS.items()
+            ]
+        )
+
+    async def call_tool(_context, params):
+        cancelled, started, finished = Event(), Event(), Event()
+
+        def work():
+            started.set()
+            try:
+                return bridge.call(
+                    params.name, params.arguments or {}, cancel_event=cancelled
+                )
+            finally:
+                finished.set()
+
+        try:
+            result = await anyio.to_thread.run_sync(
+                work, abandon_on_cancel=True, limiter=limiter
+            )
+        except anyio.get_cancelled_exc_class():
+            cancelled.set()
+            if started.is_set():
+                with anyio.CancelScope(shield=True):
+                    await anyio.to_thread.run_sync(finished.wait, 20)
+            raise
+        except (OSError, RuntimeError, ValueError, KeyError) as exc:
+            error = error_result(exc)
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text", text=json.dumps(error, ensure_ascii=False)
+                    )
+                ],
+                is_error=True,
+            )
+        return types.CallToolResult(
+            content=[
+                types.TextContent(
+                    type="text", text=json.dumps(result, ensure_ascii=False)
+                )
+            ],
+            structured_content=result,
+        )
+
+    server = Server(
+        "reposteward",
+        version="0.1.0",
+        instructions="Local assistance for one linked workspace. Agent claims remain unverified; this server grants no public-write authority.",
+        on_list_tools=list_tools,
+        on_call_tool=call_tool,
+    )
+    # This local bridge never exports tracing or prompt data.
+    server.middleware.clear()
+    return server
+
+
+class _BoundedInput:
+    def __init__(self, source):
+        self.source = source
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        import anyio
+
+        line = await anyio.to_thread.run_sync(
+            self.source.readline, MAX_REQUEST_BYTES + 1, abandon_on_cancel=True
+        )
+        if not line:
+            raise StopAsyncIteration
+        if len(line) > MAX_REQUEST_BYTES:
+            raise ValueError("MCP frame exceeds the request limit; connection closed")
+        return line.decode("utf-8", errors="strict")
+
+
+def serve(config: AppConfig, workspace: Path) -> None:
+    import sys
+
+    server = create_server(config, workspace)
+    import anyio
+    from mcp.server.stdio import stdio_server
+
+    async def run():
+        async with stdio_server(stdin=_BoundedInput(sys.stdin.buffer)) as (
+            incoming,
+            outgoing,
+        ):
+            await server.run(incoming, outgoing, server.create_initialization_options())
+
+    anyio.run(run)

--- a/src/reposteward/mcp_config.py
+++ b/src/reposteward/mcp_config.py
@@ -1,0 +1,67 @@
+"""Preview client-specific local STDIO configurations without changing client settings."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from .config import AppConfig
+from .mcp_bridge import ScopedBridge
+
+
+def client_config(config: AppConfig, workspace: Path, *, client: str) -> dict:
+    bridge = ScopedBridge(config, workspace)
+    entry = {
+        "command": sys.executable,
+        "args": [
+            "-m",
+            "reposteward.cli",
+            "--config",
+            str(config.path),
+            "mcp",
+            "serve",
+            str(bridge.root),
+        ],
+    }
+    if client == "codex":
+        fragment = (
+            "[mcp_servers.reposteward]\n"
+            + "\n".join(
+                f"{key} = {json.dumps(value, ensure_ascii=False)}"
+                for key, value in entry.items()
+            )
+            + "\n"
+        )
+        destination = "user Codex config.toml"
+        syntax = "toml"
+    elif client == "claude-code":
+        fragment = json.dumps(
+            {"mcpServers": {"reposteward": {"type": "stdio", **entry}}},
+            ensure_ascii=False,
+            indent=2,
+        )
+        destination = "a user-owned temporary file passed to Claude Code --mcp-config"
+        syntax = "json"
+    elif client == "copilot-vscode":
+        fragment = json.dumps(
+            {"servers": {"reposteward": {"type": "stdio", **entry}}},
+            ensure_ascii=False,
+            indent=2,
+        )
+        destination = "VS Code user MCP configuration"
+        syntax = "json"
+    else:
+        raise ValueError("unsupported MCP client; use the file/CLI handoff")
+    return {
+        "client": client,
+        "format": syntax,
+        "destination": destination,
+        "fragment": fragment,
+        "writes_files": False,
+        "client_version": "not_probed",
+        "actual_session_validation": "not_run",
+        "scope": "one local workspace",
+        "note": "This machine-specific preview is for local client settings. Keep it outside Git. Install reposteward[mcp] in the indicated Python environment first.",
+        "public_write": False,
+    }

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -13,6 +13,7 @@ from reposteward.cli import main
 from reposteward.config import load_config
 from reposteward.external_tasks import TaskConflict
 from reposteward.knowledge import ProjectKnowledge
+from reposteward.mcp_bridge import ScopedBridge
 from reposteward.policy import PolicyError
 
 
@@ -217,6 +218,15 @@ class KnowledgeTests(unittest.TestCase):
             self.run_id, full["knowledge"]["entries"][0]["evidence_id"], limit=25
         )
         self.assertEqual(evidence["returned"], 25)
+        bridge = ScopedBridge(self.config, self.repo)
+        self.assertEqual(
+            len(
+                bridge.call(
+                    "context", {"run_id": self.run_id, "scope_paths": ["source.txt"]}
+                )["knowledge"]["entries"]
+            ),
+            5,
+        )
 
     def test_cli_does_not_launch_pipeline_and_scope_limits_are_explicit(self) -> None:
         entry = self.propose()

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import unittest
+from dataclasses import asdict
+from threading import Event
+from unittest.mock import patch
+
+import test_external_verification
+from test_projects import git, repository
+
+from reposteward.mcp_bridge import SCHEMAS, ScopedBridge, create_server
+from reposteward.mcp_config import client_config
+from reposteward.projects import ProjectError
+from reposteward.verifier import DockerVerifier
+from reposteward.workspace import sanitized_environment
+
+HAS_MCP = importlib.util.find_spec("mcp") is not None
+
+
+class BridgeTests(unittest.TestCase):
+    container_run = test_external_verification.ExternalVerificationTests.container_run
+
+    def setUp(self) -> None:
+        test_external_verification.ExternalVerificationTests.setUp(self)
+        self.bridge = ScopedBridge(self.config, self.repo)
+
+    def test_understanding_is_read_only_and_matches_shared_service(self):
+        from reposteward.understanding import Understanding
+
+        service = Understanding(self.config.state_dir / "understanding")
+        self.assertEqual(
+            self.bridge.call("understanding", {"action": "guide"})["status"],
+            "not_scanned",
+        )
+        service.scan(self.repo)
+        self.assertEqual(
+            self.bridge.call("understanding", {"action": "query", "focus": "source"}),
+            service.guide(self.repo, focus="source"),
+        )
+        item = service.guide(self.repo, focus="source")["reading_path"][0]
+        arguments = {
+            "action": "evidence",
+            "evidence_id": item["source"]["evidence_id"],
+            "limit": 4,
+        }
+        self.assertEqual(
+            self.bridge.call("understanding", arguments),
+            service.evidence(self.repo, arguments["evidence_id"], limit=4),
+        )
+        with self.assertRaises(ValueError):
+            self.bridge.call("understanding", {"action": "scan"})
+        self.service.registry.unlink(self.task["binding_id"])
+        with self.assertRaises(ProjectError):
+            self.bridge.call("understanding", {"action": "guide"})
+
+    def checkpoint_arguments(self) -> dict:
+        current = self.service.inspect(self.task["run_id"], live=True)
+        return {
+            "run_id": self.task["run_id"],
+            "expected_revision": current["revision"],
+            "expected_snapshot": current["current_snapshot"]["digest"],
+            "idempotency_key": "mcp-cp",
+            "payload": {
+                "remaining": ["Check the boundary"],
+                "next_action": "inspect boundary",
+                "notes": "Agent observation only",
+            },
+        }
+
+    def test_application_facts_match_cli_services_and_preserve_open_work(self) -> None:
+        run_id = self.task["run_id"]
+        self.assertEqual(
+            self.bridge.call("context", {"run_id": run_id, "live": True}),
+            self.service.context(run_id, live=True),
+        )
+        saved = self.bridge.call("checkpoint", self.checkpoint_arguments())
+        self.assertEqual(saved["revision"], 1)
+        context = self.bridge.call("context", {})
+        self.assertEqual(context["open_work"], ["Check the boundary"])
+        self.assertEqual(context["agent_claims"]["trust"], "agent_unverified")
+        evidence = self.bridge.call("evidence", {"run_id": run_id, "action": "list"})
+        source = self.bridge.call(
+            "evidence",
+            {
+                "run_id": run_id,
+                "action": "get",
+                "evidence_id": evidence["sources"][0]["evidence_id"],
+                "limit": 20,
+            },
+        )
+        self.assertEqual(source["returned"], 20)
+        self.assertEqual(
+            self.bridge.call("verification", {"run_id": run_id, "action": "profiles"})[
+                "profiles"
+            ][0]["name"],
+            "test",
+        )
+
+    def test_all_tools_reject_arbitrary_paths_commands_and_authority_claims(
+        self,
+    ) -> None:
+        for name in SCHEMAS:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                self.bridge.call(
+                    name, {"path": "/etc/passwd", "command": "echo unsafe"}
+                )
+        args = self.checkpoint_arguments()
+        args["payload"]["status"] = "ready"
+        with self.assertRaises(ValueError):
+            self.bridge.call("checkpoint", args)
+        with self.assertRaises(ValueError):
+            self.bridge.call("context", {"budget": True})
+        with self.assertRaises(ValueError):
+            self.bridge.call("project", {"value": "x" * 120001})
+
+    def test_same_project_other_workspace_is_out_of_scope_and_unlink_revokes_access(
+        self,
+    ) -> None:
+        other = repository(self.root / "other", remote="git@github.com:owner/repo.git")
+        git(other, "update-ref", "refs/remotes/origin/main", "HEAD")
+        git(other, "switch", "-c", "owner/other")
+        self.service.registry.link(other)
+        self.github.branch_head_sha.return_value = git(other, "rev-parse", "HEAD")
+        second = self.service.start(other, issue_number=7, reviewed_by="owner")
+        for name, args in [
+            ("context", {"run_id": second["run_id"]}),
+            ("evidence", {"run_id": second["run_id"], "action": "list"}),
+            ("verification", {"run_id": second["run_id"], "action": "profiles"}),
+            ("checkpoint", {**self.checkpoint_arguments(), "run_id": second["run_id"]}),
+        ]:
+            with self.subTest(name=name), self.assertRaisesRegex(ProjectError, "scope"):
+                self.bridge.call(name, args)
+        self.service.registry.unlink(self.task["binding_id"])
+        with self.assertRaises(ProjectError):
+            self.bridge.call("project", {})
+
+    def test_client_configuration_previews_are_distinct_and_do_not_write(self) -> None:
+        before = set(self.repo.rglob("*"))
+        for client, marker in (
+            ("codex", "mcp_servers"),
+            ("claude-code", "mcpServers"),
+            ("copilot-vscode", '"servers"'),
+        ):
+            result = client_config(self.config, self.repo, client=client)
+            self.assertIn(marker, result["fragment"])
+            self.assertFalse(result["writes_files"])
+            self.assertEqual(result["actual_session_validation"], "not_run")
+        self.assertEqual(before, set(self.repo.rglob("*")))
+        with self.assertRaises(ValueError):
+            client_config(self.config, self.repo, client="unknown")
+
+    @unittest.skipUnless(HAS_MCP, "install reposteward[mcp] for SDK protocol tests")
+    def test_official_sdk_calls_all_capabilities(self) -> None:
+        from mcp import Client
+
+        async def run():
+            async with Client(create_server(self.config, self.repo)) as client:
+                listing = await client.list_tools()
+                self.assertEqual({tool.name for tool in listing.tools}, set(SCHEMAS))
+                project = await client.call_tool("project", {})
+                self.assertEqual(
+                    project.structured_content["project"]["id"], self.task["project_id"]
+                )
+                context = await client.call_tool(
+                    "context", {"run_id": self.task["run_id"]}
+                )
+                self.assertEqual(
+                    context.structured_content["run_id"], self.task["run_id"]
+                )
+                evidence = await client.call_tool(
+                    "evidence", {"run_id": self.task["run_id"], "action": "list"}
+                )
+                self.assertTrue(evidence.structured_content["sources"])
+                understanding = await client.call_tool(
+                    "understanding", {"action": "guide"}
+                )
+                self.assertEqual(
+                    understanding.structured_content["status"], "not_scanned"
+                )
+                cp = await client.call_tool("checkpoint", self.checkpoint_arguments())
+                self.assertEqual(cp.structured_content["revision"], 1)
+                current = self.service.inspect(self.task["run_id"], live=True)
+                verified = await client.call_tool(
+                    "verification",
+                    {
+                        "run_id": self.task["run_id"],
+                        "action": "request",
+                        "profile": "test",
+                        "expected_revision": 1,
+                        "expected_snapshot": current["current_snapshot"]["digest"],
+                        "idempotency_key": "sdk-test",
+                    },
+                )
+                self.assertEqual(verified.structured_content["outcome"], "passed")
+                self.assertFalse(verified.structured_content["publication_eligible"])
+
+        with (
+            patch.object(DockerVerifier, "image_available", return_value=True),
+            patch.object(
+                DockerVerifier, "_run_container", side_effect=self.container_run
+            ),
+        ):
+            asyncio.run(run())
+
+    def stdio_environment(self) -> tuple[dict, list[str]]:
+        user_root = self.root / "client-config"
+        user_file = user_root / "reposteward/config.toml"
+        user_file.parent.mkdir(parents=True)
+        lines = [
+            "config_version = 1",
+            "[project]",
+            f"state_dir = {json.dumps(str(self.config.state_dir))}",
+            "namespace_state = false",
+            "[github]",
+            'login = "owner"',
+            '[repositories."owner/repo"]',
+        ]
+        for key, value in asdict(self.config.repositories["owner/repo"]).items():
+            if key != "name" and value is not None:
+                lines.append(f"{key} = {json.dumps(value)}")
+        user_file.write_text("\n".join(lines) + "\n")
+        empty_project = self.root / "client-project.toml"
+        empty_project.write_text("config_version = 1\n")
+        environment = sanitized_environment(keep_codex_credentials=False)
+        environment["XDG_CONFIG_HOME"] = str(user_root)
+        arguments = [
+            "-m",
+            "reposteward.cli",
+            "--config",
+            str(empty_project),
+            "mcp",
+            "serve",
+            str(self.repo),
+        ]
+        return environment, arguments
+
+    @unittest.skipUnless(
+        HAS_MCP, "install reposteward[mcp] for real STDIO protocol tests"
+    )
+    def test_real_stdio_legacy_and_modern_clients_and_clean_eof(self) -> None:
+        from mcp import Client, StdioServerParameters
+
+        environment, arguments = self.stdio_environment()
+
+        async def run():
+            for mode in ("legacy", "2026-07-28"):
+                async with Client(
+                    StdioServerParameters(
+                        command=sys.executable, args=arguments, env=environment
+                    ),
+                    mode=mode,
+                    read_timeout_seconds=10,
+                ) as client:
+                    listing = await client.list_tools()
+                    self.assertEqual(
+                        {tool.name for tool in listing.tools}, set(SCHEMAS)
+                    )
+                    result = await client.call_tool(
+                        "context", {"run_id": self.task["run_id"]}
+                    )
+                    self.assertEqual(
+                        result.structured_content["run_id"], self.task["run_id"]
+                    )
+                    self.assertEqual(
+                        result.structured_content["contract"]["source_digest"],
+                        self.task["context_pack"]["task_contract"]["source_digest"],
+                    )
+
+        asyncio.run(asyncio.wait_for(run(), timeout=35))
+
+    @unittest.skipUnless(
+        HAS_MCP, "install reposteward[mcp] for cancellation protocol tests"
+    )
+    def test_sdk_cancellation_reaches_worker_and_waits_for_cleanup(self) -> None:
+        from mcp import Client
+
+        from reposteward.external_verification import ExternalVerification
+
+        started, cancelled, finished = Event(), Event(), Event()
+
+        def waiting(*args, cancel_event, **kwargs):
+            started.set()
+            if cancel_event.wait(5):
+                cancelled.set()
+            finished.set()
+            return {"outcome": "cancelled", "public_write": False}
+
+        async def run():
+            async with Client(create_server(self.config, self.repo)) as client:
+                task = asyncio.create_task(
+                    client.call_tool(
+                        "verification",
+                        {
+                            "run_id": self.task["run_id"],
+                            "action": "request",
+                            "profile": "test",
+                            "expected_revision": 0,
+                            "expected_snapshot": self.task["snapshot"]["digest"],
+                            "idempotency_key": "cancel-test",
+                        },
+                    )
+                )
+                self.assertTrue(await asyncio.to_thread(started.wait, 2))
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+        with patch.object(ExternalVerification, "request", side_effect=waiting):
+            asyncio.run(asyncio.wait_for(run(), timeout=10))
+        self.assertTrue(cancelled.is_set())
+        self.assertTrue(finished.is_set())
+
+    @unittest.skipUnless(HAS_MCP, "install reposteward[mcp] for strict transport tests")
+    def test_unknown_version_and_oversized_wire_frame_fail_without_nonprotocol_stdout(
+        self,
+    ) -> None:
+        environment, arguments = self.stdio_environment()
+
+        async def run():
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                *arguments,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=environment,
+            )
+            request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {
+                    "_meta": {"io.modelcontextprotocol/protocolVersion": "2999-01-01"}
+                },
+            }
+            process.stdin.write((json.dumps(request) + "\n").encode())
+            await process.stdin.drain()
+            result = json.loads(await asyncio.wait_for(process.stdout.readline(), 5))
+            self.assertIn("error", result)
+            process.stdin.close()
+            await asyncio.wait_for(process.communicate(), 5)
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                *arguments,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=environment,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(b"x" * 120001 + b"\n"), 10
+            )
+            self.assertEqual(stdout, b"")
+            self.assertNotEqual(process.returncode, 0)
+            self.assertIn(b"request limit", stderr)
+
+        asyncio.run(asyncio.wait_for(run(), timeout=25))

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -12,12 +16,226 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", hash = "sha256:b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e", size = 276504, upload-time = "2026-09-02T21:46:36.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", hash = "sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99", size = 131908, upload-time = "2026-09-02T21:46:35.485Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -48,6 +266,44 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
 name = "openai-codex"
 version = "0.147.0"
 source = { registry = "https://pypi.org/simple" }
@@ -73,6 +329,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/b6/c159da0a1ec136fde6d2742ec05347e311f000dfe19024ed7d708cf60aa5/openai_codex_cli_bin-0.147.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:a9be23f46326494b7ebf4bd98cbe985542f5ad076355f3b0fb636a984df56816", size = 119921665, upload-time = "2026-08-18T06:06:15.061Z" },
     { url = "https://files.pythonhosted.org/packages/54/38/1bb47e08b9c523b673358e4f5597fc99699e855ec63bd02fdc157f1679c9/openai_codex_cli_bin-0.147.0-py3-none-win_amd64.whl", hash = "sha256:1a403ff803ae27e078189a0fd24687f32d43c46f152e50cdbe3eddc9e302f697", size = 127586208, upload-time = "2026-08-18T06:06:19.395Z" },
     { url = "https://files.pythonhosted.org/packages/d2/1e/a44a8da140ef080aebac6da6517e8fe6ac1aad49436c8b1f9b87e735b813/openai_codex_cli_bin-0.147.0-py3-none-win_arm64.whl", hash = "sha256:be0c8b9e34b067151d0964a24e9f4b8b48ea516448a08ef2636f357ebdc877b7", size = 117863410, upload-time = "2026-08-18T06:06:23.554Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -166,6 +443,48 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -191,13 +510,25 @@ dependencies = [
 codex-sdk = [
     { name = "openai-codex" },
 ]
+mcp = [
+    { name = "mcp" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mcp" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.23,<5" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.1.1,<3" },
     { name = "openai-codex", marker = "extra == 'codex-sdk'", specifier = ">=0.147,<0.148" },
 ]
-provides-extras = ["codex-sdk"]
+provides-extras = ["codex-sdk", "mcp"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "mcp", specifier = ">=2.1.1,<3" }]
 
 [[package]]
 name = "rpds-py"
@@ -296,6 +627,41 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e1/8a41e88e825ea26c44333897c7ffe35fe60153a2cfc097a5bd1d209ad281/sse_starlette-3.4.10.tar.gz", hash = "sha256:c6c87280d8feb4e55a8d79633782766b9cac6a26da5c79a145d00aa404117a86", size = 33720, upload-time = "2026-09-03T09:36:24.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/3c/96018a51c7301a64f7b0579d9ce8f9b69dd39ca8ed5aa100ba3feadee503/sse_starlette-3.4.10-py3-none-any.whl", hash = "sha256:710f5f5b0527409903a22a91699db02f76f4c2eb9204e882e4ee7cada76bdf75", size = 17120, upload-time = "2026-09-03T09:36:22.56Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -314,4 +680,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]


### PR DESCRIPTION
Closes #101

Expose workspace-scoped task assistance through a local MCP bridge shared with the CLI use cases.

---

Provide bounded task context with scoped project knowledge, source evidence, checkpoints, allowed verification and read-only project understanding on the bound workspace. Reuse the existing CLI application services. Enforce protocol validation, revisions, snapshots, cancellation and revocation, with bounded pagination and no arbitrary path or command access. The optional MCP dependency and lockfile entries require the repository risk review path. The MCP SDK is also a development dependency, so the existing CI install command runs real SDK, STDIO, cancellation, knowledge interop and bounded transport regressions. Runtime MCP support remains optional. All locked package versions are unchanged; the built wheel exactly matches the independently installed and exercised artifact. Client configuration is a preview and does not grant credentials or launch a coding agent.

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
