### PR TITLE
feat(runtime): inspect installation and state without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,14 @@ the model-governed repository direction.
 
 ## Install
 
-RepoSteward requires Python 3.12 or newer, uv, Git, Docker, GitHub CLI, and a logged-in
-Codex CLI.
+For an isolated installation used outside this source checkout, see the
+[local installation and offline diagnostics guide](docs/local-installation.zh-CN.md).
+`reposteward version` reports installation metadata; `reposteward doctor --local`
+checks configuration sources and database compatibility without authentication or migration.
+
+The full Issue-to-PR workflow requires Python 3.12 or newer, uv, Git, Docker,
+GitHub authentication, and the configured coding harness. Local code reading and
+offline diagnostics can be used before configuring those execution services.
 
 ```bash
 git clone https://github.com/tiammomo/RepoSteward.git

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,6 +61,10 @@ PR 为目标。
 
 ## 安装
 
+日常从源码目录之外使用时，参见[独立安装与离线诊断指南](docs/local-installation.zh-CN.md)。
+`reposteward version` 显示安装信息；`reposteward doctor --local` 可检查配置来源与数据库
+兼容性，无需认证，也不会触发迁移。
+
 RepoSteward 要求 Python 3.12+、uv、Git、Docker、GitHub CLI，以及已登录的 Codex CLI。
 
 ```bash

--- a/docs/local-installation.zh-CN.md
+++ b/docs/local-installation.zh-CN.md
@@ -1,0 +1,100 @@
+# 从独立安装开始使用 RepoSteward
+
+日常维护时可以直接打开目标项目。RepoSteward 的安装环境、用户配置、台账和目标
+工作区分别管理；开发 RepoSteward 本身时才需要进入它的源码 checkout。
+
+## 固定安装来源
+
+选择已审阅提交构建的 wheel，并保存提交 SHA 与 wheel 的 SHA256。当前包版本为
+`0.1.0`，多个开发提交可能使用相同版本号，单独比较版本字符串不足以确认代码相同。
+这里不假定 PyPI 已发布包含本文命令的版本。
+
+在构建源码的目录执行 `uv build` 后，从绝对 wheel 路径安装到 uv 的独立工具环境：
+
+```bash
+uv tool install --python 3.12 /absolute/path/reposteward-0.1.0-py3-none-any.whl
+uv tool update-shell
+reposteward --version
+reposteward version
+```
+
+`uv tool update-shell` 提示的 PATH 变化可能需要新开终端。已有安装时，先完成下文的
+状态检查与备份，再使用 `uv tool install --force` 安装已核验的替换 wheel。工具安装
+环境的替换不等于数据库回退；保留之前的 wheel 和状态备份。
+
+要使用 MCP，在安装时明确选择同一个 wheel 的 `mcp` extra，例如：
+
+```bash
+uv tool install --python 3.12 'reposteward[mcp] @ file:///absolute/path/reposteward-0.1.0-py3-none-any.whl'
+```
+
+本地导览不要求 GitHub 登录、Docker 或某个特定 Agent 已登录；联网维护需要 GitHub
+身份与仓库策略，独立验证需要 Docker/Runner，实际 Agent 会话使用其自身客户端认证。
+CLI/MCP 的相关依赖及客户端实机验收状态见[已有 Agent 使用指南](coding-agent-assistance.zh-CN.md)。
+
+## 检查当前安装与状态
+
+`version` 不加载项目配置、不联网，输出包版本、Python、模块与安装位置；存在安装
+元数据时还显示 editable 标记和合法格式的 VCS commit。普通 wheel 未提供源码提交时
+`source_revision` 为 null，应与保存的构建记录核对。安装 URL 不进入输出。
+
+```bash
+reposteward doctor --local
+reposteward doctor --local --expect-state-dir /absolute/path/to/effective/state
+```
+
+本地诊断只显示允许的配置字段及其加载来源：用户层、项目层、默认值。路径显示最终
+生效值，包括命名空间；API 地址仅显示 origin，不显示凭据和查询参数。后续手工构造
+或修改 AppConfig 的调用方应将来源视为加载时记录，而非另一次实时配置读取。
+
+API URL 带 userinfo、查询或 fragment 时，本地诊断会先要求修正 URL，并停止输出由它
+派生的路径；认证应通过单独的凭据来源配置。
+
+期望状态目录不匹配时，诊断返回失败并且不读取那个目录的数据库。没有配置时返回
+结构化说明；可通过 `reposteward init` 配置身份，或修复所选配置文件后重试。
+
+| 数据库结果 | 含义与下一步 |
+| --- | --- |
+| missing | 尚未创建，可在确有需要时显式关联项目或创建任务 |
+| compatible | 观察到的 schema 与当前安装一致，且基础表存在 |
+| migration_required | 需要备份和升级；本次诊断没有执行迁移 |
+| newer_than_supported | 当前安装太旧，先切换到能支持该 schema 的版本 |
+| snapshot_required | 有未结算的 WAL/journal 或文件变化；先让写入者正常退出，再检查 |
+| uninitialized / unrecognized / invalid_database / unreadable / unsupported_path | 空库、非预期台账、损坏、读取失败或链接路径；先检查来源或恢复备份 |
+
+`compatible` 不代表所有业务行完整、认证成功、测试通过或 PR 可以合并。诊断使用
+无副作用的稳定 SQLite 视图；遇到活动 WAL 时保守返回未知，不忽略 WAL 报告旧结果。
+任务数据库与项目注册表分别检查。缺少数据库不创建目录；诊断不初始化 Store，不执行
+迁移、Harness、Docker、认证命令或 GitHub 请求。需要完整执行环境检查时单独运行
+既有 `reposteward doctor`。
+
+## 在目标项目继续工作
+
+```bash
+cd /absolute/path/to/your-project
+reposteward project link .
+reposteward project inspect .
+reposteward understand scan .
+reposteward understand guide .
+```
+
+关联身份不会自动创建仓库维护权限。需要任务与交付时，再用
+`reposteward repo add owner/repo --mode maintainer` 或 `--mode contributor` 配置对应
+角色和仓库策略。用户已有的 clone/worktree 保持原位置。
+
+按[任务接续指南](coding-agent-assistance.zh-CN.md)创建或选择任务，然后在该目标项目
+打开平时的 Agent。`reposteward mcp config . --client codex|claude-code|copilot-vscode`
+表示三个可选客户端之一，实际执行时替换为具体名称；它输出本机配置预览。修改策略、
+更换安装或更新绑定后重启对应 MCP 服务。无 MCP 的客户端可使用 CLI 与文件接续。
+
+## 升级前检查
+
+先暂停会写入同一台账的 CLI、MCP 或队列进程，核对最终状态目录，使用 SQLite 的一致性
+备份保存数据库，并保留关联注册表、用户配置及需要的证据文件。在副本演练新版本迁移
+和必要的恢复核验，再切换日常安装。不要只复制活动数据库的主文件而忽略 WAL。
+
+当前 Store 的既有写入口可能自动迁移旧 schema；`doctor --local` 不改变这一行为。
+读取旧台账时先诊断，不要通过随意创建任务来探测版本。本文没有提供自动回退命令，
+发生新写入后的回退需要核对新增数据，不能仅覆盖旧备份。
+
+工具安装行为参考 [uv 工具管理文档](https://docs.astral.sh/uv/guides/tools/)。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import __version__
 from .batch import render_batch_plan_text
 from .benchmark import (
     BENCHMARK_CATEGORIES,
@@ -45,7 +46,11 @@ def _parser() -> argparse.ArgumentParser:
         default=None,
         help="project TOML config (default: discover and layer over user config)",
     )
+    parser.add_argument(
+        "--version", action="version", version=f"reposteward {__version__}"
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("version", help="show offline installation metadata as JSON")
 
     initialize = subparsers.add_parser("init", help="create per-user configuration")
     initialize.add_argument("--path", type=Path, default=None)
@@ -316,7 +321,19 @@ def _parser() -> argparse.ArgumentParser:
         "--duplicates-reviewed", action="store_true", required=True
     )
 
-    subparsers.add_parser("doctor", help="check local tools and authentication")
+    doctor = subparsers.add_parser(
+        "doctor", help="check local tools and authentication"
+    )
+    doctor.add_argument(
+        "--local",
+        action="store_true",
+        help="inspect installation and state without authentication or writes",
+    )
+    doctor.add_argument(
+        "--expect-state-dir",
+        type=Path,
+        help="require this effective state directory in local mode",
+    )
     image = subparsers.add_parser("image", help="manage the isolated verifier image")
     image.add_argument("action", choices=("build",))
 
@@ -703,6 +720,29 @@ def _runner_dockerfile() -> Path:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
+        if args.command == "version":
+            from .runtime import installation_info
+
+            _json(installation_info())
+            return 0
+        if args.command == "doctor" and args.local:
+            from .runtime import local_diagnostics
+
+            try:
+                local_config = load_config(args.config, include_user=True)
+            except ConfigError:
+                local_config = None
+            report, ok = local_diagnostics(
+                local_config, expected_state_dir=args.expect_state_dir
+            )
+            if local_config is None and args.config:
+                report["configuration"]["selected_path"] = str(
+                    Path(args.config).expanduser().resolve()
+                )
+            _json(report)
+            return 0 if ok else 1
+        if args.command == "doctor" and args.expect_state_dir:
+            raise ConfigError("--expect-state-dir requires doctor --local")
         if args.command == "init":
             _json(
                 initialize_user_config(

--- a/src/reposteward/config.py
+++ b/src/reposteward/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import tomllib
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal, InvalidOperation
@@ -12,6 +13,15 @@ from urllib.parse import urlparse
 
 CONFIG_VERSION = 1
 PROJECT_CONFIG_NAMES = (".reposteward.toml", "reposteward.toml", "starfix.toml")
+DIAGNOSTIC_SETTINGS = (
+    "project.state_dir",
+    "project.workspace_dir",
+    "project.namespace_state",
+    "github.login",
+    "github.api_url",
+    "agent.harness",
+    "runner.image",
+)
 REPOSITORY_NAME = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SENSITIVE_PATH_NAMES = frozenset({"credentials", "secrets"})
 
@@ -218,6 +228,8 @@ class AppConfig:
     repositories: dict[str, RepositoryPolicy] = field(default_factory=dict)
     verification_profiles: tuple[VerificationProfile, ...] = ()
     guidance_preferences: tuple[str, ...] = ()
+    config_files: tuple[tuple[str, str], ...] = ()
+    setting_sources: tuple[tuple[str, str], ...] = ()
 
 
 def _tuple(value: Any, default: tuple[str, ...] = ()) -> tuple[str, ...]:
@@ -544,6 +556,30 @@ def _tracked_sensitive_paths(
                 paths.append(canonical)
         configured[normalized_repository] = tuple(paths)
     return tuple(sorted(configured.items()))
+
+
+def _setting_sources(user: dict, project: dict) -> tuple[tuple[str, str], ...]:
+    """Trace a small allowlist through the same trust merge without retaining values."""
+    marked_user, marked_project = deepcopy(user), deepcopy(project)
+    markers: list[tuple[object, str]] = []
+    for source, data in (("user", marked_user), ("project", marked_project)):
+        for setting in DIAGNOSTIC_SETTINGS:
+            section, key = setting.split(".")
+            values = data.get(section)
+            if isinstance(values, dict) and key in values:
+                marker = object()
+                values[key] = marker
+                markers.append((marker, source))
+    merged = _merge_layers(marked_user, marked_project)
+    result = []
+    for setting in DIAGNOSTIC_SETTINGS:
+        section, key = setting.split(".")
+        value = _section(merged, section).get(key)
+        source = next(
+            (source for marker, source in markers if value is marker), "default"
+        )
+        result.append((setting, source))
+    return tuple(result)
 
 
 def load_config(
@@ -1117,4 +1153,13 @@ def load_config(
         repositories=repositories,
         verification_profiles=tuple(profiles),
         guidance_preferences=preferences,
+        config_files=tuple(
+            (source, str(file))
+            for source, file, data in (
+                ("user", resolved_user_path, user_raw),
+                ("project", project_path, project_raw),
+            )
+            if file is not None and data
+        ),
+        setting_sources=_setting_sources(user_raw, project_raw),
     )

--- a/src/reposteward/runtime.py
+++ b/src/reposteward/runtime.py
@@ -1,0 +1,236 @@
+"""Offline installation and state diagnostics shared by local user interfaces."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from contextlib import closing
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from . import __version__
+from .config import AppConfig, default_user_config_path
+from .projects import PROJECT_SCHEMA_VERSION
+from .store import SCHEMA_VERSION
+
+
+def installation_info() -> dict:
+    result = {
+        "version": __version__,
+        "metadata_available": False,
+        "python": sys.version.split()[0],
+        "executable": sys.executable,
+        "module_path": str(Path(__file__).resolve().parent),
+        "distribution_path": None,
+        "editable": None,
+        "source_revision": None,
+    }
+    try:
+        distribution = metadata.distribution("reposteward")
+        result.update(
+            version=distribution.version,
+            metadata_available=True,
+            distribution_path=str(distribution.locate_file("")),
+        )
+        direct = distribution.read_text("direct_url.json")
+        if direct and len(direct) <= 64_000:
+            value = json.loads(direct)
+            if isinstance(value, dict):
+                directory = value.get("dir_info")
+                if isinstance(directory, dict):
+                    result["editable"] = directory.get("editable") is True
+                vcs = value.get("vcs_info")
+                revision = vcs.get("commit_id") if isinstance(vcs, dict) else None
+                if isinstance(revision, str) and re.fullmatch(
+                    "(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})", revision
+                ):
+                    result["source_revision"] = revision
+        # Deliberately never return the installation URL or unparsed metadata.
+    except (metadata.PackageNotFoundError, OSError, ValueError):
+        pass
+    return result
+
+
+def _signature(path: Path) -> tuple[int, int, int, int]:
+    value = path.stat()
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+
+def _pending_journal(path: Path) -> bool:
+    return any(
+        sidecar.exists() and sidecar.stat().st_size > 0
+        for sidecar in (Path(str(path) + "-wal"), Path(str(path) + "-journal"))
+    )
+
+
+def inspect_database(path: Path, *, supported: int, required_tables: tuple) -> dict:
+    """Inspect a settled SQLite snapshot without creating a DB, WAL or SHM file.
+
+    A live journal is intentionally reported as unknown. Immutable SQLite reads
+    cannot include its latest state; a read/write connection could create sidecars.
+    This report is diagnostic evidence, never a migration or mutation permit.
+    """
+    result = {"path": str(path), "schema": None, "supported_schema": supported}
+    try:
+        if path.is_symlink():
+            return {**result, "status": "unsupported_path"}
+        if not path.exists():
+            return {**result, "status": "missing"}
+        if not path.is_file():
+            return {**result, "status": "unreadable"}
+        before = _signature(path)
+        if _pending_journal(path):
+            return {**result, "status": "snapshot_required"}
+        with closing(
+            sqlite3.connect(
+                path.resolve().as_uri() + "?mode=ro&immutable=1", uri=True, timeout=0.2
+            )
+        ) as db:
+            db.execute("PRAGMA query_only=ON")
+            steps = 0
+
+            def limit() -> int:
+                nonlocal steps
+                steps += 1
+                return int(steps > 1000)
+
+            db.set_progress_handler(limit, 1000)
+            schema = int(db.execute("PRAGMA user_version").fetchone()[0])
+            tables = {
+                row[0]
+                for row in db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        if _pending_journal(path) or _signature(path) != before:
+            return {**result, "status": "snapshot_required"}
+        result["schema"] = schema
+        if schema > supported:
+            status = "newer_than_supported"
+        elif schema == 0:
+            status = "uninitialized" if not tables else "unrecognized"
+        elif not set(required_tables).issubset(tables):
+            status = "unrecognized"
+        elif schema < supported:
+            status = "migration_required"
+        else:
+            status = "compatible"
+        return {**result, "status": status}
+    except sqlite3.OperationalError:
+        return {**result, "status": "unreadable"}
+    except sqlite3.DatabaseError:
+        return {**result, "status": "invalid_database"}
+    except OSError:
+        return {**result, "status": "unreadable"}
+
+
+def local_diagnostics(
+    config: AppConfig | None, *, expected_state_dir: Path | None = None
+) -> tuple[dict, bool]:
+    report = {
+        "observed_at": datetime.now(UTC).isoformat(),
+        "mode": "local",
+        "installation": installation_info(),
+        "configuration": {"status": "unavailable"},
+        "databases": {},
+        "next_actions": [],
+        "public_write": False,
+    }
+    if config is None:
+        report["configuration"]["user_config_path"] = str(default_user_config_path())
+        report["next_actions"].append(
+            "Create missing configuration with reposteward init, or correct the selected TOML file."
+        )
+        return report, False
+    api = urlsplit(config.github.api_url)
+    if api.username or api.password or api.query or api.fragment:
+        # Other effective values, such as a namespaced path, may have been
+        # derived from this URL. Avoid echoing them as well as the URL itself.
+        report["configuration"]["status"] = "unsupported_api_url"
+        report["next_actions"].append(
+            "Use a GitHub API URL without userinfo, query or fragment; configure authentication separately."
+        )
+        return report, False
+    sources = dict(config.setting_sources)
+    values = {
+        "project.state_dir": str(config.state_dir),
+        "project.workspace_dir": str(config.workspace_dir),
+        "project.namespace_state": config.state_namespace,
+        "github.login": config.github.login,
+        "agent.harness": config.agent.harness,
+        "runner.image": config.runner.image,
+    }
+    # Only a public origin is useful here; URLs may contain userinfo or query tokens.
+    host = api.hostname or ""
+    if ":" in host:
+        host = "[" + host + "]"
+    try:
+        port = ":" + str(api.port) if api.port else ""
+    except ValueError:
+        port = ""
+    values["github.api_url"] = api.scheme + "://" + host + port
+    expected = expected_state_dir.expanduser().resolve() if expected_state_dir else None
+    matches = expected is None or config.state_dir.resolve() == expected
+    report["configuration"] = {
+        "status": "loaded",
+        "selected_path": str(config.path),
+        "files": [
+            {"layer": source, "path": path} for source, path in config.config_files
+        ],
+        "settings": {
+            key: {"effective_value": value, "source": sources.get(key, "unknown")}
+            for key, value in values.items()
+        },
+        "expected_state_dir": str(expected) if expected is not None else None,
+        "state_dir_matches": matches,
+        "workspace_fallback": (
+            "state_dir/workspaces"
+            if config.workspace_dir == config.state_dir / "workspaces"
+            else None
+        ),
+    }
+    report["configuration"]["settings"]["github.api_url"]["display_scope"] = (
+        "origin_only"
+    )
+    if not matches:
+        report["next_actions"].append(
+            "The effective state directory differs from the expected directory; correct configuration before any write."
+        )
+        # Do not inspect an unexpectedly selected database.
+        return report, False
+    report["databases"] = {
+        "tasks": inspect_database(
+            config.state_dir / "reposteward.sqlite3",
+            supported=SCHEMA_VERSION,
+            required_tables=("runs", "candidates", "issue_drafts"),
+        ),
+        "projects": inspect_database(
+            config.state_dir / "projects.sqlite3",
+            supported=PROJECT_SCHEMA_VERSION,
+            required_tables=("projects", "workspace_bindings", "project_events"),
+        ),
+    }
+    ok = True
+    actions = {
+        "missing": "No local ledger yet; explicit project/task setup will create it when needed.",
+        "migration_required": "Stop writers and back up this database before upgrading with the newer installation.",
+        "newer_than_supported": "Use an installation supporting this schema; do not open it for writes with this version.",
+        "snapshot_required": "An active or pending journal prevents offline inspection; stop writers cleanly and inspect again.",
+    }
+    for name, database in report["databases"].items():
+        status = database["status"]
+        if status != "compatible":
+            report["next_actions"].append(
+                name
+                + ": "
+                + actions.get(status, "Inspect or restore this ledger before using it.")
+            )
+        ok = ok and status in {"compatible", "missing"}
+    report["scope"] = (
+        "Installation and schema diagnostics only; authentication, integrity of all rows, verification and merge eligibility are not evaluated."
+    )
+    return report, ok

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import unittest
+from contextlib import closing, redirect_stdout
+from importlib import metadata
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
+
+from reposteward.cli import main
+from reposteward.config import load_config
+from reposteward.runtime import inspect_database, installation_info, local_diagnostics
+from reposteward.store import SCHEMA_VERSION, Store
+
+
+class RuntimeTests(unittest.TestCase):
+    def config(self, root: Path):
+        config = root / "config.toml"
+        config.write_text(
+            "config_version = 1\n[project]\nnamespace_state = false\n"
+            f'state_dir = "{root.as_posix()}/state"\n[github]\nlogin = "alice"\n'
+        )
+        return load_config(config)
+
+    def test_missing_state_is_not_created_and_no_execution_is_attempted(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self.config(root)
+            before = sorted(root.rglob("*"))
+            with (
+                patch("subprocess.run", side_effect=AssertionError("no processes")),
+                patch(
+                    "reposteward.store.Store.__init__",
+                    side_effect=AssertionError("no Store"),
+                ),
+                patch(
+                    "reposteward.github.resolve_token",
+                    side_effect=AssertionError("no credentials"),
+                ),
+            ):
+                report, ok = local_diagnostics(config)
+            self.assertTrue(ok)
+            self.assertEqual(report["databases"]["tasks"]["status"], "missing")
+            self.assertEqual(sorted(root.rglob("*")), before)
+
+    def test_expected_directory_mismatch_does_not_open_a_database(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            with patch("sqlite3.connect", side_effect=AssertionError("no DB read")):
+                report, ok = local_diagnostics(
+                    self.config(root), expected_state_dir=root / "other"
+                )
+            self.assertFalse(ok)
+            self.assertFalse(report["configuration"]["state_dir_matches"])
+            self.assertEqual(report["databases"], {})
+
+    def test_compatible_and_older_ledgers_remain_unchanged(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self.config(root)
+            path = config.state_dir / "reposteward.sqlite3"
+            Store(path)
+            for version, expected in (
+                (SCHEMA_VERSION, "compatible"),
+                (17, "migration_required"),
+            ):
+                with closing(sqlite3.connect(path)) as db:
+                    db.execute(f"PRAGMA user_version={version}")
+                    db.commit()
+                before = {p.name: p.read_bytes() for p in path.parent.iterdir()}
+                report, ok = local_diagnostics(config)
+                self.assertEqual(report["databases"]["tasks"]["status"], expected)
+                self.assertEqual(ok, version == SCHEMA_VERSION)
+                self.assertEqual(
+                    {p.name: p.read_bytes() for p in path.parent.iterdir()}, before
+                )
+
+    def test_future_corrupt_unrecognized_and_uninitialized_database(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.sqlite3"
+            path.write_bytes(b"not a database")
+            self.assertEqual(
+                inspect_database(path, supported=22, required_tables=())["status"],
+                "invalid_database",
+            )
+            path.unlink()
+            with closing(sqlite3.connect(path)) as db:
+                db.execute("PRAGMA user_version=999")
+            before = path.read_bytes()
+            self.assertEqual(
+                inspect_database(path, supported=22, required_tables=())["status"],
+                "newer_than_supported",
+            )
+            self.assertEqual(path.read_bytes(), before)
+            with closing(sqlite3.connect(path)) as db:
+                db.execute("PRAGMA user_version=22")
+            self.assertEqual(
+                inspect_database(path, supported=22, required_tables=("runs",))[
+                    "status"
+                ],
+                "unrecognized",
+            )
+            path.write_bytes(b"")
+            self.assertEqual(
+                inspect_database(path, supported=22, required_tables=())["status"],
+                "uninitialized",
+            )
+            self.assertEqual(path.read_bytes(), b"")
+
+    def test_live_wal_is_unknown_and_no_sidecars_are_created(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.sqlite3"
+            with closing(sqlite3.connect(path)) as writer:
+                writer.execute("PRAGMA journal_mode=WAL")
+                writer.execute("CREATE TABLE sample(value)")
+                writer.commit()
+                before = {p.name: p.read_bytes() for p in path.parent.iterdir()}
+                with patch(
+                    "reposteward.runtime.sqlite3.connect",
+                    side_effect=AssertionError("no stale immutable read"),
+                ):
+                    result = inspect_database(path, supported=22, required_tables=())
+                self.assertEqual(result["status"], "snapshot_required")
+                self.assertIsNone(result["schema"])
+                self.assertEqual(
+                    {p.name: p.read_bytes() for p in path.parent.iterdir()}, before
+                )
+
+    def test_project_registry_compatibility_is_reported_separately(self):
+        with TemporaryDirectory() as directory:
+            config = self.config(Path(directory))
+            config.state_dir.mkdir()
+            with closing(sqlite3.connect(config.state_dir / "projects.sqlite3")) as db:
+                for table in ("projects", "workspace_bindings", "project_events"):
+                    db.execute(f"CREATE TABLE {table}(id TEXT)")
+                db.execute("PRAGMA user_version=1")
+                db.commit()
+            report, ok = local_diagnostics(config)
+            self.assertTrue(ok)
+            self.assertEqual(report["databases"]["projects"]["status"], "compatible")
+            self.assertEqual(report["databases"]["tasks"]["status"], "missing")
+
+    def test_layer_sources_match_trusted_merge_without_exposing_config(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            user = root / "user.toml"
+            user.write_text(
+                'config_version = 1\n[project]\nstate_dir = "/trusted/state"\n'
+                'namespace_state = false\n[github]\nlogin = "alice"\n'
+                'api_url = "https://example.test:8443/api/v3"\n'
+                'gh_auth_command = ["SECRET_COMMAND"]\n'
+            )
+            project = root / "project.toml"
+            project.write_text(
+                'config_version = 1\n[project]\nstate_dir = "/untrusted/state"\n'
+                '[github]\nlogin = "mallory"\n[agent]\nharness = "codex-sdk"\n'
+                '[runner]\nimage = "untrusted-image"\n'
+            )
+            config = load_config(project, user_path=user)
+            # Deliberately require a different directory: provenance is still visible,
+            # but this test never inspects the configured absolute state path.
+            report, _ = local_diagnostics(config, expected_state_dir=root / "expected")
+            settings = report["configuration"]["settings"]
+            self.assertEqual(settings["project.state_dir"]["source"], "user")
+            self.assertEqual(
+                settings["project.state_dir"]["effective_value"], "/trusted/state"
+            )
+            self.assertEqual(settings["github.login"]["source"], "user")
+            self.assertEqual(settings["agent.harness"]["source"], "default")
+            self.assertEqual(settings["runner.image"]["source"], "default")
+            encoded = json.dumps(report)
+            for secret in ("SECRET", "HIDDEN", "mallory", "untrusted-image"):
+                self.assertNotIn(secret, encoded)
+            self.assertEqual(
+                dict(load_config(project).setting_sources)["github.login"], "project"
+            )
+            self.assertEqual(config.github.gh_auth_command, ("SECRET_COMMAND",))
+
+    def test_url_userinfo_is_not_exposed_through_derived_state_paths(self):
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "config.toml"
+            path.write_text(
+                'config_version = 1\n[github]\nlogin = "alice"\n'
+                'api_url = "https://alice:SECRET@example.test/api/v3"\n'
+            )
+            config = load_config(path)
+            with patch("sqlite3.connect", side_effect=AssertionError("no DB read")):
+                report, ok = local_diagnostics(config)
+            self.assertFalse(ok)
+            self.assertEqual(report["configuration"]["status"], "unsupported_api_url")
+            self.assertNotIn("secret", json.dumps(report).lower())
+
+    def test_version_redacts_direct_url_and_reports_metadata_absence(self):
+        distribution = Mock(version="0.1.0")
+        distribution.locate_file.return_value = Path("/installed")
+        distribution.read_text.return_value = json.dumps(
+            {
+                "url": "https://token:SECRET@example.test/repo",
+                "vcs_info": {"commit_id": "a" * 40},
+            }
+        )
+        with patch(
+            "reposteward.runtime.metadata.distribution", return_value=distribution
+        ):
+            report = installation_info()
+        self.assertEqual(report["source_revision"], "a" * 40)
+        self.assertNotIn("SECRET", json.dumps(report))
+        with patch(
+            "reposteward.runtime.metadata.distribution",
+            side_effect=metadata.PackageNotFoundError,
+        ):
+            self.assertFalse(installation_info()["metadata_available"])
+
+    def test_version_cli_needs_no_config_and_local_doctor_handles_missing_config(self):
+        with patch(
+            "reposteward.cli.load_config", side_effect=AssertionError("no config")
+        ):
+            with redirect_stdout(io.StringIO()) as output:
+                self.assertEqual(main(["version"]), 0)
+            self.assertIn("version", json.loads(output.getvalue()))
+            with (
+                redirect_stdout(io.StringIO()) as output,
+                self.assertRaises(SystemExit) as stopped,
+            ):
+                main(["--version"])
+            self.assertEqual(stopped.exception.code, 0)
+            self.assertTrue(output.getvalue().startswith("reposteward "))
+        with (
+            TemporaryDirectory() as directory,
+            patch(
+                "reposteward.config.default_user_config_path",
+                return_value=Path(directory) / "user.toml",
+            ),
+        ):
+            with redirect_stdout(io.StringIO()) as output:
+                self.assertEqual(
+                    main(
+                        [
+                            "--config",
+                            str(Path(directory) / "missing.toml"),
+                            "doctor",
+                            "--local",
+                        ]
+                    ),
+                    1,
+                )
+            self.assertEqual(
+                json.loads(output.getvalue())["configuration"]["status"],
+                "unavailable",
+            )
+
+    def test_full_doctor_remains_a_separate_explicit_path(self):
+        with TemporaryDirectory() as directory:
+            config = self.config(Path(directory))
+            with (
+                patch("reposteward.cli.load_config", return_value=config),
+                patch(
+                    "reposteward.cli.run_doctor", return_value=({"tools": {}}, True)
+                ) as doctor,
+            ):
+                with redirect_stdout(io.StringIO()):
+                    self.assertEqual(main(["doctor"]), 0)
+                doctor.assert_called_once_with(config)


### PR DESCRIPTION
Closes #125

新增本地只读诊断，报告安装版本与模块位置、关键配置的生效来源、实际状态目录和数据库兼容性；明确指出缺失、需升级、版本过新和损坏等情况，并提供可执行的下一步。

---

承接维护者已确认的本地工作台规划第一阶段。复用已有安装、doctor、ProjectRegistry 与 Understanding；本项不改变数据库迁移策略，不实现网页和后台调度。升级备份与迁移工具作为单独聚焦改动处理，网页后续复用此诊断服务。

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
