### PR TITLE
feat(workbench): add a read-only local maintenance workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ the model-governed repository direction.
 
 For an isolated installation used outside this source checkout, see the
 [local installation and offline diagnostics guide](docs/local-installation.zh-CN.md).
+
+Run `reposteward web` for the [read-only local workbench](docs/local-workbench.zh-CN.md):
+project guides, task continuity, review evidence and diagnostics in one browser window.
 `reposteward version` reports installation metadata; `reposteward doctor --local`
 checks configuration sources and database compatibility without authentication or migration.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,6 +62,9 @@ PR 为目标。
 ## 安装
 
 日常从源码目录之外使用时，参见[独立安装与离线诊断指南](docs/local-installation.zh-CN.md)。
+
+运行 `reposteward web` 打开[本地只读工作台](docs/local-workbench.zh-CN.md)，集中查看
+跨项目待办、代码导览、任务接续、审阅依据与设置诊断。
 `reposteward version` 显示安装信息；`reposteward doctor --local` 可检查配置来源与数据库
 兼容性，无需认证，也不会触发迁移。
 

--- a/docs/local-installation.zh-CN.md
+++ b/docs/local-installation.zh-CN.md
@@ -70,6 +70,9 @@ API URL 带 userinfo、查询或 fragment 时，本地诊断会先要求修正 U
 
 ## 在目标项目继续工作
 
+可用 `reposteward web` 启动[本地只读工作台](local-workbench.zh-CN.md)，集中查看已关联
+项目、代码导览、任务接续与审阅依据。网页随安装提供，不需要源码 checkout 或 Node。
+
 ```bash
 cd /absolute/path/to/your-project
 reposteward project link .

--- a/docs/local-workbench.zh-CN.md
+++ b/docs/local-workbench.zh-CN.md
@@ -1,0 +1,79 @@
+# 本地只读工作台
+
+安装后运行：
+
+```bash
+reposteward web
+```
+
+用同一台机器上的浏览器打开终端打印的完整链接。默认选择可用端口；可用
+`--port 8765` 指定端口，用 `--expect-state-dir /absolute/path/to/state` 核对作用域。
+按 Ctrl+C 停止。网页、样式和脚本都随 Python wheel 安装，日常使用无需 Node 或源码
+checkout，也不需要启动模型、Docker 或 GitHub 认证。
+
+## 从项目进入一次任务
+
+先使用已有命令准备本地事实：
+
+```bash
+reposteward project link /absolute/path/to/project
+reposteward understand scan /absolute/path/to/project
+reposteward overview refresh
+```
+
+`project link` 登记本地工作区，不授予仓库维护权限；已有 clone/worktree 保持原位置。
+需维护或贡献时，再配置对应仓库策略。`scan` 显式更新代码索引，`overview refresh`
+显式读取 GitHub 并保存缓存。网页中的“重新读取”只读取已保存的本地状态。
+
+| 页面 | 可以完成的事 | 事实边界 |
+| --- | --- | --- |
+| 今日待处理 | 跨项目查看待办、来源时间、未知/省略和下一步，跳入任务 | 复用 overview；缓存不是实时 GitHub 状态 |
+| 项目空间 | 查找项目、切换 worktree、查看角色/分支/HEAD、按关注点读导览和代码依据 | 导览过期时要求重新扫描；代码文字不执行 |
+| 任务接续 | 查看最近任务尝试、目标/验收、未完成工作、决定、阻塞，复制接续数据 | 外部任务复用 CLI/MCP 的预算与适用性核对；维护任务显示原 Context Pack/Checkpoint |
+| 审阅依据 | 查看验证适用性、历史状态、任务轨迹和来源 | 历史通过/合并判定不是新的提交或合并授权 |
+| 设置与诊断 | 查看安装、配置来源、状态目录和两个数据库的兼容性 | 复用 doctor --local，不认证、不升级 |
+
+外部任务沿已有 `task start/checkpoint` 流程创建和接续。网页保留 Agent 自述与独立
+验证的区别，也保留上下文的来源和省略信息。缺少任务上下文时仍可查看相应 Issue 的
+生命周期轨迹。项目导览可选择 Codex、Claude Code 或 Copilot（VS Code）的 MCP 配置
+预览命令；配置预览不等于实际客户端会话已验证。浏览器只复制接续数据或 POSIX 终端
+命令；不会替你执行命令。导览与任务接续命令保留当前配置路径，便于从其他目录使用。
+
+任务列表最多显示某项目最近50次尝试，项目列表最多50项、工作区列表最多100项；
+详情响应上限400KB。超限、无法读取或不兼容时显示明确状态，不截掉关键上下文后
+宣称完整。异常详情不会删除其他项目。可继续使用 CLI 查看更大的范围。
+
+## 本机入口与会话
+
+服务固定绑定 `127.0.0.1`，只接受精确 Host 与同源请求，API 还需当前进程随机生成的
+会话。链接中的会话放在 URL fragment 中，由页面取出并移除；同一标签页使用
+sessionStorage 保持刷新后的连接，API 通过 Authorization 请求头携带会话。
+访问日志不记录请求或会话。链接相当于本机工作台读取权限，不放入公开 Issue/PR。
+
+会话最长12小时，进程退出即失效。无会话的页面只有静态外壳，不能读取项目数据。
+API 没有 CORS 授权或写操作，拒绝任意文件路径和跨项目任务请求；所有仓库文字按
+文本显示，页面使用 CSP 限定脚本和资源。接口重新核对登记身份与工作区绑定。
+已加载的配置文件变化会要求重启；新增配置层也应重启后重新核对生效配置。
+
+这是单机维护入口，使用标准库 HTTP 服务的受限适配层，不提供公网部署、反向代理、
+远程账户或多用户隔离。标准库 HTTP 服务本身只提供基础检查，本项目的固定路由、
+会话和请求边界不能被解释为面向公网的服务器方案。
+
+不存在的数据库不创建，旧数据库不由网页迁移。需要升级时退出相关写入客户端，按
+[升级与备份说明](state-upgrades.zh-CN.md)操作，再启动工作台。更换安装参见
+[独立安装说明](local-installation.zh-CN.md)。
+
+## 接口与验证
+
+`workbench.Workbench` 组合现有只读应用服务；`web_server` 仅负责本机 HTTP 边界。
+前端调用 `/api/overview`、`projects`、`workspace`、`code`、`tasks`、`task`、`review`
+和 `settings`。接口只接受声明参数，项目/工作区/任务均使用登记 ID；不暴露 Pipeline、
+SQL、shell、原始配置或任意文件服务。没有新增网页任务表或另一套状态机。
+
+回归测试覆盖会话/请求来源、固定路由、写方法拒绝、跨项目隔离、绑定变化、旧库、
+读取不变性以及 CLI/MCP 与网页查询的一致性。浏览器交互与打包检查在加固验证容器中
+执行；用于浏览器验证的额外工具不成为日常安装依赖。
+
+设计依据：[Python HTTP 服务](https://docs.python.org/3.12/library/http.server.html)、
+[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)、
+[Fetch Metadata](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site)。

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -51,6 +51,16 @@ def _parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("version", help="show offline installation metadata as JSON")
+    web = subparsers.add_parser(
+        "web", help="open the read-only local maintainer workbench"
+    )
+    web.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="local port (default: choose an available port)",
+    )
+    web.add_argument("--expect-state-dir", type=Path)
     state = subparsers.add_parser(
         "state", help="plan and explicitly back up local database upgrades"
     )
@@ -741,6 +751,19 @@ def main(argv: list[str] | None = None) -> int:
             from .runtime import installation_info
 
             _json(installation_info())
+            return 0
+        if args.command == "web":
+            from .web_server import serve
+
+            web_config = load_config(args.config, include_user=True)
+            if args.expect_state_dir is not None and (
+                web_config.state_dir.expanduser().resolve()
+                != args.expect_state_dir.expanduser().resolve()
+            ):
+                raise ValueError(
+                    "effective state directory differs from the expected directory"
+                )
+            serve(web_config, port=args.port)
             return 0
         if args.command == "state":
             from .state_upgrade import inspect_backup, upgrade_plan, upgrade_state

--- a/src/reposteward/web/app.css
+++ b/src/reposteward/web/app.css
@@ -1,0 +1,102 @@
+:root { color-scheme: light; --bg: #f4f5f1; --paper: #fff; --ink: #20352e; --muted: #6d7973; --line: #dee4dc; --green: #285c49; --pale: #e8f0e8; --amber: #86601e; --red: #a23d35; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink); font-size: 14px; line-height: 1.65; }
+a { color: var(--green); text-decoration-thickness: 1px; text-underline-offset: 3px; }
+button, input, select { font: inherit; }
+button, a, select { -webkit-tap-highlight-color: transparent; }
+button { cursor: pointer; }
+:focus-visible { outline: 3px solid #84b7a0; outline-offset: 3px; }
+.skip { position: absolute; top: -60px; left: 20px; z-index: 10; background: white; padding: 12px; }
+.skip:focus { top: 12px; }
+.shell { display: grid; grid-template-columns: 236px minmax(0, 1fr); min-height: 100vh; }
+.sidebar { background: #fafbf8; border-right: 1px solid var(--line); padding: 32px 20px 22px; display: flex; flex-direction: column; position: sticky; top: 0; height: 100vh; }
+.brand { display: flex; gap: 12px; align-items: center; text-decoration: none; font-size: 19px; font-weight: 650; letter-spacing: -.5px; margin: 0 6px 50px; }
+.brand-mark { background: var(--green); color: white; width: 39px; height: 41px; border-radius: 9px; display: grid; place-items: center; font-family: Georgia, serif; font-size: 28px; }
+.brand small { display: block; color: var(--muted); font-size: 10px; letter-spacing: 2px; font-weight: 400; margin-top: 2px; }
+.nav-label, .eyebrow { font-size: 10px; font-weight: 700; letter-spacing: 2px; color: var(--muted); }
+.nav-label { margin: 0 15px 12px; }
+nav { display: grid; gap: 7px; }
+nav a { display: flex; gap: 14px; align-items: center; padding: 12px 15px; color: #5c6b63; text-decoration: none; border-radius: 7px; }
+nav a span { font-size: 19px; width: 21px; line-height: 1; }
+nav a[aria-current="page"] { background: var(--pale); color: var(--green); font-weight: 650; }
+nav a:hover { background: #edf1ea; }
+.sidebar-bottom { margin-top: auto; padding: 24px 15px 0; border-top: 1px solid var(--line); color: var(--green); font-size: 12px; }
+.sidebar-bottom p { color: var(--muted); margin: 12px 0 0; line-height: 1.8; }
+.live-dot { display: inline-block; height: 6px; width: 6px; border-radius: 50%; background: #5b947a; margin-right: 7px; }
+.main { min-width: 0; }
+.topbar { height: 78px; border-bottom: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; padding: 0 42px; background: #fafbf8; gap: 12px; }
+.breadcrumb { color: var(--muted); font-size: 12px; }
+.breadcrumb span { margin: 0 12px; color: #a7b2aa; }
+.breadcrumb strong { font-weight: 500; color: var(--ink); }
+.top-actions, .row, .actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+main { max-width: 1400px; padding: 36px 42px 28px; margin: 0 auto; min-height: calc(100vh - 132px); }
+main:focus { outline: none; }
+.hero { margin-bottom: 28px; }
+.hero h1 { font-size: clamp(25px, 3vw, 34px); font-weight: 600; letter-spacing: -1px; line-height: 1.4; margin: 8px 0 9px; }
+.hero p { color: var(--muted); margin: 0; max-width: 740px; }
+.stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; margin-bottom: 30px; }
+.stat { padding: 18px 22px; border: 1px solid var(--line); background: var(--paper); border-radius: 10px; }
+.stat-label { font-size: 12px; color: var(--muted); }
+.stat-number { font-size: 29px; line-height: 1.4; font-weight: 550; margin: 8px 0 1px; letter-spacing: -1px; }
+.stat-note { font-size: 11px; color: var(--muted); }
+.section-head { display: flex; justify-content: space-between; align-items: baseline; margin: 28px 0 13px; gap: 14px; flex-wrap: wrap; }
+h2 { font-size: 17px; font-weight: 600; margin: 0; }
+h3 { font-size: 15px; margin: 0 0 5px; font-weight: 600; }
+p { margin: 7px 0; }
+.muted, .meta { color: var(--muted); }
+.meta { font-size: 12px; }
+.badge { display: inline-flex; border-radius: 5px; background: #edf1ec; padding: 3px 8px; color: #55685c; font-size: 11px; font-weight: 550; white-space: nowrap; }
+.badge.good { color: #276348; background: #e6f2e8; }
+.badge.warn { color: var(--amber); background: #f6efde; }
+.badge.bad { color: var(--red); background: #f9e9e5; }
+.panel { background: var(--paper); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; margin-bottom: 18px; }
+.panel-pad { padding: 22px; }
+.panel-title { padding: 16px 21px; border-bottom: 1px solid var(--line); display: flex; gap: 12px; align-items: center; justify-content: space-between; }
+.item { padding: 18px 21px; border-bottom: 1px solid #e9ede6; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 18px; align-items: center; }
+.item:last-child { border-bottom: 0; }
+.item-title { font-size: 14px; font-weight: 550; margin: 5px 0; overflow-wrap: anywhere; }
+.item .meta { overflow-wrap: anywhere; }
+.button { border: 1px solid var(--line); border-radius: 6px; padding: 7px 12px; background: white; color: var(--ink); font-size: 12px; font-weight: 500; text-decoration: none; display: inline-block; }
+.button:hover { border-color: #9cae9e; background: #f4f7f1; }
+.button.primary { color: white; background: var(--green); border-color: var(--green); }
+.button.subtle { background: transparent; }
+.button:disabled { opacity: .55; cursor: progress; }
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.project-card { background: white; border: 1px solid var(--line); border-radius: 10px; padding: 23px; }
+.project-card h2 { margin: 16px 0 6px; font-size: 22px; overflow-wrap: anywhere; }
+.project-card .actions { margin-top: 22px; }
+.project-symbol { font-family: ui-monospace, monospace; background: var(--pale); color: var(--green); border-radius: 8px; padding: 7px 12px; font-size: 20px; }
+.toolbar { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin: 20px 0; }
+label { color: var(--muted); font-size: 12px; }
+input, select { border: 1px solid #cfd9ce; background: white; color: var(--ink); border-radius: 6px; padding: 9px 12px; max-width: 100%; min-width: 0; }
+input[type="search"] { flex: 1; min-width: 160px; }
+select { max-width: 640px; }
+.empty { border: 1px dashed #cdd8cb; border-radius: 10px; padding: 36px 25px; color: var(--muted); line-height: 1.9; background: #fafbf8; }
+.empty strong { color: var(--ink); display: block; margin-bottom: 5px; }
+.callout { padding: 14px 18px; border-left: 3px solid #b48d49; background: #faf5e9; border-radius: 0 6px 6px 0; margin: 15px 0; color: #6f5a34; }
+.error { border-left-color: #b56155; background: #fbefec; color: #8a4237; }
+.split { display: grid; grid-template-columns: minmax(0, 1.8fr) minmax(250px, 1fr); gap: 22px; align-items: start; }
+.key-values { display: grid; grid-template-columns: 100px minmax(0, 1fr); gap: 12px; margin: 0; font-size: 12px; }
+dt { color: var(--muted); } dd { margin: 0; overflow-wrap: anywhere; }
+pre, code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; max-height: 440px; overflow-y: auto; margin: 12px 0 0; padding: 16px; background: #f5f7f2; border-radius: 6px; border: 1px solid #e2e7dc; line-height: 1.7; }
+.command { display: flex; gap: 10px; align-items: start; margin: 12px 0; background: #f5f7f2; padding: 12px; border-radius: 6px; }
+.command code { flex: 1; overflow-wrap: anywhere; padding-top: 3px; }
+.step { display: flex; gap: 14px; padding: 18px 0; border-bottom: 1px solid #e9ede6; }
+.step:last-child { border-bottom: 0; }
+.step-number { border-radius: 50%; width: 25px; height: 25px; flex-shrink: 0; display: grid; place-items: center; background: #edf2e9; color: #52684f; font-size: 11px; }
+.step-content { min-width: 0; flex: 1; }
+.step-content h3 { overflow-wrap: anywhere; font-family: ui-monospace, monospace; font-size: 13px; }
+.step-content p { color: var(--muted); font-size: 12px; }
+.step-content .actions { margin-top: 10px; }
+details { margin: 15px 0; }
+summary { cursor: pointer; font-size: 12px; color: var(--green); padding: 5px 0; }
+ul.plain { padding-left: 19px; margin: 10px 0; }
+ul.plain li { margin: 8px 0; overflow-wrap: anywhere; }
+.task-button { text-align: left; border: 0; background: transparent; color: var(--ink); padding: 0; font: inherit; font-weight: 550; text-decoration: underline; text-underline-offset: 4px; }
+.toast { position: fixed; bottom: 25px; left: 50%; transform: translateX(-50%); color: white; background: #203a2d; padding: 10px 18px; border-radius: 7px; z-index: 5; max-width: 90vw; }
+footer { padding: 14px 42px 20px; color: #849080; font-size: 10px; display: flex; justify-content: space-between; gap: 15px; }
+@media (min-width: 1500px) { main { padding-top: 46px; } }
+@media (max-width: 1050px) { .shell { grid-template-columns: 200px minmax(0, 1fr); } .sidebar { padding-inline: 13px; } .topbar { padding-inline: 25px; } main { padding: 28px 25px; } .split { grid-template-columns: 1fr; } .grid { gap: 12px; } }
+@media (max-width: 720px) { .shell { display: block; } .sidebar { height: auto; position: static; padding: 17px 18px 10px; border-right: 0; border-bottom: 1px solid var(--line); } .brand { margin: 0 0 15px; font-size: 18px; } .brand-mark { width: 33px; height: 35px; } .nav-label, .sidebar-bottom { display: none; } nav { display: flex; overflow-x: auto; gap: 5px; } nav a { white-space: nowrap; font-size: 12px; gap: 7px; padding: 9px 10px; } nav a span { font-size: 16px; width: auto; } .topbar { height: 60px; padding-inline: 18px; } .breadcrumb { font-size: 11px; } .breadcrumb span { margin: 0 5px; } main { padding: 25px 18px; } .stats { gap: 8px; margin-bottom: 20px; } .stat { padding: 14px 12px; } .stat-number { font-size: 25px; } .stat-note { font-size: 10px; } .grid { grid-template-columns: 1fr; } .item { grid-template-columns: 1fr; gap: 10px; } .item > .actions { justify-self: start; } .panel-pad, .panel-title { padding: 17px; } .toolbar { align-items: stretch; } .toolbar label { width: 100%; } select { width: 100%; } footer { padding-inline: 18px; } footer span { display: none; } }
+@media (prefers-reduced-motion: no-preference) { .button, nav a { transition: background .15s ease; } }

--- a/src/reposteward/web/app.js
+++ b/src/reposteward/web/app.js
@@ -1,0 +1,297 @@
+"use strict";
+
+(() => {
+  const content = document.getElementById("content");
+  const connection = document.getElementById("connection");
+  const labels = {today: "今日待处理", projects: "项目空间", tasks: "任务接续", review: "审阅依据", settings: "设置与诊断"};
+  const statusNames = {current: "当前有效", stale: "已过期", not_scanned: "尚未扫描", compatible: "兼容", missing: "尚未创建", migration_required: "需要升级", newer_than_supported: "安装版本过旧", snapshot_required: "等待稳定快照", unavailable: "暂不可用", not_checked: "未核对当前适用性", matches: "匹配当前快照", not_verified: "当前未验证", passed: "历史验证通过", failed: "验证失败", running: "进行中", ready: "准备完成", submitted: "已提交", merged: "已合入", blocked: "有阻塞", complete: "完成", cached: "线上缓存", not_refreshed: "未刷新线上状态", refresh_failed: "线上刷新失败", maintainer: "维护者", contributor: "贡献者", unconfigured: "未配置策略", unknown: "未知"};
+  const storageKey = "reposteward-local-session";
+  let token = "";
+  try { token = sessionStorage.getItem(storageKey) || ""; } catch { /* Storage can be disabled. */ }
+  if (location.hash.startsWith("#session=")) {
+    const candidate = location.hash.slice(9);
+    if (/^[A-Za-z0-9_-]{43}$/.test(candidate)) {
+      token = candidate;
+      try { sessionStorage.setItem(storageKey, token); } catch { /* Keep it only in memory. */ }
+    }
+    history.replaceState(null, "", location.pathname + "#today");
+  }
+  let controller = new AbortController();
+  let generation = 0;
+  let projectCache = [];
+  let selectedProject = "";
+  let noticeTimer;
+
+  function node(tag, className, ...children) {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    for (const child of children.flat(Infinity)) {
+      if (child !== null && child !== undefined) element.append(child instanceof Node ? child : document.createTextNode(String(child)));
+    }
+    return element;
+  }
+  const values = value => Array.isArray(value) ? value : [];
+  const text = value => typeof value === "string" ? value : JSON.stringify(value ?? "");
+  const name = value => statusNames[value] || value || "未知";
+  function badge(value, tone = "") { return node("span", "badge " + tone, name(value)); }
+  function button(label, action, primary = false) {
+    const b = node("button", "button" + (primary ? " primary" : ""), label);
+    b.type = "button"; b.addEventListener("click", action); return b;
+  }
+  function notify(message) {
+    const box = document.getElementById("notice");
+    clearTimeout(noticeTimer); box.textContent = message; box.hidden = false;
+    noticeTimer = setTimeout(() => { box.hidden = true; }, 3000);
+  }
+  async function copy(value) {
+    try { await navigator.clipboard.writeText(value); notify("已复制，可在目标项目中继续。"); }
+    catch { notify("浏览器未允许复制，请选择下方文本手动复制。"); }
+  }
+  function command(value) {
+    return node("div", "command", node("code", "", value), button("复制", () => copy(value)));
+  }
+  function details(title, value) {
+    return node("details", "", node("summary", "", title), node("pre", "", JSON.stringify(value, null, 2)));
+  }
+  function list(items, empty = "尚无记录") {
+    return values(items).length ? node("ul", "plain", values(items).map(item => node("li", "", text(item)))) : node("p", "muted", empty);
+  }
+  function date(value) {
+    const d = new Date(value);
+    return value && Number.isFinite(d.getTime()) ? d.toLocaleString("zh-CN", {hour12: false}) : "时间未知";
+  }
+  function pairs(entries) {
+    return node("dl", "key-values", entries.flatMap(([key, value]) => [node("dt", "", key), node("dd", "", value ?? "未知")]));
+  }
+  function link(label, raw) {
+    try {
+      const url = new URL(raw);
+      if (url.protocol !== "https:" || url.username || url.password) return node("span", "meta", label);
+      const a = node("a", "", label); a.href = url.href; a.target = "_blank"; a.rel = "noopener noreferrer"; return a;
+    } catch { return node("span", "meta", label); }
+  }
+  function hero(title, subtitle, eyebrow = "LOCAL WORKSPACE") {
+    return node("section", "hero", node("div", "eyebrow", eyebrow), node("h1", "", title), node("p", "", subtitle));
+  }
+  function errorBox(error) { return node("div", "callout error", error.message || "读取失败，请重试。"); }
+  function empty(title, message) { return node("div", "empty", node("strong", "", title), message); }
+  function go(view, project = "", item = "") {
+    location.hash = [view, project, item].filter(Boolean).map(encodeURIComponent).join("/");
+  }
+  async function api(route, params = {}) {
+    const response = await fetch("/api/" + route + (Object.keys(params).length ? "?" + new URLSearchParams(params) : ""), {
+      headers: {Authorization: "Bearer " + token}, signal: controller.signal, cache: "no-store", credentials: "omit"
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      if (response.status === 401) { connection.textContent = "会话未连接"; connection.className = "badge warn"; }
+      throw new Error(data.error?.message || "读取失败，请重试。");
+    }
+    return data;
+  }
+  function omitted(count, unit = "项") { return count ? node("p", "callout", `另有 ${count} ${unit}未显示；可使用 CLI 查询完整范围。`) : document.createDocumentFragment(); }
+  function section(title, detail = "") { return node("div", "section-head", node("h2", "", title), node("span", "meta", detail)); }
+
+  async function today(host) {
+    host.append(hero("今天，先处理重要的事。", "集中查看需要你介入的事项，再回到目标项目继续工作。"));
+    let result;
+    try { result = await api("overview"); } catch (error) { host.append(errorBox(error)); return; }
+    const projects = values(result.projects);
+    const items = projects.flatMap(p => values(p.items));
+    const unknown = projects.filter(p => !p.complete).length;
+    const stat = (label, number, note) => node("div", "stat", node("div", "stat-label", label), node("div", "stat-number", number), node("div", "stat-note", note));
+    host.append(node("div", "stats", stat("已关联项目", projectCache.length, "从项目空间进入工作区"), stat("本页待处理", items.length, "按维护者介入优先级排列"), stat("数据覆盖", result.complete ? "完整" : "部分", unknown ? `${unknown} 个项目有未知或省略` : "依据本地台账与线上缓存")));
+    host.append(section("需要关注", `本次读取 · ${date(result.observed_at)}`));
+    if (!projects.length) host.append(empty("从一个项目开始", "在终端关联项目并配置仓库策略后，它会出现在这里。"), command("reposteward project link /absolute/path/to/project"));
+    for (const project of projects) {
+      const source = project.sources || {};
+      const panel = node("section", "panel", node("div", "panel-title", button(project.repository, () => go("projects", project.project_id)), node("div", "row", badge(source.status, source.status === "cached" ? "" : "warn"), node("span", "meta", date(source.fetched_at)))));
+      if (!values(project.items).length) panel.append(node("div", "panel-pad muted", "当前范围内没有需要介入的事项。"));
+      for (const item of values(project.items)) {
+        const actions = node("div", "actions");
+        if (item.run_id) actions.append(button("查看任务", () => go("tasks", project.project_id, item.run_id)));
+        if (item.next_command) actions.append(button("复制下一步", () => copy(item.next_command)));
+        panel.append(node("div", "item", node("div", "", node("div", "row", badge(item.priority >= 90 ? "需要介入" : "待核对", item.priority >= 90 ? "warn" : ""), node("span", "meta", item.pull_number ? `PR #${item.pull_number}` : "本地任务")), node("div", "item-title", item.summary), node("div", "meta", "来源更新 · " + date(item.source_updated_at))), actions));
+      }
+      if (source.error) panel.append(node("div", "panel-pad", errorBox(new Error(source.error))));
+      if (project.omitted) panel.append(node("div", "panel-pad", omitted(project.omitted)));
+      host.append(panel);
+    }
+    host.append(omitted(result.omitted_projects, "个项目"));
+    if (result.excluded_projects) host.append(node("p", "meta", `${result.excluded_projects} 个项目因策略、来源或工作区不可用未进入待办；请到项目空间检查。`));
+    host.append(details("本页来源与覆盖信息", result), node("p", "meta", "“重新读取”只读取本地数据。更新 GitHub 缓存请在终端执行："), command("reposteward overview refresh"));
+  }
+
+  function projectSelector(host, projectId, onChange) {
+    const select = node("select", ""); select.id = "project-select";
+    for (const project of projectCache) {
+      const option = node("option", "", project.repository); option.value = project.id; select.append(option);
+    }
+    select.value = projectId;
+    select.addEventListener("change", () => { selectedProject = select.value; onChange(select.value); });
+    host.append(node("div", "toolbar", node("label", "", "当前项目"), select));
+    select.setAttribute("aria-label", "当前项目");
+  }
+  async function projects(host, projectId, bindingId) {
+    host.append(hero("每个项目，都有清晰的入口。", "从工作区、代码导览和阅读路线，快速找回项目的结构。", "PROJECT SPACES"));
+    if (!projectId) {
+      const grid = node("div", "grid");
+      const input = node("input", ""); input.type = "search"; input.placeholder = "查找项目或仓库…"; input.setAttribute("aria-label", "查找项目");
+      const draw = () => {
+        grid.replaceChildren();
+        const matched = projectCache.filter(p => (p.repository + " " + p.name).toLowerCase().includes(input.value.toLowerCase()));
+        for (const project of matched) grid.append(node("article", "project-card", node("div", "row", node("span", "project-symbol", "⌘"), badge(project.policy.mode), !project.policy.enabled ? badge("策略未启用", "warn") : null), node("h2", "", project.name), node("p", "meta", project.repository), node("p", "meta", `${project.workspace_count} 个工作区 · ${project.missing_workspaces} 个路径不可用`), node("div", "actions", button("进入项目", () => go("projects", project.id), true), button("查看任务", () => go("tasks", project.id)))));
+        if (!matched.length) grid.append(empty("没有匹配项目", "可调整查找条件，或使用 project link 关联本地工作区。"));
+      };
+      input.addEventListener("input", draw); host.append(node("div", "toolbar", input), grid); draw(); return;
+    }
+    selectedProject = projectId;
+    projectSelector(host, projectId, id => go("projects", id));
+    const project = projectCache.find(p => p.id === projectId);
+    if (!project) { host.append(empty("项目不在当前列表中", "请重新读取项目列表，或从 CLI 检查登记信息。")); return; }
+    const workspaces = values(project.workspaces);
+    if (!workspaces.length) { host.append(empty("尚无有效关联", "使用 project link 关联这个项目的工作区。")); return; }
+    const selected = workspaces.find(w => w.id === bindingId) || workspaces[0];
+    const select = node("select", ""); select.setAttribute("aria-label", "本地工作区");
+    for (const workspace of workspaces) { const option = node("option", "", workspace.root); option.value = workspace.id; select.append(option); }
+    select.value = selected.id; select.addEventListener("change", () => go("projects", projectId, select.value));
+    const input = node("input", ""); input.type = "search"; input.placeholder = "关注哪个模块或问题？"; input.maxLength = 2000; input.setAttribute("aria-label", "导览关注点");
+    const detail = node("div", "");
+    let guideGeneration = 0;
+    async function load() {
+      const currentGuide = ++guideGeneration;
+      detail.replaceChildren(empty("读取导览中", "正在核对工作区与代码来源…"));
+      try {
+        const result = await api("workspace", {project_id: projectId, binding_id: selected.id, focus: input.value});
+        if (currentGuide !== guideGeneration) return;
+        const guide = result.guide;
+        detail.replaceChildren(node("div", "row", badge(guide.status, guide.status === "current" ? "good" : "warn"), badge(result.policy.mode), node("span", "meta", `分支 ${result.workspace.branch || "游离 HEAD"} · ${result.workspace.head.slice(0, 10)}${result.workspace.dirty ? " · 有本地修改" : ""}`)));
+        detail.append(node("p", "meta", "导览来源 · " + date(guide.scanned_at)));
+        if (guide.status !== "current") detail.append(node("div", "callout", "代码导览尚未就绪或已过期。请显式扫描后重新读取。"), command(result.commands.scan));
+        const route = node("section", "panel panel-pad", section("建议阅读路线", "基于静态事实与仓库声明"));
+        for (const step of values(guide.reading_path)) {
+          const evidence = node("div", "");
+          const actions = node("div", "actions", button("查看代码依据", async () => {
+            evidence.replaceChildren(node("p", "meta", "正在读取证据…"));
+            try {
+              const r = await api("code", {project_id: projectId, binding_id: selected.id, evidence_id: step.source.evidence_id, start_line: String(step.source.line)});
+              evidence.replaceChildren(r.status === "current_source" ? node("pre", "", r.text) : node("div", "callout", "代码依据已变化，请重新扫描后读取。"), r.truncated ? node("p", "meta", "当前展示部分代码；可在源文件中继续阅读。") : document.createDocumentFragment(), details("证据来源", r));
+            }
+            catch (error) { evidence.replaceChildren(errorBox(error)); }
+          }));
+          if (step.source.url) actions.append(link("在 GitHub 查看", step.source.url));
+          route.append(node("div", "step", node("span", "step-number", step.step), node("div", "step-content", node("h3", "", step.path), node("p", "", step.summary || step.reason), node("div", "row", badge(step.language), node("span", "meta", step.reason)), actions, evidence)));
+        }
+        if (values(guide.reading_path).length) detail.append(route);
+        const clientSelect = node("select", ""); clientSelect.setAttribute("aria-label", "Coding Agent 客户端");
+        const clientNames = {codex: "Codex", "claude-code": "Claude Code", "copilot-vscode": "Copilot · VS Code"};
+        for (const client of Object.keys(result.commands.mcp_clients)) { const option = node("option", "", clientNames[client] || client); option.value = client; clientSelect.append(option); }
+        const preview = node("div", "", command(result.commands.mcp_clients[clientSelect.value]));
+        clientSelect.addEventListener("change", () => preview.replaceChildren(command(result.commands.mcp_clients[clientSelect.value])));
+        detail.append(details("入口、关联模块与覆盖说明", guide), section("在目标项目继续"), clientSelect, preview, node("p", "meta", "复制的是 POSIX 终端命令，保留当前 RepoSteward 配置来源。它预览客户端配置；实际会话由你使用的 Agent 提供。"));
+      } catch (error) { if (error.name !== "AbortError" && currentGuide === guideGeneration) detail.replaceChildren(errorBox(error)); }
+    }
+    input.addEventListener("keydown", event => { if (event.key === "Enter") load(); });
+    host.append(node("div", "toolbar", node("label", "", "本地工作区"), select), node("div", "toolbar", input, button("查阅导览", load)), detail);
+    host.append(omitted(project.workspace_check_omitted, "个工作区")); await load();
+  }
+
+  async function taskPage(host, view, projectId, runId) {
+    host.append(hero(view === "review" ? "让交付依据，可以核对。" : "从上次停下的地方继续。", view === "review" ? "查看历史验证、当前适用性和审阅轨迹。这里的历史判定不授予交付权限。" : "把目标、约束、决定与未完成工作带回你的 Coding Agent。", view === "review" ? "REVIEW EVIDENCE" : "TASK CONTINUITY"));
+    if (!projectCache.length) { host.append(empty("还没有项目", "先关联一个本地项目，再查看任务与检查点。")); return; }
+    projectId = projectId || selectedProject || projectCache[0].id; selectedProject = projectId;
+    projectSelector(host, projectId, id => go(view, id));
+    const project = projectCache.find(p => p.id === projectId);
+    if (!project?.policy.task_access) { host.append(empty("项目策略未启用", "关联工作区后，还需要在 CLI 中配置仓库角色与贡献策略。")); return; }
+    if (!runId) {
+      const result = await api("tasks", {project_id: projectId});
+      host.append(section("最近任务尝试", "每次尝试保留自己的记录"));
+      if (!values(result.tasks).length) host.append(empty("这里还没有任务", "从已审阅 Issue 开始一次任务后，目标、检查点和证据会出现在这里。"));
+      const panel = node("section", "panel");
+      for (const task of values(result.tasks)) {
+        const title = button(task.title || `Issue #${task.issue_number}`, () => go(view, projectId, task.id)); title.className = "task-button";
+        panel.append(node("div", "item", node("div", "", node("div", "row", badge(task.status), node("span", "meta", `#${task.issue_number} · ${task.stage === "external" ? "外部 Agent" : "仓库维护"}`)), node("div", "item-title", title), node("div", "meta", date(task.updated_at))), button("查看" + (view === "review" ? "依据" : "上下文"), () => go(view, projectId, task.id))));
+      }
+      if (result.tasks.length) host.append(panel); host.append(omitted(result.omitted)); return;
+    }
+    host.append(node("div", "actions", button("返回任务列表", () => go(view, projectId)), button(view === "review" ? "任务上下文" : "审阅依据", () => go(view === "review" ? "tasks" : "review", projectId, runId))), node("p", "meta", "任务 · " + runId));
+    if (view === "review") {
+      const result = await api("review", {project_id: projectId, run_id: runId});
+      const trace = result.trace;
+      host.append(node("div", "callout", "以下为已有证据与审计记录。历史验证通过不等于当前可以提交或合并。"));
+      host.append(node("section", "panel panel-pad", section("Issue 最新记录摘要", `#${trace.issue_number} · 包含该 Issue 的多次尝试`), pairs([["后续动作", trace.next_action], ["记录状态", name(trace.current?.status)], ["合并结果", name(trace.current?.merge_outcome)], ["证据 HEAD", trace.current?.head_sha || "未知"], ["覆盖", trace.complete ? "范围内完整" : "有省略或未知"]])));
+      if (result.verification) for (const evidence of values(result.verification.evidence)) host.append(node("section", "panel panel-pad", node("div", "row", badge(evidence.outcome, evidence.outcome === "failed" ? "bad" : ""), badge(evidence.current_applicability, evidence.current_applicability === "matches" ? "good" : "warn")), node("p", "meta", `${evidence.profile} · ${date(evidence.updated_at)}`), list(evidence.validity, "未观察到已检查项的差异。"), details("验证证据", evidence)));
+      host.append(section("任务轨迹", `${trace.stats.events} 条已展示事件`));
+      const panel = node("section", "panel");
+      for (const event of values(trace.events)) panel.append(node("div", "item", node("div", "", node("div", "row", badge(event.source || event.kind), node("span", "meta", date(event.occurred_at))), node("div", "item-title", event.summary || event.event || event.kind || event.id), details("事件依据", event))));
+      host.append(panel, omitted(trace.stats.events_omitted), details("完整范围与来源", result)); return;
+    }
+    const result = await api("task", {project_id: projectId, run_id: runId});
+    const c = result.context;
+    if (!c) { host.append(empty("缺少接续上下文", "这次尝试尚未保存上下文或检查点，可先查看审阅轨迹。")); return; }
+    const external = result.kind === "external";
+    const pack = external ? c : (c.context_pack || {});
+    const checkpoint = external ? c : c.checkpoint;
+    const task = pack.task || {};
+    host.append(node("section", "panel panel-pad", section(task.title || c.work_item?.title || "任务目标"), task.url ? link("查看原始 Issue", task.url) : document.createDocumentFragment(), node("p", "meta", external ? `检查点版本 ${c.revision} · ${name(c.remote_freshness)}` : `上下文保存于 ${date(c.context_metadata?.created_at)}`)));
+    if (!external) host.append(node("div", "callout", "这是已保存的维护上下文，当前工作区适用性尚未重新核对。"));
+    if (external && values(c.validity).length) host.append(node("div", "callout", "当前基线存在变化：", list(c.validity)));
+    if (!checkpoint) host.append(empty("尚无检查点", "当前仍可阅读任务目标与原始上下文。"));
+    const left = node("div", "", node("section", "panel panel-pad", section("未完成工作"), list(external ? c.open_work : checkpoint?.remaining)), node("section", "panel panel-pad", section("已经做出的决定"), list(checkpoint?.decisions)));
+    const right = node("div", "", node("section", "panel panel-pad", section("下一步"), node("p", "", checkpoint?.next_action || "尚未记录"), section("阻塞"), list(checkpoint?.blockers, "尚未记录阻塞。")), node("section", "panel panel-pad", section("接续入口"), command(result.command)));
+    host.append(node("div", "split", left, right));
+    const contract = external ? c.contract : pack.task_contract;
+    if (contract) host.append(node("section", "panel panel-pad", section("目标与验收约束"), node("p", "", contract.goal || "尚未记录目标"), node("h3", "", "验收条件"), list(contract.acceptance_criteria, "原始契约未单列验收条件。"), node("h3", "", "范围约束"), list(contract.scope_boundaries, "原始契约未单列范围约束。"), contract.source_requirements ? node("p", "", contract.source_requirements) : null, details("契约来源与版本", contract)));
+    host.append(details("Agent 自述（尚未独立核验）", external ? c.agent_claims : {completed: checkpoint?.completed, tests_observed: checkpoint?.tests_observed}), details("完整接续数据、来源与省略说明", c), button("复制接续数据", () => copy(JSON.stringify(c, null, 2)), true));
+  }
+
+  async function settings(host) {
+    host.append(hero("知道当前运行的是什么。", "核对安装、配置来源与台账状态；此页只诊断，不执行升级或认证。", "LOCAL DIAGNOSTICS"));
+    const result = await api("settings");
+    const install = result.installation, config = result.configuration;
+    host.append(node("section", "panel panel-pad", section("当前安装"), pairs([["包版本", install.version], ["Python", install.python], ["代码位置", install.module_path], ["来源提交", install.source_revision || "wheel 未提供，请核对安装记录"]])));
+    const panel = node("section", "panel panel-pad", section("本地台账"));
+    for (const [key, database] of Object.entries(result.databases || {})) panel.append(node("div", "item", node("div", "", node("h3", "", key === "tasks" ? "任务数据库" : "项目注册表"), node("p", "meta", database.path), node("span", "meta", `当前 ${database.schema ?? "未知"} / 支持 ${database.supported_schema}`)), badge(database.status, database.status === "compatible" ? "good" : "warn")));
+    host.append(panel, node("section", "panel panel-pad", section("生效配置与来源"), node("pre", "", JSON.stringify(config, null, 2))));
+    if (values(result.next_actions).length) host.append(node("section", "panel panel-pad", section("诊断建议"), list(result.next_actions)));
+    host.append(command("reposteward doctor --local"), node("p", "meta", "配置发生变化后需重启工作台。浏览器会话最长有效 12 小时，进程退出后立即失效。"));
+  }
+
+  async function render() {
+    controller.abort(); controller = new AbortController(); const current = ++generation;
+    let parts;
+    try { parts = location.hash.slice(1).split("/").map(decodeURIComponent); } catch { parts = []; }
+    const view = labels[parts[0]] ? parts[0] : "today";
+    document.getElementById("page-label").textContent = labels[view];
+    document.title = labels[view] + " · RepoSteward";
+    for (const anchor of document.querySelectorAll("nav a")) {
+      if (anchor.dataset.view === view) anchor.setAttribute("aria-current", "page"); else anchor.removeAttribute("aria-current");
+    }
+    content.replaceChildren(); content.setAttribute("aria-busy", "true");
+    if (!token) {
+      content.append(hero("连接你的本地工作空间。", "请使用终端打印的完整会话链接打开。链接只在本机、当前进程内有效。"), command("reposteward web"));
+      connection.textContent = "会话未连接"; connection.className = "badge warn"; content.setAttribute("aria-busy", "false"); return;
+    }
+    const host = node("div", ""); content.append(host);
+    const loading = node("p", "meta", "正在读取本地数据…"); host.append(loading);
+    try {
+      if (view !== "settings") {
+        const result = await api("projects");
+        if (current !== generation) return;
+        projectCache = values(result.projects);
+        if (result.omitted) host.append(omitted(result.omitted, "个项目"));
+      }
+      loading.remove(); connection.textContent = "本地已连接"; connection.className = "badge good";
+      if (view === "today") await today(host);
+      else if (view === "projects") await projects(host, parts[1], parts[2]);
+      else if (view === "settings") await settings(host);
+      else await taskPage(host, view, parts[1], parts[2]);
+    } catch (error) {
+      if (error.name !== "AbortError") { loading.remove(); host.append(errorBox(error)); }
+    } finally { if (current === generation) content.setAttribute("aria-busy", "false"); }
+  }
+  document.querySelector(".skip").addEventListener("click", event => { event.preventDefault(); content.focus(); content.scrollIntoView(); });
+  document.getElementById("reload").addEventListener("click", render);
+  window.addEventListener("hashchange", render);
+  render();
+})();

--- a/src/reposteward/web/index.html
+++ b/src/reposteward/web/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RepoSteward · 本地工作台</title>
+  <link rel="stylesheet" href="/app.css">
+  <script src="/app.js" defer></script>
+</head>
+<body>
+  <a class="skip" href="#content">跳到内容</a>
+  <div class="shell">
+    <aside class="sidebar">
+      <a class="brand" href="#today"><span class="brand-mark" aria-hidden="true">R</span><span>RepoSteward<small>本地维护工作台</small></span></a>
+      <div class="nav-label">工作空间</div>
+      <nav aria-label="主要导航">
+        <a href="#today" data-view="today"><span aria-hidden="true">◷</span>今日待处理</a>
+        <a href="#projects" data-view="projects"><span aria-hidden="true">▦</span>项目空间</a>
+        <a href="#tasks" data-view="tasks"><span aria-hidden="true">☷</span>任务接续</a>
+        <a href="#review" data-view="review"><span aria-hidden="true">◇</span>审阅依据</a>
+        <a href="#settings" data-view="settings"><span aria-hidden="true">⚙</span>设置与诊断</a>
+      </nav>
+      <div class="sidebar-bottom"><span class="live-dot"></span>只读 · 本地连接<p>项目的事实与进度，<br>留在你的工作环境中。</p></div>
+    </aside>
+    <div class="main">
+      <header class="topbar"><div class="breadcrumb">工作空间 <span>/</span> <strong id="page-label">今日待处理</strong></div><div class="top-actions"><span id="connection" class="badge">连接中</span><button id="reload" class="button subtle" type="button">重新读取</button></div></header>
+      <main id="content" tabindex="-1" aria-live="polite"><div class="empty">正在读取本地工作空间…</div></main>
+      <footer>RepoSteward <span>项目事实 · 任务上下文 · 验证证据</span></footer>
+    </div>
+  </div>
+  <div id="notice" role="status" class="toast" hidden></div>
+</body>
+</html>

--- a/src/reposteward/web_server.py
+++ b/src/reposteward/web_server.py
@@ -1,0 +1,233 @@
+"""A bounded loopback-only HTTP adapter; no file server or mutation routes."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import secrets
+import socket
+import sqlite3
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.resources import files
+from threading import BoundedSemaphore
+from urllib.parse import parse_qs, urlsplit
+
+from .config import AppConfig
+from .external_tasks import TaskConflict
+from .projects import ProjectError
+from .workbench import Workbench
+
+MAX_RESPONSE_BYTES = 400_000
+SESSION_SECONDS = 12 * 60 * 60
+ASSETS = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/app.css": ("app.css", "text/css; charset=utf-8"),
+}
+ROUTES = {
+    "/api/overview": ("overview", (), ()),
+    "/api/projects": ("projects", (), ()),
+    "/api/workspace": ("workspace", ("project_id", "binding_id"), ("focus",)),
+    "/api/code": ("code", ("project_id", "binding_id", "evidence_id"), ("start_line",)),
+    "/api/tasks": ("tasks", ("project_id",), ()),
+    "/api/task": ("task", ("project_id", "run_id"), ()),
+    "/api/review": ("review", ("project_id", "run_id"), ()),
+    "/api/settings": ("settings", (), ()),
+}
+
+
+class LocalServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = False
+    request_queue_size = 8
+
+    def __init__(self, app: Workbench, *, port: int = 0):
+        if type(port) is not int or not 0 <= port <= 65535:
+            raise ValueError("port must be between 0 and 65535")
+        self.app = app
+        self.session = secrets.token_urlsafe(32)
+        self.expires = time.monotonic() + SESSION_SECONDS
+        self.slots = BoundedSemaphore(4)
+        self.assets = {
+            route: (files("reposteward").joinpath("web", name).read_bytes(), mime)
+            for route, (name, mime) in ASSETS.items()
+        }
+        super().__init__(("127.0.0.1", port), Handler)
+        self.authority = f"127.0.0.1:{self.server_port}"
+        self.origin = "http://" + self.authority
+
+    @property
+    def url(self) -> str:
+        return self.origin + "/#session=" + self.session
+
+    def get_request(self) -> tuple[socket.socket, tuple]:
+        request, address = super().get_request()
+        request.settimeout(5)
+        return request, address
+
+    def verify_request(self, request, client_address) -> bool:
+        return client_address[0] == "127.0.0.1"
+
+    def process_request(self, request, client_address) -> None:
+        if not self.slots.acquire(blocking=False):
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            self.slots.release()
+            raise
+
+    def process_request_thread(self, request, client_address) -> None:
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self.slots.release()
+
+    def handle_error(self, request, client_address) -> None:
+        # Neither arbitrary requests, repository data nor local session keys go to logs.
+        pass
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: LocalServer
+    server_version = "RepoSteward"
+    sys_version = ""
+
+    def log_message(self, format, *args) -> None:
+        pass
+
+    def _send(self, status: int, body: bytes, mime: str = "application/json") -> None:
+        self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", mime)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header(
+            "Permissions-Policy", "camera=(), microphone=(), geolocation=()"
+        )
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; script-src 'self'; style-src 'self'; "
+            "connect-src 'self'; img-src 'self'; base-uri 'none'; "
+            "frame-ancestors 'none'; form-action 'none'",
+        )
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _error(self, status: int, code: str, message: str) -> None:
+        self._send(
+            status, json.dumps({"error": {"code": code, "message": message}}).encode()
+        )
+
+    def send_error(self, code, message=None, explain=None) -> None:
+        self._error(code, "invalid_request", "请求不可用。请使用工作台提供的入口。")
+
+    def do_GET(self) -> None:
+        try:
+            self._get()
+        except TaskConflict:
+            self._error(409, "changed", "配置或工作区已变化，请核对后重新打开工作台。")
+        except ProjectError:
+            self._error(
+                409,
+                "binding_or_policy",
+                "项目绑定或策略不可用，请在 CLI 检查关联与配置。",
+            )
+        except KeyError:
+            self._error(
+                404, "not_found", "所选项目、工作区或任务不存在，或不属于当前范围。"
+            )
+        except ValueError:
+            self._error(
+                400,
+                "invalid_request",
+                "请求超出读取边界，请检查选择或使用 CLI 查看完整内容。",
+            )
+        except (OSError, RuntimeError, sqlite3.Error):
+            self._error(
+                503,
+                "unavailable",
+                "本地数据暂不可读。请检查设置诊断；其他页面仍可使用。",
+            )
+
+    def _get(self) -> None:
+        if (
+            self.headers.get_all("Host") != [self.server.authority]
+            or self.headers.get_all("Origin") not in (None, [self.server.origin])
+            or self.headers.get("Sec-Fetch-Site", "none") not in {"none", "same-origin"}
+        ):
+            self._error(403, "origin", "仅接受当前本地工作台的请求。")
+            return
+        if (
+            len(self.path) > 4096
+            or len(str(self.headers)) > 16_000
+            or self.headers.get_all("Transfer-Encoding")
+            or self.headers.get_all("Content-Length") not in (None, ["0"])
+        ):
+            self._error(400, "invalid_request", "请求超出读取边界。")
+            return
+        parsed = urlsplit(self.path)
+        if parsed.scheme or parsed.netloc or parsed.fragment or "%" in parsed.path:
+            raise ValueError("invalid route")
+        if parsed.path in self.server.assets and not parsed.query:
+            body, mime = self.server.assets[parsed.path]
+            self._send(200, body, mime)
+            return
+        authorization = self.headers.get_all("Authorization") or []
+        if (
+            len(authorization) != 1
+            or not hmac.compare_digest(
+                authorization[0].encode(), ("Bearer " + self.server.session).encode()
+            )
+            or time.monotonic() >= self.server.expires
+        ):
+            self._error(401, "session", "请用终端打印的本地会话链接重新打开工作台。")
+            return
+        route = ROUTES.get(parsed.path)
+        if route is None:
+            self._error(404, "not_found", "没有这个读取入口。")
+            return
+        method, required, optional = route
+        query = parse_qs(
+            parsed.query, strict_parsing=True, keep_blank_values=True, max_num_fields=6
+        )
+        if (
+            not set(required).issubset(query)
+            or not set(query).issubset((*required, *optional))
+            or any(len(value) != 1 or len(value[0]) > 2000 for value in query.values())
+        ):
+            raise ValueError("invalid query")
+        self.server.app.check_configuration()
+        result = getattr(self.server.app, method)(**{k: v[0] for k, v in query.items()})
+        self.server.app.check_configuration()
+        body = json.dumps(result, ensure_ascii=False).encode()
+        if len(body) > MAX_RESPONSE_BYTES:
+            raise ValueError("read result exceeds response limit")
+        self._send(200, body)
+
+    def do_POST(self) -> None:
+        self._error(405, "read_only", "工作台仅提供读取；请通过已有 CLI 执行明确操作。")
+
+    do_PUT = do_POST
+    do_PATCH = do_POST
+    do_DELETE = do_POST
+    do_OPTIONS = do_POST
+    do_HEAD = do_POST
+
+
+def serve(config: AppConfig, *, port: int = 0) -> None:
+    with LocalServer(Workbench(config), port=port) as server:
+        print(f"RepoSteward 本地工作台：{server.url}", flush=True)
+        print("仅本机、只读。链接在本次进程中有效；按 Ctrl+C 停止。", flush=True)
+        try:
+            server.serve_forever(poll_interval=0.2)
+        except KeyboardInterrupt:
+            pass

--- a/src/reposteward/workbench.py
+++ b/src/reposteward/workbench.py
@@ -1,0 +1,279 @@
+"""Read-only application queries for the local maintainer workbench."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from .config import AppConfig
+from .external_tasks import ExternalTasks, TaskConflict
+from .external_verification import ExternalVerification
+from .lifecycle import build_lifecycle_trace
+from .overview import ProjectOverview
+from .projects import ProjectError, ProjectRegistry
+from .runtime import local_diagnostics
+from .store import Store
+from .understanding import Understanding
+
+
+def identifier(value: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{32}", value):
+        raise ValueError("invalid local identifier")
+    return value
+
+
+class Workbench:
+    """Compose existing reads; never construct Pipeline or a writable Store."""
+
+    def __init__(self, config: AppConfig):
+        api = urlsplit(config.github.api_url)
+        if api.username or api.password or api.query or api.fragment:
+            raise ValueError("correct the API URL using doctor --local first")
+        self.config = config
+        self.registry = ProjectRegistry(config.state_dir / "projects.sqlite3")
+        self.tasks_service = ExternalTasks(config)
+        self.understanding = Understanding(config.state_dir / "understanding")
+        self.config_files = [Path(path) for _, path in config.config_files]
+        self.config_signatures = self._signatures()
+
+    def _signatures(self) -> list:
+        return [
+            (stat.st_ino, stat.st_size, stat.st_mtime_ns)
+            for p in self.config_files
+            for stat in (p.stat(),)
+        ]
+
+    def check_configuration(self) -> None:
+        try:
+            if self._signatures() == self.config_signatures:
+                return
+        except OSError:
+            pass
+        raise TaskConflict("configuration changed; restart the local workbench")
+
+    def _command(self, *arguments: str) -> str:
+        return shlex.join(
+            ["reposteward", "--config", str(self.config.path), *arguments]
+        )
+
+    def _store(self) -> Store:
+        return Store(self.config.state_dir / "reposteward.sqlite3", read_only=True)
+
+    def _role(self, project: dict) -> dict:
+        policy = self.config.repositories.get(project["repository"].casefold())
+        api_host = urlsplit(self.config.github.api_url).hostname
+        host = "github.com" if api_host == "api.github.com" else api_host
+        enabled = bool(policy and policy.enabled and project["host"] == host)
+        return {
+            "mode": policy.mode if policy else "unconfigured",
+            "enabled": enabled,
+            "task_access": enabled,
+        }
+
+    def _project(self, project_id: str, *, tasks: bool = False) -> dict:
+        identifier(project_id)
+        with self.registry.connection() as db:
+            row = (
+                db.execute(
+                    "SELECT * FROM projects WHERE id=?", (project_id,)
+                ).fetchone()
+                if db
+                else None
+            )
+        if row is None:
+            raise KeyError("registered project not found")
+        project = dict(row)
+        if tasks and not self._role(project)["task_access"]:
+            raise ProjectError("project needs an enabled repository policy")
+        return project
+
+    def _binding(self, project_id: str, binding_id: str) -> dict:
+        self._project(project_id)
+        identifier(binding_id)
+        with self.registry.connection() as db:
+            row = db.execute(
+                "SELECT root FROM workspace_bindings WHERE id=? AND project_id=? AND active=1",
+                (binding_id, project_id),
+            ).fetchone()
+        if row is None:
+            raise KeyError("active project workspace not found")
+        linked = self.registry.inspect(Path(row["root"]))
+        if (
+            linked["project"]["id"] != project_id
+            or linked["binding"]["id"] != binding_id
+        ):
+            raise ProjectError("workspace binding changed")
+        return linked
+
+    def projects(self) -> dict:
+        listing = self.registry.list(limit=50)
+        return {
+            **listing,
+            "projects": [{**p, "policy": self._role(p)} for p in listing["projects"]],
+        }
+
+    def overview(self) -> dict:
+        return ProjectOverview(self.config).show(project_limit=20, item_limit=15)
+
+    def workspace(self, project_id: str, binding_id: str, focus: str = "") -> dict:
+        linked = self._binding(project_id, binding_id)
+        root = Path(linked["binding"]["root"])
+        role = self._role(linked["project"])
+        guide = self.understanding.guide(
+            root,
+            mode="contributor" if role["mode"] == "contributor" else "maintainer",
+            focus=focus,
+        )
+        if self._binding(project_id, binding_id)["binding"] != linked["binding"]:
+            raise TaskConflict("workspace binding changed during the read")
+        return {
+            **linked,
+            "policy": role,
+            "guide": guide,
+            "commands": {
+                "scan": self._command("understand", "scan", str(root)),
+                "mcp_clients": {
+                    client: self._command(
+                        "mcp", "config", str(root), "--client", client
+                    )
+                    for client in ("codex", "claude-code", "copilot-vscode")
+                },
+            },
+            "command_shell": "POSIX",
+        }
+
+    def code(
+        self,
+        project_id: str,
+        binding_id: str,
+        evidence_id: str,
+        start_line: str = "1",
+    ) -> dict:
+        if not re.fullmatch(r"code:[0-9a-f]{64}", evidence_id) or not re.fullmatch(
+            r"[1-9][0-9]{0,6}", start_line
+        ):
+            raise ValueError("invalid code evidence request")
+        linked = self._binding(project_id, binding_id)
+        result = self.understanding.evidence(
+            Path(linked["binding"]["root"]),
+            evidence_id,
+            start_line=int(start_line),
+            limit=80,
+        )
+        if self._binding(project_id, binding_id)["binding"] != linked["binding"]:
+            raise TaskConflict("workspace binding changed during the read")
+        return result
+
+    def tasks(self, project_id: str) -> dict:
+        project = self._project(project_id, tasks=True)
+        path = self.config.state_dir / "reposteward.sqlite3"
+        if not path.exists():
+            return {
+                "tasks": [],
+                "omitted": 0,
+                "status": "missing",
+                "public_write": False,
+            }
+        store = self._store()
+        with store._connection() as db:
+            total = db.execute(
+                "SELECT count(*) FROM runs WHERE repository=?",
+                (project["repository"].casefold(),),
+            ).fetchone()[0]
+            rows = db.execute(
+                """SELECT r.id,r.issue_number,r.stage,r.status,r.updated_at,
+                    substr(w.title,1,300) AS title FROM runs r
+                    LEFT JOIN harness_runs h ON h.run_id=r.id
+                    LEFT JOIN work_items w ON w.id=h.work_item_id
+                    WHERE r.repository=? ORDER BY r.updated_at DESC,r.id LIMIT 50""",
+                (project["repository"].casefold(),),
+            ).fetchall()
+        return {
+            "tasks": [dict(row) for row in rows],
+            "omitted": max(0, total - len(rows)),
+            "status": "available",
+            "selection": "recent_attempts",
+            "public_write": False,
+        }
+
+    def _run(self, project_id: str, run_id: str) -> tuple[Store, dict]:
+        project = self._project(project_id, tasks=True)
+        identifier(run_id)
+        store = self._store()
+        run = store.run(run_id)
+        if (
+            run is None
+            or run["repository"].casefold() != project["repository"].casefold()
+        ):
+            raise KeyError("task is outside the selected project")
+        if run["stage"] == "external":
+            record = self.tasks_service._record(store, run_id)
+            if record["project_id"] != project_id:
+                raise ProjectError("external task project binding changed")
+            linked = self._binding(project_id, record["binding_id"])
+            if linked["binding"]["fingerprint"] != record["binding_fingerprint"]:
+                raise ProjectError("external task workspace binding changed")
+        return store, run
+
+    def task(self, project_id: str, run_id: str) -> dict:
+        store, run = self._run(project_id, run_id)
+        external = run["stage"] == "external"
+        context = (
+            self.tasks_service.context(run_id, live=True)
+            if external
+            else store.context_bundle(run_id)
+        )
+        self._run(project_id, run_id)
+        return {
+            "run_id": run_id,
+            "kind": "external" if external else "managed",
+            "context": context,
+            "context_status": "available" if context else "missing",
+            "current_applicability": "see_context_validity"
+            if external
+            else "not_checked",
+            "command": self._command(
+                *[
+                    "task" if external else "context",
+                    "context" if external else "inspect",
+                    run_id,
+                ]
+                + (["--live"] if external else [])
+            ),
+            "public_write": False,
+        }
+
+    def review(self, project_id: str, run_id: str) -> dict:
+        _, run = self._run(project_id, run_id)
+        trace = build_lifecycle_trace(
+            self.config.state_dir,
+            run["repository"],
+            run["issue_number"],
+            event_limit=60,
+        )
+        verification = None
+        if run["stage"] == "external":
+            service = ExternalVerification(self.config)
+            listing = service.list(run_id, limit=3)
+            verification = {
+                **listing,
+                "evidence": [
+                    service.inspect(run_id, e["evidence_id"].split(":")[1], live=True)
+                    for e in listing["evidence"]
+                ],
+            }
+        self._run(project_id, run_id)
+        return {
+            "run_id": run_id,
+            "trace": trace,
+            "verification": verification,
+            "decision_freshness": "historical_only",
+            "publication_eligible": False,
+            "public_write": False,
+        }
+
+    def settings(self) -> dict:
+        report, _ = local_diagnostics(self.config)
+        return report

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import sqlite3
+import unittest
+from contextlib import closing, redirect_stdout
+from dataclasses import replace
+from unittest.mock import patch
+
+import test_external_tasks
+from test_projects import repository
+
+from reposteward.cli import main
+from reposteward.external_tasks import TaskConflict
+from reposteward.lifecycle import build_lifecycle_trace
+from reposteward.mcp_bridge import ScopedBridge
+from reposteward.overview import ProjectOverview
+from reposteward.projects import ProjectError
+from reposteward.store import Store, StoreError
+from reposteward.workbench import Workbench
+
+
+class WorkbenchTests(unittest.TestCase):
+    def setUp(self):
+        test_external_tasks.ExternalTaskTests.setUp(self)
+        (self.repo / "app.py").write_text(
+            '"""Entry point for the workbench fixture."""\ndef main():\n    return "hello"\n'
+        )
+        self.task = self.service.start(self.repo, issue_number=7, reviewed_by="owner")
+        test_external_tasks.ExternalTaskTests.checkpoint(self, self.task["run_id"])
+        self.app = Workbench(self.config)
+        self.project_id = self.task["project_id"]
+        self.binding_id = self.task["binding_id"]
+        self.app.understanding.scan(self.repo)
+
+    def second(self):
+        root = repository(
+            self.root / "second", remote="https://github.com/owner/second"
+        )
+        linked = self.app.registry.link(root)
+        policy = replace(self.config.repositories["owner/repo"], name="owner/second")
+        self.config = replace(
+            self.config,
+            repositories={**self.config.repositories, "owner/second": policy},
+        )
+        self.app = Workbench(self.config)
+        return root, linked
+
+    def test_external_context_and_guide_match_cli_and_mcp(self):
+        run_id = self.task["run_id"]
+        bridge = ScopedBridge(self.config, self.repo)
+        response = self.app.task(self.project_id, run_id)
+        self.assertEqual(
+            response["context"], bridge.call("context", {"run_id": run_id})
+        )
+        self.assertEqual(response["context"]["open_work"], ["Handle empty input"])
+        output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            redirect_stdout(output),
+        ):
+            self.assertEqual(main(["task", "context", run_id, "--live"]), 0)
+        self.assertEqual(response["context"], json.loads(output.getvalue()))
+        workspace = self.app.workspace(self.project_id, self.binding_id)
+        self.assertEqual(
+            workspace["guide"], bridge.call("understanding", {"action": "guide"})
+        )
+        source = workspace["guide"]["reading_path"][0]["source"]
+        self.assertEqual(
+            self.app.code(self.project_id, self.binding_id, source["evidence_id"]),
+            bridge.call(
+                "understanding",
+                {"action": "evidence", "evidence_id": source["evidence_id"]},
+            ),
+        )
+
+    def test_reads_do_not_write_authenticate_or_start_pipeline(self):
+        paths = [
+            self.config.state_dir / name
+            for name in ("reposteward.sqlite3", "projects.sqlite3")
+        ]
+        before = [p.read_bytes() for p in paths]
+        initialize = Store.__init__
+
+        def guarded(instance, path, *, read_only=False):
+            self.assertTrue(read_only)
+            initialize(instance, path, read_only=read_only)
+
+        with (
+            patch.object(Store, "__init__", guarded),
+            patch(
+                "reposteward.github.resolve_token", side_effect=AssertionError("auth")
+            ),
+            patch("reposteward.cli.Pipeline", side_effect=AssertionError("Pipeline")),
+            patch(
+                "reposteward.overview.GitHubClient",
+                side_effect=AssertionError("network"),
+            ),
+        ):
+            self.app.projects()
+            self.app.overview()
+            self.app.workspace(self.project_id, self.binding_id)
+            self.app.tasks(self.project_id)
+            self.app.task(self.project_id, self.task["run_id"])
+            self.app.review(self.project_id, self.task["run_id"])
+            self.app.settings()
+        self.assertEqual(before, [p.read_bytes() for p in paths])
+
+    def test_cross_project_run_binding_and_evidence_are_rejected(self):
+        root, linked = self.second()
+        pid, bid = linked["project"]["id"], linked["binding"]["id"]
+        self.app.understanding.scan(root)
+        evidence = self.app.workspace(self.project_id, self.binding_id)["guide"][
+            "reading_path"
+        ][0]["source"]["evidence_id"]
+        with self.assertRaises(KeyError):
+            self.app.task(pid, self.task["run_id"])
+        with self.assertRaises(KeyError):
+            self.app.review(pid, self.task["run_id"])
+        with self.assertRaises(KeyError):
+            self.app.workspace(pid, self.binding_id)
+        with self.assertRaises(ProjectError):
+            self.app.code(pid, bid, evidence)
+
+    def test_unlink_and_replaced_workspace_revoke_detail_access(self):
+        self.app.registry.unlink(self.binding_id)
+        with self.assertRaises(KeyError):
+            self.app.task(self.project_id, self.task["run_id"])
+        self.app.registry.link(self.repo)
+        moved = self.repo.with_name("moved")
+        self.repo.rename(moved)
+        repository(self.repo)
+        with self.assertRaises(ProjectError):
+            self.app.workspace(self.project_id, self.binding_id)
+
+    def test_changed_source_is_stale_without_an_implicit_scan(self):
+        (self.repo / "source.txt").write_text("changed\n")
+        with patch.object(
+            self.app.understanding, "scan", side_effect=AssertionError("scan")
+        ):
+            self.assertEqual(
+                self.app.workspace(self.project_id, self.binding_id)["guide"]["status"],
+                "stale",
+            )
+        context = self.app.task(self.project_id, self.task["run_id"])["context"]
+        self.assertIn("workspace_changed_since_checkpoint", context["validity"])
+
+    def test_one_unavailable_workspace_keeps_the_other_project_visible(self):
+        root, linked = self.second()
+        shutil.rmtree(self.repo)
+        projects = self.app.projects()["projects"]
+        self.assertEqual(len(projects), 2)
+        self.assertEqual(sum(p["missing_workspaces"] for p in projects), 1)
+        self.assertEqual(
+            self.app.workspace(linked["project"]["id"], linked["binding"]["id"])[
+                "guide"
+            ]["status"],
+            "not_scanned",
+        )
+        self.assertFalse(
+            (self.config.state_dir / "understanding").joinpath(root.name).exists()
+        )
+        self.assertEqual(len(self.app.overview()["projects"]), 2)
+
+    def test_missing_and_newer_state_are_not_initialized_or_migrated(self):
+        app = Workbench(replace(self.config, state_dir=self.root / "missing"))
+        self.assertEqual(app.projects()["projects"], [])
+        self.assertEqual(app.overview()["projects"], [])
+        self.assertEqual(app.settings()["databases"]["tasks"]["status"], "missing")
+        self.assertFalse((self.root / "missing").exists())
+        path = self.config.state_dir / "reposteward.sqlite3"
+        with closing(sqlite3.connect(path)) as db:
+            db.execute("PRAGMA user_version=99")
+        before = path.read_bytes()
+        with self.assertRaises(StoreError):
+            self.app.tasks(self.project_id)
+        self.assertEqual(
+            self.app.settings()["databases"]["tasks"]["status"], "newer_than_supported"
+        )
+        self.assertEqual(before, path.read_bytes())
+
+    def test_policy_and_configuration_changes_do_not_silently_grant_access(self):
+        policy = replace(self.config.repositories["owner/repo"], enabled=False)
+        app = Workbench(replace(self.config, repositories={"owner/repo": policy}))
+        self.assertFalse(app.projects()["projects"][0]["policy"]["task_access"])
+        with self.assertRaises(ProjectError):
+            app.task(self.project_id, self.task["run_id"])
+        app.config_files[0].write_text("changed configuration")
+        with self.assertRaises(TaskConflict):
+            app.check_configuration()
+
+    def test_managed_context_and_review_remain_historical_evidence(self):
+        store = self.service._store(write=True)
+        run_id = self.task["run_id"]
+        store.update_run(run_id, status="submitted", stage="pull_request", details={})
+        self.assertEqual(
+            self.app.task(self.project_id, run_id)["context"],
+            store.context_bundle(run_id),
+        )
+        self.assertEqual(
+            self.app.task(self.project_id, run_id)["current_applicability"],
+            "not_checked",
+        )
+        review = self.app.review(self.project_id, run_id)
+        self.assertEqual(
+            review["trace"],
+            build_lifecycle_trace(
+                self.config.state_dir, "owner/repo", 7, event_limit=60
+            ),
+        )
+        self.assertFalse(review["publication_eligible"])
+        self.assertEqual(review["decision_freshness"], "historical_only")
+
+    def test_overview_preserves_the_shared_fact_digest(self):
+        self.assertEqual(
+            self.app.overview()["overview_digest"],
+            ProjectOverview(self.config).show(project_limit=20, item_limit=15)[
+                "overview_digest"
+            ],
+        )
+
+    def test_cli_web_uses_explicit_scope_without_pipeline(self):
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            patch("reposteward.cli.Pipeline", side_effect=AssertionError("Pipeline")),
+            patch("reposteward.web_server.serve") as serve,
+        ):
+            self.assertEqual(
+                main(
+                    [
+                        "web",
+                        "--port",
+                        "8765",
+                        "--expect-state-dir",
+                        str(self.config.state_dir),
+                    ]
+                ),
+                0,
+            )
+            serve.assert_called_once_with(self.config, port=8765)
+
+    def test_unsafe_api_origin_is_not_exposed_via_derived_paths(self):
+        config = replace(
+            self.config,
+            github=replace(self.config.github, api_url="https://secret@api.github.com"),
+        )
+        with self.assertRaisesRegex(ValueError, "correct the API URL"):
+            Workbench(config)

--- a/tests/test_workbench_http.py
+++ b/tests/test_workbench_http.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from threading import Thread
+from unittest.mock import Mock
+
+from reposteward.external_tasks import TaskConflict
+from reposteward.web_server import LocalServer
+
+
+class WorkbenchHTTPTests(unittest.TestCase):
+    def setUp(self):
+        self.app = Mock()
+        self.app.settings.return_value = {"status": "local", "public_write": False}
+        self.server = LocalServer(self.app)
+        self.thread = Thread(
+            target=self.server.serve_forever,
+            kwargs={"poll_interval": 0.01},
+            daemon=True,
+        )
+        self.thread.start()
+        self.addCleanup(self.close_server)
+
+    def close_server(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.assertFalse(self.thread.is_alive())
+
+    def request(self, path="/api/settings", *, method="GET", headers=None, token=True):
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", self.server.server_port, timeout=5
+        )
+        default = {"Authorization": "Bearer " + self.server.session} if token else {}
+        try:
+            connection.request(method, path, headers={**default, **(headers or {})})
+            response = connection.getresponse()
+            return response.status, dict(response.getheaders()), response.read()
+        finally:
+            connection.close()
+
+    def test_loopback_session_and_fixed_assets(self):
+        self.assertEqual(self.server.server_address[0], "127.0.0.1")
+        self.assertFalse(self.server.verify_request(None, ("192.0.2.1", 1234)))
+        self.assertIn("/#session=", self.server.url)
+        status, headers, body = self.request("/", token=False)
+        self.assertEqual(status, 200)
+        self.assertIn(b"RepoSteward", body)
+        self.assertNotIn(self.server.session.encode(), body)
+        self.assertEqual(headers["Cache-Control"], "no-store")
+        self.assertIn("frame-ancestors 'none'", headers["Content-Security-Policy"])
+        for path in ("/app.js", "/app.css"):
+            self.assertEqual(self.request(path, token=False)[0], 200)
+        self.assertEqual(self.request(token=False)[0], 401)
+        self.assertEqual(self.request()[0], 200)
+        self.app.check_configuration.assert_called()
+
+    def test_host_origin_and_fetch_metadata_are_checked_even_with_session(self):
+        for headers in (
+            {"Host": "evil.example"},
+            {"Host": "localhost:" + str(self.server.server_port)},
+            {"Origin": "https://evil.example"},
+            {"Origin": "null"},
+            {"Sec-Fetch-Site": "cross-site"},
+            {"Sec-Fetch-Site": "same-site"},
+        ):
+            with self.subTest(headers=headers):
+                self.assertEqual(self.request(headers=headers)[0], 403)
+                self.assertEqual(self.request("/", headers=headers)[0], 403)
+        self.assertEqual(
+            self.request(
+                headers={"Origin": self.server.origin, "Sec-Fetch-Site": "same-origin"}
+            )[0],
+            200,
+        )
+
+    def test_stale_wrong_and_duplicate_sessions_are_rejected(self):
+        self.assertEqual(
+            self.request(headers={"Authorization": "Bearer wrong"})[0], 401
+        )
+        self.assertEqual(self.request(headers={"Authorization": "Bearer café"})[0], 401)
+        self.server.expires = time.monotonic() - 1
+        self.assertEqual(self.request()[0], 401)
+        self.app.settings.assert_not_called()
+
+    def test_duplicate_host_or_authorization_header_is_rejected(self):
+        for header, value, expected in (
+            ("Host", self.server.authority, 403),
+            ("Authorization", "Bearer " + self.server.session, 401),
+        ):
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", self.server.server_port, timeout=5
+            )
+            try:
+                connection.putrequest("GET", "/api/settings")
+                connection.putheader("Authorization", "Bearer " + self.server.session)
+                connection.putheader(header, value)
+                connection.endheaders()
+                response = connection.getresponse()
+                self.assertEqual(response.status, expected)
+                response.read()
+            finally:
+                connection.close()
+
+    def test_write_methods_and_request_bodies_never_reach_services(self):
+        for method in ("POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"):
+            self.assertEqual(self.request(method=method)[0], 405)
+        for headers in ({"Content-Length": "8"}, {"Transfer-Encoding": "chunked"}):
+            self.assertEqual(self.request(headers=headers)[0], 400)
+        self.app.settings.assert_not_called()
+
+    def test_only_fixed_routes_and_declared_bounded_parameters_are_accepted(self):
+        self.assertEqual(self.request("http://evil.example/api/settings")[0], 403)
+        for path in ("/../.env", "/api/refresh", "/favicon.ico"):
+            self.assertEqual(self.request(path)[0], 404)
+        for path in (
+            "/%2e%2e/.env",
+            "/api/settings?path=/etc/passwd",
+            "/api/settings?x=1&x=2",
+            "/api/workspace?project_id=abc",
+            "/api/settings?" + "x" * 5000,
+        ):
+            self.assertEqual(self.request(path)[0], 400)
+        self.app.settings.assert_not_called()
+
+    def test_untrusted_errors_requests_and_tokens_do_not_enter_logs_or_html(self):
+        secret = "private-test-value"
+        self.app.settings.side_effect = RuntimeError(secret)
+        logs = io.StringIO()
+        with redirect_stderr(logs):
+            status, headers, body = self.request("/api/settings")
+            self.request("/not-found?secret=" + secret)
+        self.assertEqual(status, 503)
+        self.assertIn("application/json", headers["Content-Type"])
+        self.assertNotIn(secret, body.decode())
+        self.assertNotIn(secret, logs.getvalue())
+        self.assertNotIn(self.server.session, logs.getvalue())
+        self.assertNotIn("Access-Control-Allow-Origin", headers)
+
+    def test_changed_configuration_and_large_results_fail_without_partial_data(self):
+        self.app.check_configuration.side_effect = TaskConflict("changed")
+        self.assertEqual(self.request()[0], 409)
+        self.app.check_configuration.side_effect = [
+            None,
+            TaskConflict("changed during read"),
+        ]
+        self.assertEqual(self.request()[0], 409)
+        self.app.check_configuration.side_effect = None
+        self.app.settings.return_value = {"data": "x" * 400001}
+        status, _, body = self.request()
+        self.assertEqual(status, 400)
+        self.assertNotIn("data", json.loads(body))
+
+    @unittest.skipUnless(
+        shutil.which("node"), "Node is available in the verifier image"
+    )
+    def test_packaged_javascript_parses(self):
+        data = self.server.assets["/app.js"][0]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "app.js"
+            path.write_bytes(data)
+            result = subprocess.run(
+                ["node", "--check", str(path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
Closes #129

运行 reposteward web 后从本机浏览器访问工作台，按已登记项目和任务切换，阅读可回查的当前事实与历史证据，复制接续命令；浏览器读取不修改任务状态或公开写入。

---

新增按需启动的 reposteward web，提供今日待处理、项目/代码导览、任务接续、审阅依据、设置诊断。Workbench查询层复用现有只读服务；固定127.0.0.1 HTTP适配校验Host/Origin/本次进程会话和登记项目/任务绑定，限制并发和响应，页面以文本呈现仓库内容。HTML/CSS/JS随wheel安装，无日用Node依赖。导览提供Codex、Claude Code、Copilot(VS Code)的MCP配置预览命令，保留配置路径；任务保持CLI/MCP原始预算及来源信息，契约以可读目标和条件显示。

验证：加固DockerVerifier内全量582项测试（含21项新回归）、ruff、格式、CLI smoke和构建；额外使用安装wheel的真实Chromium/Playwright流程，验证RepoSteward与Flask项目切换和阅读路线、过期代码提示、合成任务的上下文复制与历史审阅、三客户端配置预览、桌面/窄屏、会话刷新与空库CLI启动/退出。网页读取前后台账文件摘要相同，浏览器请求均为本机GET，无页面脚本异常。首次开发全量检查曾有既有MCP协议测试5秒启动超时，后续全量通过，未放宽测试时限。

边界：此版为单机只读入口；扫描、线上缓存刷新和交付仍通过既有显式CLI。历史验证或合并判定不代表当前授权。配置变化需重启，详情超过400KB明确拒绝并提示CLI；来源和省略信息保留。双项目验收使用公开代码副本，任务台账为合成数据；不将其计为新的Claude/Copilot真实会话或人工效率收益。没有新增数据库表、日用依赖或workflow改动。

Verified with `uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v`, `uvx ruff check .`, `uvx ruff format --check .`, `uv run reposteward --help`, `uv build`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `tiammomo` reviewed the final diff, understands it, and takes responsibility
for this contribution.
