### PR TITLE
fix(verification): API 重试、Runner JDK 17 与 JVM user.home 固定

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -18,26 +18,28 @@ ARG HELM_SHA256=0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         aspell aspell-en build-essential ca-certificates curl git git-lfs unzip \
+        openjdk-17-jdk-headless \
         libasound2 libatk-bridge2.0-0 libatk1.0-0 libcups2 libdbus-1-3 \
         libgbm1 libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxdamage1 \
         libxfixes3 libxkbcommon0 libxrandr2 \
-    && curl --fail --location --silent --show-error "$TEMURIN_8_URL" --output /tmp/temurin.tar.gz \
+    && curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 2 "$TEMURIN_8_URL" --output /tmp/temurin.tar.gz \
     && echo "$TEMURIN_8_SHA256  /tmp/temurin.tar.gz" | sha256sum --check - \
-    && curl --fail --location --silent --show-error \
-        "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" \
+    && curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 2 \
+        "https://mirrors.tuna.tsinghua.edu.cn/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" \
         --output /tmp/maven.tar.gz \
     && echo "$MAVEN_SHA512  /tmp/maven.tar.gz" | sha512sum --check - \
-    && curl --fail --location --silent --show-error \
+    && curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 2 \
         "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip" \
         --output /tmp/protoc.zip \
     && echo "$PROTOC_SHA256  /tmp/protoc.zip" | sha256sum --check - \
-    && curl --fail --location --silent --show-error \
+    && curl --fail --location --silent --show-error --retry 5 --retry-all-errors --retry-delay 2 \
         "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz" \
         --output /tmp/helm.tar.gz \
     && echo "$HELM_SHA256  /tmp/helm.tar.gz" | sha256sum --check - \
     && mkdir -p /opt/java/temurin-8u502-b07 /opt/maven/apache-maven-$MAVEN_VERSION \
         /opt/protobuf/protoc-$PROTOC_VERSION \
     && tar -xzf /tmp/temurin.tar.gz --strip-components=1 -C /opt/java/temurin-8u502-b07 \
+    && ln -s /usr/lib/jvm/java-17-openjdk-amd64 /opt/java/temurin-17 \
     && tar -xzf /tmp/maven.tar.gz --strip-components=1 -C /opt/maven/apache-maven-$MAVEN_VERSION \
     && unzip -q /tmp/protoc.zip -d /opt/protobuf/protoc-$PROTOC_VERSION \
     && tar -xzf /tmp/helm.tar.gz -C /tmp \

--- a/src/reposteward/github.py
+++ b/src/reposteward/github.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
 import os
 import re
@@ -144,23 +145,42 @@ class GitHubClient:
         }
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-        request = urllib.request.Request(url, data=body, headers=headers, method=method)
-        try:
-            response = urllib.request.urlopen(request, timeout=30)
-            payload_bytes = response.read()
-        except urllib.error.HTTPError as exc:
-            error_body = exc.read().decode("utf-8", errors="replace")
-            message = error_body
+        # GET 请求在瞬时网络错误（截断响应、连接重置等）下重试；POST/PATCH 可能非幂等，不重试
+        attempts = 5 if method == "GET" else 1
+        last_error: Exception | None = None
+        for attempt in range(attempts):
+            request = urllib.request.Request(
+                url, data=body, headers=headers, method=method
+            )
             try:
-                message = json.loads(error_body).get("message", error_body)
-            except json.JSONDecodeError:
-                pass
+                response = urllib.request.urlopen(request, timeout=30)
+                payload_bytes = response.read()
+                last_error = None
+                break
+            except urllib.error.HTTPError as exc:
+                error_body = exc.read().decode("utf-8", errors="replace")
+                message = error_body
+                try:
+                    message = json.loads(error_body).get("message", error_body)
+                except json.JSONDecodeError:
+                    pass
+                raise GitHubError(
+                    f"GitHub {method} {path} failed ({exc.code}): {message}",
+                    status_code=exc.code,
+                ) from exc
+            except (
+                urllib.error.URLError,
+                http.client.IncompleteRead,
+                ConnectionResetError,
+                TimeoutError,
+            ) as exc:
+                last_error = exc
+                if attempt + 1 < attempts:
+                    time.sleep((attempt + 1) ** 2)
+        if last_error is not None:
             raise GitHubError(
-                f"GitHub {method} {path} failed ({exc.code}): {message}",
-                status_code=exc.code,
-            ) from exc
-        except urllib.error.URLError as exc:
-            raise GitHubError(f"GitHub {method} {path} failed: {exc.reason}") from exc
+                f"GitHub {method} {path} failed after retries: {last_error}"
+            ) from last_error
         if response.status not in set(expected):
             raise GitHubError(
                 f"GitHub {method} {path} returned unexpected status {response.status}"

--- a/src/reposteward/verifier.py
+++ b/src/reposteward/verifier.py
@@ -539,6 +539,11 @@ class DockerVerifier:
             "PNPM_HOME=/reposteward-env/pnpm-home",
             "-e",
             "GRADLE_USER_HOME=/reposteward-env/gradle",
+            # 容器以 host uid 运行且镜像内无对应 passwd 条目时，部分 JDK 会把
+            # user.home 解析为 "?"，导致 Maven 等工具把缓存写到工作区内随沙箱销毁。
+            # 固定 user.home 到持久卷，保证 bootstrap 下载的依赖在断网 verify 阶段可用。
+            "-e",
+            "JAVA_TOOL_OPTIONS=-Duser.home=/reposteward-env/home",
             "-v",
             f"{worktree.resolve()}:/workspace:rw",
             "-v",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http.client
 import io
 import unittest
 import urllib.error
@@ -967,6 +968,41 @@ class GitHubActionsEvidenceTests(unittest.TestCase):
             self.assertRaisesRegex(GitHubError, "unsafe redirect"),
         ):
             client.workflow_job_log("owner/repo", 20, max_bytes=12)
+
+    def test_get_request_retries_transient_transport_errors(self) -> None:
+        class FakeResponse(io.BytesIO):
+            def __init__(self, payload: bytes) -> None:
+                super().__init__(payload)
+                self.status = 200
+
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        responses = [
+            http.client.IncompleteRead(b'{"login": "pw', 5),
+            FakeResponse(b'{"login": "pwd11"}'),
+        ]
+        with (
+            patch("urllib.request.urlopen", side_effect=responses) as urlopen_mock,
+            patch("time.sleep", return_value=None) as sleep_mock,
+        ):
+            payload, _ = client._request("GET", "/user")
+
+        self.assertEqual(payload, {"login": "pwd11"})
+        self.assertEqual(urlopen_mock.call_count, 2)
+        sleep_mock.assert_called_once_with(1)
+
+    def test_post_request_does_not_retry_transient_transport_errors(self) -> None:
+        client = GitHubClient(GitHubConfig(), token="test-token")
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=http.client.IncompleteRead(b"{}", 1),
+            ),
+            patch("time.sleep") as sleep_mock,
+            self.assertRaisesRegex(GitHubError, "failed after retries"),
+        ):
+            client._request("POST", "/issues", data={"title": "x"})
+
+        sleep_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -549,6 +549,9 @@ class VerificationSandboxTests(unittest.TestCase):
         self.assertIn(f"{environment.resolve()}:/reposteward-env:rw", command)
         self.assertIn(f"{git_dir.resolve()}:/reposteward-git:ro", command)
         self.assertIn("none", command)
+        # JVM user.home 固定到持久卷，避免无 passwd 条目时解析为 "?" 导致缓存丢失
+        env_index = command.index("JAVA_TOOL_OPTIONS=-Duser.home=/reposteward-env/home")
+        self.assertEqual(command[env_index - 1], "-e")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 关联 Issue

Closes #134

## 问题与改动

受限网络环境（github.com:443 间歇断流、api.github.com 大响应被截断）下实测暴露验证链路三个可靠性问题，三个聚焦提交分别修复：

1. **GitHub API 无瞬时错误重试**：`GitHubClient._request` 单次请求，约 750KB 的 open pull requests 列表间歇性 `IncompleteRead`，gate/adopt 随机失败。改为 GET 最多 5 次尝试、平方退避（1/4/9/16s）；POST/PATCH 非幂等不重试。重试成功后清除 `last_error` 避免误报。
2. **JVM user.home 解析为 "?"**：容器以 host uid 运行且镜像内无 passwd 条目时，JDK 将 user.home 解析为字面量 "?"，Maven/JGit 缓存落到工作区内随沙箱销毁，bootstrap 下载的依赖在断网 verify 阶段全部失效。在容器环境注入 `JAVA_TOOL_OPTIONS=-Duser.home=/reposteward-env/home`（持久卷），覆盖所有 Java 进程。
3. **Runner 镜像缺少 JDK 17 且下载易失败**：apt 安装 openjdk-17-jdk-headless 并链接为 `/opt/java/temurin-17`（默认 JDK 8 不变）；Maven 发行版改 TUNA 镜像（SHA512 校验不变）；所有 curl 加 `--retry 5 --retry-all-errors`。

## 验证

```text
$ uv run --python 3.12 python -m unittest discover -s tests
Ran 584 tests in 207.300s
OK

$ uvx ruff check .
All checks passed!

$ uvx ruff format --check .
135 files already formatted

$ uv build
Successfully built dist/reposteward-0.1.0.tar.gz / .whl

$ uv run reposteward image build   # 新镜像构建成功（Temurin 8 + apt JDK 17 + TUNA maven）
```

端到端证据（本机受限网络实测）：使用新镜像对 spring-ai-alibaba/DataAgent 完成两次 adopt 全流程，bootstrap 联网下载 + 断网 verify（1712/1715 个 Java 测试、spotless、checkstyle）全部通过；此前相同流程因 user.home="?" 与 API 截断反复失败。新增回归测试：`test_get_request_retries_transient_transport_errors`、`test_post_request_does_not_retry_transient_transport_errors`、`test_container_receives_shared_cache_and_read_only_git_mounts` 中补充 JAVA_TOOL_OPTIONS 断言。

## 风险与兼容性

- `JAVA_TOOL_OPTIONS` 会打印 "Picked up JAVA_TOOL_OPTIONS" 到 stderr（无害）；对非 Java 仓库无影响
- Runner 镜像默认 JDK 仍为 8，`/opt/java/current` 链接未变，既有仓库行为不变；镜像体积增加约 300MB
- Dockerfile 下载源变化均保留 SHA 校验；POST/PATCH 不重试，公开写入路径语义不变

## 自动化辅助

使用 Claude Code 实现与验证；人工复核了完整 diff、三个提交边界、测试结果与镜像构建日志。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
