### PR TITLE
feat(usage): collect task-bound Codex session usage without storing transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,18 @@ uv run reposteward branch-cleanup plan owner/repository --format text
 uv run reposteward batch plan owner/repository --format text
 uv run reposteward trace owner/repository 123 --format text
 uv run reposteward usage report owner/repository
+uv run reposteward usage external-report owner/repository
 uv run reposteward storage stats --repo owner/repository
 uv run reposteward benchmark run --output .artifacts/benchmark.json
 ```
 
 The persistent queue and batch planner store bounded control-plane intent. They do not
 turn on submit, owner-attestation, or merge permissions.
+
+For an existing Codex session, [external usage collection](docs/external-usage.md)
+binds explicit turns to an external task and refreshes real client counters with
+`usage collect RUN_ID`. Missing metrics and prices remain unknown; reports retain
+no conversation text. Savings comparisons wait for real usage data.
 
 For maintainer same-repository policies, `branch-cleanup plan` builds a read-only,
 digest-bound backlog from submitted runs and successful merge audits. Applying a

--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -1,0 +1,87 @@
+# External Coding Agent usage collection
+
+Use this local collector when developing with an existing Codex session. It
+associates explicitly selected **turns** with a registered external task or an
+adopted workspace run. It does not launch an agent, access GitHub, scan session
+history, or save prompts, responses, tool arguments, or credentials.
+
+## Collect and refresh
+
+Start a reviewed external task with `reposteward task start`, or use the `RUN_ID`
+from `reposteward adopt`. Select the local rollout file and the `turn_id` from
+its `turn_context` metadata. Select only turns devoted to this Issue. A turn
+mixing multiple tasks cannot be apportioned reliably and should be left unbound.
+
+```bash
+reposteward usage collect RUN_ID \
+  --codex-session /path/to/selected-rollout.jsonl \
+  --turn-id SELECTED_TURN_ID
+
+# Register more explicit turns using another --turn-id (or a later invocation).
+# Refresh all sources already bound to this WorkItem, without discovering others:
+reposteward usage collect RUN_ID
+
+reposteward usage external-report owner/repository --issue 123 --include-turns
+reposteward usage external-report owner/repository --group-by model
+```
+
+Repeat collection at task checkpoints and after the selected turn completes.
+There is no background watcher. Reports show the last successfully collected
+snapshot, its collection time, and whether each turn completed, was interrupted,
+or remains in progress. A running turn's values are provisional. A successor run
+for the same WorkItem refreshes the same records; a different WorkItem cannot
+claim an already bound session/turn pair. Cwd is checked against the task's
+repository and configured GitHub host, allowing another clone or worktree of
+that project. This verifies a local association, not that the source is authentic.
+
+## Counting and uncertainty
+
+Codex `token_count` updates contain cumulative **session** totals. The adapter
+subtracts the latest baseline before the selected turn from its last observed
+update, checking intermediate values for regression. Repeated updates are not
+summed. Repeated `turn_context` records within a turn do not reset the baseline.
+Identical `session_meta` records appended when resuming also preserve the baseline.
+Missing baseline or individual counters produce `null` and explicit unknown
+reasons; the collector never assumes that a partial session starts at zero.
+Consequently, the first turn of a rollout may have unknown usage.
+
+Cached input is a subset of input, and reasoning output is a subset of output.
+Neither is added again to the total. Tool-call counts and active work duration
+remain unknown in this adapter. A model change within a turn makes per-model
+attribution and price unknown. A cache hit count alone does not establish Token
+or monetary savings relative to another development workflow.
+
+`cost_estimate` uses only the trusted user's configured `observability.prices`
+entries with harness `codex-local`, a matching model, and effective date. Missing
+prices or required metrics remain unknown; nonzero cache-write counts currently
+have unsupported pricing. Estimates are for the observed counters and are not
+subscription charges or provider invoices. This report is separate from native
+`usage report`, avoiding a second count of managed Harness runs.
+
+## Compatibility, persistence, and recovery
+
+Adapter v1 supports the locally verified Codex CLI **0.153.0** rollout shape.
+Rollouts are an internal client format. Other versions or malformed metadata
+fail explicitly and require adapter review; they are not silently interpreted
+as zero. The official [non-interactive interface](https://learn.chatgpt.com/docs/non-interactive-mode)
+and [app-server interface](https://learn.chatgpt.com/docs/app-server) expose other
+usage events; this adapter does not claim their formats are interchangeable.
+
+Collection streams at most 256 MiB, one million records, and 4 MiB per line from
+one explicitly selected regular file. The unfinished final JSONL line is retried
+on the next refresh. Previously read complete bytes must remain unchanged.
+Truncation, rewriting, ambiguous turn ordering, changed source identity, and
+counter resets fail without replacing existing observations. Restore the original
+source before retrying; a moved source path is not automatically rebound.
+
+The independent schema-v1 `external-usage.sqlite3` in the effective state
+directory stores source paths, prefix hashes, session/turn identities, task
+associations, counters, model/version/timestamps, and normalized observation
+history. New databases use owner-only permissions. It does not migrate the core
+task database. Read-only reports do not create either database or initialize a
+GitHub client. Collection is atomic per source; retrying after a later source
+fails is safe. Hashes support local integrity checks, not billing authenticity.
+
+Keep this database and source files private and outside Git. Reports cover only
+explicitly selected turns. Real workflow savings comparisons (P2), additional
+agent adapters, and automatic collection should follow actual usage evidence.

--- a/src/reposteward/cli.py
+++ b/src/reposteward/cli.py
@@ -459,6 +459,24 @@ def _parser() -> argparse.ArgumentParser:
         "usage", help="report prompt-free Harness usage and configured cost"
     )
     usage_commands = usage.add_subparsers(dest="usage_command", required=True)
+    usage_collect = usage_commands.add_parser(
+        "collect", help="collect selected local Codex turns for an external task"
+    )
+    usage_collect.add_argument("run_id")
+    usage_collect.add_argument("--codex-session", type=Path)
+    usage_collect.add_argument("--turn-id", action="append", default=[])
+    external_report = usage_commands.add_parser(
+        "external-report",
+        help="report locally collected external turns without GitHub access",
+    )
+    external_report.add_argument("repository")
+    external_report.add_argument("--issue", type=int, default=0)
+    external_report.add_argument(
+        "--group-by",
+        choices=("none", "work-item", "issue", "model"),
+        default="work-item",
+    )
+    external_report.add_argument("--include-turns", action="store_true")
     usage_report = usage_commands.add_parser(
         "report", help="aggregate one repository's Issue/PR lifecycle usage"
     )
@@ -892,6 +910,28 @@ def main(argv: list[str] | None = None) -> int:
                     print(render_guide(result), end="")
             return 0
         config = load_config(args.config, include_user=True)
+        if args.command == "usage" and args.usage_command in {
+            "collect",
+            "external-report",
+        }:
+            from .external_usage import ExternalUsage
+
+            usage_service = ExternalUsage(config)
+            if args.usage_command == "collect":
+                result = usage_service.collect(
+                    args.run_id,
+                    codex_session=args.codex_session,
+                    turn_ids=tuple(args.turn_id),
+                )
+            else:
+                result = usage_service.report(
+                    args.repository,
+                    issue=args.issue,
+                    group_by=args.group_by,
+                    include_turns=args.include_turns,
+                )
+            _json(result)
+            return 0
         if args.command == "integration":
             from .integrations import AgentIntegration
 

--- a/src/reposteward/codex_usage.py
+++ b/src/reposteward/codex_usage.py
@@ -1,0 +1,312 @@
+"""Bounded, prompt-free projections of explicitly selected local Codex turns.
+
+Rollouts are an internal client format, not a provider billing API. Keep this
+compatibility adapter separate from the stable RepoSteward usage schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ADAPTER_VERSION = 1
+SUPPORTED_CLI_VERSIONS = {"0.153.0"}
+MAX_SOURCE_BYTES = 256 * 1024 * 1024
+MAX_LINE_BYTES = 4 * 1024 * 1024
+MAX_RECORDS = 1_000_000
+TOKEN_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+)
+
+
+class UsageSourceError(ValueError):
+    """The source cannot safely establish the selected turn's counters."""
+
+
+def identifier(value: Any) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", value):
+        raise UsageSourceError("invalid usage identity or model")
+    return value
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        if not isinstance(value, str) or len(value) > 40:
+            raise ValueError
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            raise ValueError
+        return parsed.isoformat()
+    except ValueError as exc:
+        raise UsageSourceError("invalid usage timestamp") from exc
+
+
+def _counters(value: Any) -> dict[str, int | None]:
+    if not isinstance(value, dict):
+        raise UsageSourceError("unsupported Codex cumulative usage shape")
+    result = {}
+    for key in TOKEN_FIELDS:
+        count = value.get(key)
+        if count is not None and (
+            type(count) is not int or not 0 <= count <= 2**63 - 1
+        ):
+            raise UsageSourceError("invalid Codex token counter")
+        result[key] = count
+    _consistent(result)
+    return result
+
+
+def _consistent(counts: dict[str, int | None]) -> None:
+    for subset, total in (
+        ("cached_input_tokens", "input_tokens"),
+        ("cache_write_input_tokens", "input_tokens"),
+        ("reasoning_output_tokens", "output_tokens"),
+    ):
+        if (
+            counts[subset] is not None
+            and counts[total] is not None
+            and counts[subset] > counts[total]
+        ):
+            raise UsageSourceError("inconsistent Codex token subsets")
+    if (
+        all(
+            counts[k] is not None
+            for k in ("input_tokens", "output_tokens", "total_tokens")
+        )
+        and counts["input_tokens"] + counts["output_tokens"] != counts["total_tokens"]
+    ):
+        raise UsageSourceError("inconsistent Codex total tokens")
+
+
+def _delta(end: dict, start: dict | None) -> dict[str, int | None]:
+    result = {}
+    for key in TOKEN_FIELDS:
+        a, b = (start or {}).get(key), end.get(key)
+        result[key] = b - a if a is not None and b is not None else None
+        if result[key] is not None and result[key] < 0:
+            raise UsageSourceError("Codex counters reset within the selected turn")
+    _consistent(result)
+    return result
+
+
+def read_codex_turns(
+    path: Path,
+    turn_ids: set[str],
+    *,
+    previous_prefix: tuple[int, str] | None = None,
+) -> dict[str, Any]:
+    """Read one bounded snapshot; retain identities and counters, never messages.
+
+    A previous full-line prefix must remain byte-identical. The final partial
+    line is retried next time. A second prefix hash detects concurrent rewrites.
+    """
+    selected = {identifier(value) for value in turn_ids}
+    if not selected or len(selected) > 100:
+        raise UsageSourceError("select between 1 and 100 explicit Codex turn IDs")
+    path = path.expanduser().resolve(strict=True)
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as source:
+        initial = os.fstat(source.fileno())
+        if not stat.S_ISREG(initial.st_mode) or initial.st_size > MAX_SOURCE_BYTES:
+            raise UsageSourceError("Codex source must be a bounded regular file")
+        if previous_prefix and initial.st_size < previous_prefix[0]:
+            raise UsageSourceError(
+                "Codex source was truncated; previous evidence retained"
+            )
+        digest = hashlib.sha256()
+        consumed = 0
+        partial = False
+        prefix_checked = previous_prefix is None or previous_prefix[0] == 0
+        meta = None
+        current = ""
+        visited: set[str] = set()
+        last: dict | None = None
+        turns: dict[str, dict] = {}
+        for _ in range(MAX_RECORDS):
+            remaining = initial.st_size - consumed
+            if remaining <= 0:
+                break
+            line = source.readline(min(MAX_LINE_BYTES + 1, remaining))
+            if len(line) > MAX_LINE_BYTES:
+                raise UsageSourceError(
+                    "Codex source line exceeds the metadata read limit"
+                )
+            if not line.endswith(b"\n"):
+                partial = True
+                break
+            consumed += len(line)
+            digest.update(line)
+            if previous_prefix and consumed == previous_prefix[0]:
+                if digest.hexdigest() != previous_prefix[1]:
+                    raise UsageSourceError(
+                        "Codex source was rewritten; previous evidence retained"
+                    )
+                prefix_checked = True
+            try:
+                record = json.loads(line)
+            except (ValueError, RecursionError) as exc:
+                raise UsageSourceError("invalid complete Codex JSONL record") from exc
+            if not isinstance(record, dict):
+                raise UsageSourceError("unsupported Codex record envelope")
+            kind = record.get("type")
+            if not isinstance(kind, str):
+                raise UsageSourceError("invalid Codex record type")
+            if kind not in {"session_meta", "turn_context", "event_msg"}:
+                continue
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                raise UsageSourceError("unsupported Codex metadata envelope")
+            event = payload.get("type") if kind == "event_msg" else kind
+            if not isinstance(event, str):
+                raise UsageSourceError("invalid Codex metadata type")
+            if kind == "session_meta":
+                version = payload.get("cli_version")
+                if (
+                    not isinstance(version, str)
+                    or version not in SUPPORTED_CLI_VERSIONS
+                ):
+                    raise UsageSourceError(
+                        "unsupported Codex CLI version; collector adapter needs review"
+                    )
+                identity = {
+                    "session_id": identifier(payload.get("id")),
+                    "cli_version": version,
+                }
+                if meta is not None and meta != identity:
+                    raise UsageSourceError("Codex session identity or version changed")
+                # Resume appends session_meta again. Identical metadata must not
+                # reset the active turn or its cumulative counter baseline.
+                meta = identity
+            elif event in {"turn_context", "task_started"}:
+                if meta is None:
+                    raise UsageSourceError("Codex session metadata is missing")
+                turn_id = identifier(payload.get("turn_id"))
+                if turn_id != current:
+                    if turn_id in visited:
+                        raise UsageSourceError("noncontiguous Codex turn identity")
+                    visited.add(turn_id)
+                    current = turn_id
+                    if turn_id in selected:
+                        turns[turn_id] = {
+                            "baseline": last,
+                            "latest": None,
+                            "high_water": dict(last or {}),
+                            "models": set(),
+                            "workspaces": set(),
+                            "started_at": _timestamp(record.get("timestamp")),
+                            "observed_at": None,
+                            "completion": "in_progress",
+                        }
+                if current in selected and kind == "turn_context":
+                    state = turns[current]
+                    state["models"].add(identifier(payload.get("model")))
+                    cwd = payload.get("cwd")
+                    if (
+                        not isinstance(cwd, str)
+                        or len(cwd) > 4096
+                        or not Path(cwd).is_absolute()
+                    ):
+                        raise UsageSourceError("invalid Codex turn workspace")
+                    state["workspaces"].add(cwd)
+            elif event == "token_count":
+                info = payload.get("info")
+                if info is None:
+                    continue  # Rate-limit-only notification, not a usage update.
+                if not isinstance(info, dict) or "total_token_usage" not in info:
+                    raise UsageSourceError("unsupported Codex usage info")
+                counters = _counters(info["total_token_usage"])
+                if current in selected:
+                    state = turns[current]
+                    # Check every update, so an intermediate reset cannot be hidden
+                    # by a subsequent cumulative value above the original baseline.
+                    _delta(counters, state["latest"] or state["baseline"])
+                    for key, count in counters.items():
+                        previous = state["high_water"].get(key)
+                        if count is not None:
+                            if previous is not None and count < previous:
+                                raise UsageSourceError(
+                                    "Codex counters reset within the selected turn"
+                                )
+                            state["high_water"][key] = count
+                    state["latest"] = counters
+                    state["observed_at"] = _timestamp(record.get("timestamp"))
+                last = counters
+            elif event in {"task_complete", "turn_aborted"}:
+                turn_id = identifier(payload.get("turn_id"))
+                if turn_id in selected:
+                    if turn_id != current or turn_id not in turns:
+                        raise UsageSourceError(
+                            "Codex completion does not match the active turn"
+                        )
+                    turns[turn_id]["completion"] = (
+                        "completed" if event == "task_complete" else "interrupted"
+                    )
+        else:
+            raise UsageSourceError("Codex source record limit exceeded")
+        if not prefix_checked:
+            raise UsageSourceError(
+                "Codex source prefix changed; previous evidence retained"
+            )
+        if meta is None or selected != turns.keys():
+            raise UsageSourceError(
+                "selected turn or session metadata not found in source"
+            )
+        source.seek(0)
+        verification = hashlib.sha256()
+        remaining = consumed
+        while remaining:
+            chunk = source.read(min(remaining, 1024 * 1024))
+            if not chunk:
+                raise UsageSourceError("Codex source changed during collection")
+            verification.update(chunk)
+            remaining -= len(chunk)
+        after = path.stat()
+        if verification.digest() != digest.digest() or (
+            initial.st_dev,
+            initial.st_ino,
+        ) != (after.st_dev, after.st_ino):
+            raise UsageSourceError("Codex source changed during collection")
+    results = {}
+    for turn_id, state in turns.items():
+        if not state["workspaces"]:
+            raise UsageSourceError("selected Codex turn has no workspace context")
+        metrics = _delta(state["latest"] or {}, state["baseline"])
+        reasons = []
+        if state["baseline"] is None:
+            reasons.append("baseline_unavailable")
+        if state["latest"] is None:
+            reasons.append("usage_unavailable")
+        if any(value is None for value in metrics.values()):
+            reasons.append("metrics_missing")
+        models = state["models"]
+        if len(models) != 1:
+            reasons.append("model_ambiguous")
+        results[turn_id] = {
+            "turn_id": turn_id,
+            "model": next(iter(models)) if len(models) == 1 else None,
+            "workspaces": sorted(state["workspaces"]),
+            "started_at": state["started_at"],
+            "observed_at": state["observed_at"],
+            "completion": state["completion"],
+            "metrics": metrics,
+            "unknown_reasons": reasons,
+        }
+    return {
+        **meta,
+        "adapter_version": ADAPTER_VERSION,
+        "prefix_bytes": consumed,
+        "prefix_sha256": digest.hexdigest(),
+        "partial_tail": partial,
+        "turns": results,
+    }

--- a/src/reposteward/external_usage.py
+++ b/src/reposteward/external_usage.py
@@ -1,0 +1,342 @@
+"""Local, explicit external-turn attribution, independent of the task DB schema."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from .codex_usage import TOKEN_FIELDS, UsageSourceError, read_codex_turns
+from .config import AppConfig
+from .projects import canonical_digest, workspace_metadata
+from .store import Store, utc_now
+from .usage import usage_cost
+
+EXTERNAL_USAGE_SCHEMA_VERSION = 1
+
+
+class ExternalUsage:
+    def __init__(self, config: AppConfig):
+        self.config = config
+        self.path = config.state_dir / "external-usage.sqlite3"
+
+    @contextmanager
+    def _connection(
+        self, *, write: bool = False
+    ) -> Iterator[sqlite3.Connection | None]:
+        if not write and not self.path.exists():
+            yield None
+            return
+        if write:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(descriptor)
+        db = sqlite3.connect(
+            str(self.path) if write else self.path.as_uri() + "?mode=ro",
+            uri=not write,
+            timeout=30,
+            isolation_level=None,
+        )
+        db.row_factory = sqlite3.Row
+        try:
+            db.execute("PRAGMA foreign_keys=ON")
+            db.execute("BEGIN IMMEDIATE" if write else "BEGIN")
+            version = db.execute("PRAGMA user_version").fetchone()[0]
+            if write and version == 0:
+                if db.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table'"
+                ).fetchone():
+                    raise UsageSourceError("unknown external usage database schema")
+                db.execute("""CREATE TABLE sources (
+                    session_id TEXT PRIMARY KEY, path TEXT NOT NULL UNIQUE,
+                    prefix_bytes INTEGER NOT NULL, prefix_sha256 TEXT NOT NULL,
+                    cli_version TEXT NOT NULL)""")
+                db.execute("""CREATE TABLE turns (
+                    session_id TEXT NOT NULL REFERENCES sources(session_id),
+                    turn_id TEXT NOT NULL, work_item_id TEXT NOT NULL,
+                    repository TEXT NOT NULL, issue_number INTEGER NOT NULL,
+                    first_run_id TEXT NOT NULL, payload TEXT NOT NULL,
+                    observation_digest TEXT NOT NULL, collected_at TEXT NOT NULL,
+                    PRIMARY KEY(session_id, turn_id))""")
+                db.execute("""CREATE TABLE observations (
+                    sequence INTEGER PRIMARY KEY, session_id TEXT NOT NULL,
+                    turn_id TEXT NOT NULL, digest TEXT NOT NULL,
+                    payload TEXT NOT NULL, collected_at TEXT NOT NULL,
+                    UNIQUE(session_id, turn_id, digest),
+                    FOREIGN KEY(session_id,turn_id) REFERENCES turns(session_id,turn_id))""")
+                db.execute(f"PRAGMA user_version={EXTERNAL_USAGE_SCHEMA_VERSION}")
+                version = EXTERNAL_USAGE_SCHEMA_VERSION
+            if version != EXTERNAL_USAGE_SCHEMA_VERSION:
+                raise UsageSourceError("unsupported external usage database schema")
+            yield db
+            db.commit() if write else db.rollback()
+        except BaseException as exc:
+            db.rollback()
+            if isinstance(exc, sqlite3.Error):
+                raise UsageSourceError(
+                    "external usage database operation failed"
+                ) from exc
+            raise
+        finally:
+            db.close()
+
+    def _task(self, run_id: str) -> dict[str, Any]:
+        store = Store(self.config.state_dir / "reposteward.sqlite3", read_only=True)
+        bundle = store.context_bundle(run_id)
+        if bundle is None:
+            raise UsageSourceError("run has no registered WorkItem context")
+        if bundle["harness_run"]["harness"] not in {
+            "external-agent",
+            "external-workspace",
+        }:
+            raise UsageSourceError(
+                "collection requires an external task or adopted workspace run"
+            )
+        work = bundle["work_item"]
+        if work["kind"] != "github_issue" or not str(work["external_id"]).isdigit():
+            raise UsageSourceError("collection requires a GitHub Issue WorkItem")
+        return work
+
+    def collect(
+        self,
+        run_id: str,
+        *,
+        codex_session: Path | None = None,
+        turn_ids: tuple[str, ...] = (),
+    ) -> dict[str, Any]:
+        work = self._task(run_id)
+        if (codex_session is None) != (not turn_ids):
+            raise UsageSourceError(
+                "provide both --codex-session and --turn-id, or neither"
+            )
+        if codex_session is not None:
+            selections = {
+                str(codex_session.expanduser().resolve(strict=True)): set(turn_ids)
+            }
+        else:
+            selections: dict[str, set[str]] = {}
+            with self._connection() as db:
+                if db is not None:
+                    for row in db.execute(
+                        """SELECT s.path, t.turn_id FROM turns t JOIN sources s
+                        ON s.session_id=t.session_id WHERE t.work_item_id=?""",
+                        (work["id"],),
+                    ):
+                        selections.setdefault(row["path"], set()).add(row["turn_id"])
+            if not selections:
+                raise UsageSourceError(
+                    "task has no selected sources; bind a session and turn first"
+                )
+        results = []
+        # Each source snapshot and its selected turns commit atomically. A failed
+        # later source can be retried without duplicating already collected ones.
+        for path, selected in selections.items():
+            results.append(self._collect_source(run_id, work, Path(path), selected))
+        return {"work_item_id": work["id"], "sources": results, "public_write": False}
+
+    def _collect_source(
+        self, run_id: str, work: dict, path: Path, selected: set[str]
+    ) -> dict:
+        with self._connection(write=True) as db:
+            assert db is not None
+            previous = db.execute(
+                "SELECT * FROM sources WHERE path=?", (str(path),)
+            ).fetchone()
+            prefix = (
+                (previous["prefix_bytes"], previous["prefix_sha256"])
+                if previous
+                else None
+            )
+            source = read_codex_turns(path, selected, previous_prefix=prefix)
+            session_id = source["session_id"]
+            existing = db.execute(
+                "SELECT * FROM sources WHERE session_id=?", (session_id,)
+            ).fetchone()
+            if existing and existing["path"] != str(path):
+                raise UsageSourceError(
+                    "session already registered at another source path"
+                )
+            if previous and previous["session_id"] != session_id:
+                raise UsageSourceError("source session identity changed")
+            db.execute(
+                """INSERT INTO sources VALUES (?,?,?,?,?) ON CONFLICT(session_id) DO UPDATE SET
+                prefix_bytes=excluded.prefix_bytes, prefix_sha256=excluded.prefix_sha256""",
+                (
+                    session_id,
+                    str(path),
+                    source["prefix_bytes"],
+                    source["prefix_sha256"],
+                    source["cli_version"],
+                ),
+            )
+            api_host = urlsplit(self.config.github.api_url).hostname
+            host = "github.com" if api_host == "api.github.com" else api_host
+            checked = set()
+            changed = 0
+            for turn_id, value in source["turns"].items():
+                for cwd in value.pop("workspaces"):
+                    if cwd not in checked:
+                        metadata = workspace_metadata(Path(cwd))
+                        if (
+                            metadata["host"] != host
+                            or metadata["repository"].casefold()
+                            != work["repository"].casefold()
+                        ):
+                            raise UsageSourceError(
+                                "selected turn workspace belongs to another project"
+                            )
+                        checked.add(cwd)
+                prior = db.execute(
+                    "SELECT * FROM turns WHERE session_id=? AND turn_id=?",
+                    (session_id, turn_id),
+                ).fetchone()
+                if prior and prior["work_item_id"] != work["id"]:
+                    raise UsageSourceError(
+                        "selected turn already belongs to another WorkItem"
+                    )
+                observation = {
+                    **value,
+                    "session_id": session_id,
+                    "adapter_version": source["adapter_version"],
+                    "cli_version": source["cli_version"],
+                    "trust": "local_client_counters",
+                }
+                digest = canonical_digest(observation)
+                if prior and prior["observation_digest"] == digest:
+                    db.execute(
+                        "UPDATE turns SET collected_at=? WHERE session_id=? AND turn_id=?",
+                        (utc_now(), session_id, turn_id),
+                    )
+                    continue
+                payload = json.dumps(observation, sort_keys=True)
+                now = utc_now()
+                db.execute(
+                    """INSERT INTO turns VALUES (?,?,?,?,?,?,?,?,?)
+                    ON CONFLICT(session_id,turn_id) DO UPDATE SET payload=excluded.payload,
+                    observation_digest=excluded.observation_digest, collected_at=excluded.collected_at""",
+                    (
+                        session_id,
+                        turn_id,
+                        work["id"],
+                        work["repository"].casefold(),
+                        int(work["external_id"]),
+                        run_id,
+                        payload,
+                        digest,
+                        now,
+                    ),
+                )
+                db.execute(
+                    "INSERT OR IGNORE INTO observations(session_id,turn_id,digest,payload,collected_at) VALUES (?,?,?,?,?)",
+                    (session_id, turn_id, digest, payload, now),
+                )
+                changed += 1
+        return {
+            "session_id": session_id,
+            "selected_turns": len(selected),
+            "updated_turns": changed,
+            "idempotent": changed == 0,
+            "partial_tail": source["partial_tail"],
+            "source_prefix_sha256": source["prefix_sha256"],
+        }
+
+    def report(
+        self,
+        repository: str,
+        *,
+        issue: int = 0,
+        group_by: str = "work-item",
+        include_turns: bool = False,
+    ) -> dict:
+        if issue < 0 or group_by not in {"work-item", "model", "issue", "none"}:
+            raise UsageSourceError("invalid external usage report filter")
+        rows = []
+        with self._connection() as db:
+            if db is not None:
+                for stored in db.execute(
+                    "SELECT * FROM turns WHERE repository=? AND (?=0 OR issue_number=?) ORDER BY session_id,turn_id",
+                    (repository.casefold(), issue, issue),
+                ):
+                    row = dict(stored)
+                    row.update(json.loads(row.pop("payload")))
+                    row["cost_estimate"] = self._cost(row)
+                    rows.append(row)
+        groups: dict[str, list[dict]] = {}
+        field = {
+            "work-item": "work_item_id",
+            "model": "model",
+            "issue": "issue_number",
+        }.get(group_by)
+        if field:
+            for row in rows:
+                groups.setdefault(str(row[field] or "unknown"), []).append(row)
+        result = {
+            "schema_version": EXTERNAL_USAGE_SCHEMA_VERSION,
+            "repository": repository.casefold(),
+            "issue_number": issue or None,
+            "source": "external_codex_turns",
+            "group_by": group_by,
+            "summary": _summary(rows),
+            "groups": [
+                {"key": key, "summary": _summary(value)}
+                for key, value in sorted(groups.items())
+            ],
+            "raw_prompts_stored": False,
+            "public_write": False,
+            "scope": "explicitly selected turns; snapshots require collection to refresh",
+        }
+        if include_turns:
+            result["turns"] = rows
+        return result
+
+    def _cost(self, row: dict) -> dict:
+        if not row["model"]:
+            return {"status": "unknown", "reason": "model_ambiguous"}
+        if row["metrics"].get("cache_write_input_tokens") is None:
+            return {"status": "unknown", "reason": "metrics_missing"}
+        if row["metrics"].get("cache_write_input_tokens") != 0:
+            return {"status": "unknown", "reason": "cache_write_pricing_unsupported"}
+        return usage_cost(
+            {**row, "harness": "codex-local", "created_at": row["started_at"]},
+            self.config.observability.prices,
+        )
+
+
+def _summary(rows: list[dict]) -> dict:
+    metrics = {}
+    for key in TOKEN_FIELDS:
+        known = [row["metrics"][key] for row in rows if row["metrics"][key] is not None]
+        metrics[key] = {
+            "value": sum(known) if known else None,
+            "known_turns": len(known),
+            "unknown_turns": len(rows) - len(known),
+        }
+    costs: dict[str, Decimal] = {}
+    for row in rows:
+        cost = row["cost_estimate"]
+        if cost["status"] == "known":
+            costs[cost["currency"]] = costs.get(cost["currency"], Decimal(0)) + Decimal(
+                cost["value"]
+            )
+    return {
+        "turns": len(rows),
+        "work_items": len({row["work_item_id"] for row in rows}),
+        "completion": dict(Counter(row["completion"] for row in rows)),
+        "metrics": metrics,
+        "cost_estimate": {
+            "by_currency": {key: str(value) for key, value in sorted(costs.items())},
+            "unknown_turns": sum(
+                row["cost_estimate"]["status"] == "unknown" for row in rows
+            ),
+        },
+        "tool_call_count": None,
+        "active_duration_seconds": None,
+        "last_collected_at": max((row["collected_at"] for row in rows), default=None),
+    }

--- a/src/reposteward/usage.py
+++ b/src/reposteward/usage.py
@@ -111,7 +111,7 @@ def _decimal_text(value: Decimal) -> str:
     return rendered.rstrip("0").rstrip(".") or "0"
 
 
-def _run_cost(row: dict[str, Any], prices: tuple[UsagePrice, ...]) -> dict[str, Any]:
+def usage_cost(row: dict[str, Any], prices: tuple[UsagePrice, ...]) -> dict[str, Any]:
     price = _select_price(row, prices)
     if price is None:
         return {"status": "unknown", "reason": "price_not_configured"}
@@ -228,7 +228,7 @@ def build_usage_report(
 ) -> dict[str, Any]:
     if group_by != "none" and group_by not in GROUP_FIELDS:
         raise ValueError(f"unsupported usage group: {group_by!r}")
-    enriched = [{**row, "cost": _run_cost(row, prices)} for row in rows]
+    enriched = [{**row, "cost": usage_cost(row, prices)} for row in rows]
     groups: list[dict[str, Any]] = []
     if group_by != "none":
         field = GROUP_FIELDS[group_by]

--- a/tests/test_external_usage.py
+++ b/tests/test_external_usage.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing, redirect_stderr, redirect_stdout
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+import test_external_tasks
+from test_projects import repository
+
+from reposteward.cli import main
+from reposteward.codex_usage import UsageSourceError, read_codex_turns
+from reposteward.config import UsagePrice
+from reposteward.external_usage import ExternalUsage
+
+
+def record(kind: str, **payload) -> dict:
+    return {"timestamp": "2026-09-07T02:00:00Z", "type": kind, "payload": payload}
+
+
+def counts(inputs=100, cached=50, outputs=10, reasoning=2) -> dict:
+    return {
+        "input_tokens": inputs,
+        "cached_input_tokens": cached,
+        "cache_write_input_tokens": 0,
+        "output_tokens": outputs,
+        "reasoning_output_tokens": reasoning,
+        "total_tokens": inputs + outputs,
+    }
+
+
+def update(**kwargs) -> dict:
+    return record(
+        "event_msg", type="token_count", info={"total_token_usage": counts(**kwargs)}
+    )
+
+
+def context(cwd: Path, turn="chosen", model="model-a") -> dict:
+    return record("turn_context", turn_id=turn, cwd=str(cwd), model=model)
+
+
+def rollout(cwd: Path) -> list[dict]:
+    return [
+        record(
+            "session_meta",
+            id="session-1",
+            cli_version="0.153.0",
+            cwd=str(cwd),
+            instructions="SENSITIVE_MARKER",
+        ),
+        context(cwd, "earlier"),
+        update(),
+        record(
+            "event_msg",
+            type="task_complete",
+            turn_id="earlier",
+            last_agent_message="SENSITIVE_MARKER",
+        ),
+        record("event_msg", type="task_started", turn_id="chosen"),
+        context(cwd),
+        record("response_item", type="message", content="SENSITIVE_MARKER"),
+        update(inputs=160, cached=80, outputs=16, reasoning=4),
+    ]
+
+
+def write(path: Path, records: list[dict], *, append=False) -> None:
+    with path.open("a" if append else "w") as stream:
+        for row in records:
+            stream.write(json.dumps(row) + "\n")
+
+
+class CodexUsageParserTests(unittest.TestCase):
+    def setUp(self):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        self.root = Path(temp.name)
+        self.path = self.root / "selected.jsonl"
+
+    def parse(self, records=None):
+        write(self.path, records if records is not None else rollout(self.root))
+        return read_codex_turns(self.path, {"chosen"})["turns"]["chosen"]
+
+    def test_cumulative_delta_duplicates_compaction_and_completion(self):
+        rows = rollout(self.root)
+        rows += [
+            rows[-1],
+            context(self.root),
+            rows[-1],
+            record("event_msg", type="task_complete", turn_id="chosen"),
+        ]
+        result = self.parse(rows)
+        self.assertEqual(result["metrics"], counts(60, 30, 6, 2))
+        self.assertEqual(result["completion"], "completed")
+        self.assertEqual(result["unknown_reasons"], [])
+        self.assertNotIn("SENSITIVE_MARKER", json.dumps(result))
+
+    def test_missing_baseline_and_missing_fields_remain_unknown(self):
+        rows = rollout(self.root)
+        result = self.parse([rows[0], *rows[4:]])
+        self.assertTrue(all(v is None for v in result["metrics"].values()))
+        self.assertIn("baseline_unavailable", result["unknown_reasons"])
+        del rows[-1]["payload"]["info"]["total_token_usage"]["cached_input_tokens"]
+        result = self.parse(rows)
+        self.assertIsNone(result["metrics"]["cached_input_tokens"])
+        self.assertEqual(result["metrics"]["input_tokens"], 60)
+
+    def test_resume_metadata_preserves_baseline_and_rejects_identity_changes(self):
+        rows = rollout(self.root)
+        result = self.parse(rows + [rows[0], context(self.root), rows[-1]])
+        self.assertEqual(result["metrics"], counts(60, 30, 6, 2))
+        changed = record("session_meta", id="another-session", cli_version="0.153.0")
+        with self.assertRaisesRegex(UsageSourceError, "identity or version changed"):
+            self.parse(rows + [changed])
+
+    def test_missing_update_cannot_hide_an_intermediate_reset(self):
+        missing = record(
+            "event_msg", type="token_count", info={"total_token_usage": {}}
+        )
+        with self.assertRaisesRegex(UsageSourceError, "reset"):
+            self.parse(rollout(self.root) + [missing, update(inputs=120, cached=60)])
+
+    def test_no_usage_rate_limit_only_and_model_switch(self):
+        rows = rollout(self.root)[:-1]
+        rows += [record("event_msg", type="token_count", info=None)]
+        result = self.parse(rows)
+        self.assertIn("usage_unavailable", result["unknown_reasons"])
+        result = self.parse(rollout(self.root) + [context(self.root, model="model-b")])
+        self.assertIsNone(result["model"])
+        self.assertIn("model_ambiguous", result["unknown_reasons"])
+
+    def test_multiple_turns_exclude_unselected_usage(self):
+        rows = rollout(self.root) + [
+            context(self.root, "unrelated"),
+            update(inputs=200, cached=100, outputs=20, reasoning=6),
+            context(self.root, "next"),
+            update(inputs=250, cached=120, outputs=30, reasoning=8),
+        ]
+        write(self.path, rows)
+        turns = read_codex_turns(self.path, {"chosen", "next"})["turns"]
+        self.assertEqual(turns["chosen"]["metrics"]["input_tokens"], 60)
+        self.assertEqual(turns["next"]["metrics"]["input_tokens"], 50)
+
+    def test_intermediate_reset_and_invalid_subsets_rejected(self):
+        for bad in [
+            update(inputs=120, cached=60),
+            update(inputs=161, cached=150, outputs=16, reasoning=4),
+            update(inputs=True),
+            update(reasoning=20),
+        ]:
+            with self.subTest(bad=bad), self.assertRaises(UsageSourceError):
+                self.parse(
+                    rollout(self.root)
+                    + [bad, update(inputs=500, cached=300, outputs=30, reasoning=10)]
+                )
+
+    def test_versions_envelopes_order_and_sensitive_errors(self):
+        base = rollout(self.root)
+        variants = [
+            [
+                {**base[0], "payload": {**base[0]["payload"], "cli_version": "99.0.0"}},
+                *base[1:],
+            ],
+            [
+                {**base[0], "payload": {**base[0]["payload"], "cli_version": []}},
+                *base[1:],
+            ],
+            base + [context(self.root, "earlier")],
+            base
+            + [
+                record(
+                    "event_msg", type="token_count", info={"SENSITIVE_MARKER": "secret"}
+                )
+            ],
+            base + [record("event_msg", type=[])],
+            base
+            + [
+                record("event_msg", type="task_complete", turn_id="not-present"),
+                context(self.root, "next"),
+                record("event_msg", type="task_complete", turn_id="chosen"),
+            ],
+        ]
+        for rows in variants:
+            with self.subTest(rows=rows), self.assertRaises(UsageSourceError) as caught:
+                self.parse(rows)
+            self.assertNotIn("SENSITIVE_MARKER", str(caught.exception))
+
+    def test_partial_tail_growing_source_and_prefix_rewrite(self):
+        write(self.path, rollout(self.root))
+        with self.path.open("ab") as stream:
+            stream.write(b'{"type":')
+        first = read_codex_turns(self.path, {"chosen"})
+        self.assertTrue(first["partial_tail"])
+        prefix = (first["prefix_bytes"], first["prefix_sha256"])
+        with self.path.open("ab") as stream:
+            stream.write(b'"response_item","payload":{}}\n')
+        write(
+            self.path,
+            [update(inputs=180, cached=90, outputs=18, reasoning=4)],
+            append=True,
+        )
+        second = read_codex_turns(self.path, {"chosen"}, previous_prefix=prefix)
+        self.assertEqual(second["turns"]["chosen"]["metrics"]["input_tokens"], 80)
+        self.path.write_bytes(
+            self.path.read_bytes().replace(b"SENSITIVE_MARKER", b"MODIFIED_MARKER")
+        )
+        with self.assertRaisesRegex(UsageSourceError, "rewritten|prefix changed"):
+            read_codex_turns(self.path, {"chosen"}, previous_prefix=prefix)
+
+    def test_malformed_complete_line_limits_and_truncation(self):
+        write(self.path, rollout(self.root))
+        result = read_codex_turns(self.path, {"chosen"})
+        prefix = (result["prefix_bytes"], result["prefix_sha256"])
+        with (
+            patch("reposteward.codex_usage.MAX_SOURCE_BYTES", 10),
+            self.assertRaisesRegex(UsageSourceError, "bounded regular"),
+        ):
+            read_codex_turns(self.path, {"chosen"})
+        with (
+            patch("reposteward.codex_usage.MAX_LINE_BYTES", 10),
+            self.assertRaisesRegex(UsageSourceError, "line exceeds"),
+        ):
+            read_codex_turns(self.path, {"chosen"})
+        with (
+            patch("reposteward.codex_usage.MAX_RECORDS", 1),
+            self.assertRaisesRegex(UsageSourceError, "record limit"),
+        ):
+            read_codex_turns(self.path, {"chosen"})
+        self.path.write_bytes(b'{"SENSITIVE_MARKER":\n')
+        with self.assertRaisesRegex(UsageSourceError, "truncated"):
+            read_codex_turns(self.path, {"chosen"}, previous_prefix=prefix)
+        with self.assertRaisesRegex(UsageSourceError, "invalid complete"):
+            read_codex_turns(self.path, {"chosen"})
+
+
+class ExternalUsageTests(unittest.TestCase):
+    def setUp(self):
+        test_external_tasks.ExternalTaskTests.setUp(self)
+        self.tasks = self.service
+        self.service = ExternalUsage(self.config)
+        self.run = self.tasks.start(self.repo, issue_number=7, reviewed_by="owner")[
+            "run_id"
+        ]
+        with closing(sqlite3.connect(self.tasks.path)) as db:
+            self.core_version = db.execute("PRAGMA user_version").fetchone()[0]
+        self.source = self.root / "selected.jsonl"
+        write(self.source, rollout(self.repo))
+
+    def collect(self, run=None, turns=("chosen",)):
+        return self.service.collect(
+            run or self.run, codex_session=self.source, turn_ids=turns
+        )
+
+    def report(self):
+        return self.service.report("owner/repo", include_turns=True)
+
+    def test_repeat_refresh_successor_run_and_adopted_run_do_not_double_count(self):
+        with patch(
+            "reposteward.external_usage.utc_now",
+            return_value="2026-09-07T02:00:00+00:00",
+        ):
+            self.assertEqual(self.collect()["sources"][0]["updated_turns"], 1)
+        with patch(
+            "reposteward.external_usage.utc_now",
+            return_value="2026-09-07T03:00:00+00:00",
+        ):
+            self.assertTrue(self.collect()["sources"][0]["idempotent"])
+        self.assertEqual(
+            self.report()["summary"]["last_collected_at"], "2026-09-07T03:00:00+00:00"
+        )
+        successor = self.tasks.start(self.repo, issue_number=7, reviewed_by="owner")[
+            "run_id"
+        ]
+        with closing(sqlite3.connect(self.tasks.path)) as db:
+            db.execute(
+                "UPDATE harness_runs SET harness='external-workspace' WHERE run_id=?",
+                (successor,),
+            )
+            db.commit()
+        self.assertTrue(self.service.collect(successor)["sources"][0]["idempotent"])
+        write(
+            self.source,
+            [
+                update(inputs=180, cached=90, outputs=18, reasoning=4),
+                record("event_msg", type="task_complete", turn_id="chosen"),
+            ],
+            append=True,
+        )
+        self.service.collect(successor)
+        report = self.report()
+        self.assertEqual(report["summary"]["turns"], 1)
+        self.assertEqual(report["summary"]["metrics"]["input_tokens"]["value"], 80)
+        self.assertEqual(report["turns"][0]["first_run_id"], self.run)
+        self.assertEqual(report["turns"][0]["completion"], "completed")
+        with closing(sqlite3.connect(self.service.path)) as db:
+            self.assertEqual(
+                db.execute("SELECT count(*) FROM observations").fetchone()[0], 2
+            )
+
+    def test_no_messages_persist_and_core_schema_unchanged(self):
+        self.collect()
+        self.assertNotIn(b"SENSITIVE_MARKER", self.service.path.read_bytes())
+        self.assertNotIn("SENSITIVE_MARKER", json.dumps(self.report()))
+        self.assertNotIn(str(self.source), json.dumps(self.report()))
+        self.assertEqual(self.service.path.stat().st_mode & 0o777, 0o600)
+        with closing(sqlite3.connect(self.tasks.path)) as db:
+            self.assertEqual(
+                db.execute("PRAGMA user_version").fetchone()[0], self.core_version
+            )
+
+    def test_rewrite_and_truncation_keep_previous_observation(self):
+        self.collect()
+        before = self.report()
+        original = self.source.read_bytes()
+        for value in (
+            original[:50],
+            original.replace(b"SENSITIVE_MARKER", b"MODIFIED_MARKER"),
+        ):
+            self.source.write_bytes(value)
+            with self.assertRaises(UsageSourceError):
+                self.collect()
+            self.assertEqual(self.report(), before)
+
+    def test_cross_project_and_cross_work_item_conflicts_are_atomic(self):
+        self.collect()
+        before = self.report()
+        self.github.issue.return_value = replace(
+            self.github.issue.return_value, number=8
+        )
+        other_run = self.tasks.start(self.repo, issue_number=8, reviewed_by="owner")[
+            "run_id"
+        ]
+        with self.assertRaisesRegex(UsageSourceError, "another WorkItem"):
+            self.collect(other_run)
+        other = repository(
+            self.root / "another", remote="git@github.com:owner/another.git"
+        )
+        write(
+            self.source,
+            [
+                context(other, "next"),
+                update(inputs=200, cached=100, outputs=20, reasoning=4),
+            ],
+            append=True,
+        )
+        with self.assertRaisesRegex(UsageSourceError, "another project"):
+            self.collect(turns=("chosen", "next"))
+        self.assertEqual(self.report(), before)
+
+    def test_separate_clone_of_same_repository_allowed(self):
+        clone = repository(
+            self.root / "clone", remote="https://github.com/owner/repo.git"
+        )
+        write(self.source, rollout(clone))
+        self.collect()
+        self.assertEqual(self.report()["summary"]["turns"], 1)
+
+    def test_concurrent_collection_is_idempotent(self):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _: self.collect(), range(2)))
+        self.assertEqual(sum(r["sources"][0]["updated_turns"] for r in results), 1)
+        self.assertEqual(self.report()["summary"]["turns"], 1)
+
+    def test_read_only_cli_without_pipeline_authentication_or_db_creation(self):
+        for command in (["usage", "external-report", "owner/repo"],):
+            output = io.StringIO()
+            with (
+                patch("reposteward.cli.load_config", return_value=self.config),
+                patch(
+                    "reposteward.cli.Pipeline",
+                    side_effect=AssertionError("must remain local"),
+                ),
+                patch(
+                    "reposteward.github.GitHubClient",
+                    side_effect=AssertionError("no auth"),
+                ),
+                redirect_stdout(output),
+            ):
+                self.assertEqual(main(command), 0)
+            self.assertEqual(json.loads(output.getvalue())["summary"]["turns"], 0)
+        self.assertFalse(self.service.path.exists())
+        output = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            patch(
+                "reposteward.cli.Pipeline",
+                side_effect=AssertionError("must remain local"),
+            ),
+            redirect_stdout(output),
+        ):
+            self.assertEqual(
+                main(
+                    [
+                        "usage",
+                        "collect",
+                        self.run,
+                        "--codex-session",
+                        str(self.source),
+                        "--turn-id",
+                        "chosen",
+                    ]
+                ),
+                0,
+            )
+        self.assertEqual(
+            json.loads(output.getvalue())["sources"][0]["updated_turns"], 1
+        )
+
+    def test_missing_selection_managed_run_and_unknown_schema_rejected(self):
+        with self.assertRaisesRegex(UsageSourceError, "no selected sources"):
+            self.service.collect(self.run)
+        with self.assertRaisesRegex(UsageSourceError, "provide both"):
+            self.service.collect(self.run, turn_ids=("chosen",))
+        with self.assertRaisesRegex(UsageSourceError, "registered WorkItem"):
+            self.collect("absent")
+        with closing(sqlite3.connect(self.tasks.path)) as db:
+            db.execute(
+                "UPDATE harness_runs SET harness='codex-sdk' WHERE run_id=?",
+                (self.run,),
+            )
+            db.commit()
+        with self.assertRaisesRegex(UsageSourceError, "external task"):
+            self.collect()
+        with closing(sqlite3.connect(self.service.path)) as db:
+            db.execute("PRAGMA user_version=999")
+        with self.assertRaisesRegex(UsageSourceError, "unsupported external usage"):
+            self.report()
+
+    def test_multiple_turns_groups_unknowns_and_configured_cost(self):
+        write(
+            self.source,
+            [
+                context(self.repo, "next", model="model-b"),
+                update(inputs=200, cached=100, outputs=20, reasoning=6),
+            ],
+            append=True,
+        )
+        self.collect(turns=("chosen", "next"))
+        report = self.service.report("owner/repo", group_by="model", include_turns=True)
+        self.assertEqual([g["key"] for g in report["groups"]], ["model-a", "model-b"])
+        self.assertEqual(report["summary"]["metrics"]["input_tokens"]["value"], 100)
+        self.assertEqual(report["summary"]["cost_estimate"]["unknown_turns"], 2)
+        self.assertIsNone(report["summary"]["tool_call_count"])
+        self.assertEqual(
+            self.service.report("owner/repo", issue=8)["summary"]["turns"], 0
+        )
+        price = UsagePrice(
+            harness="codex-local",
+            model="model-a",
+            effective_from="2026-01-01",
+            currency="USD",
+            input_per_million=Decimal(2),
+            cached_input_per_million=Decimal(1),
+            output_per_million=Decimal(4),
+        )
+        config = replace(
+            self.config,
+            observability=replace(self.config.observability, prices=(price,)),
+        )
+        cost = ExternalUsage(config).report("owner/repo")["summary"]["cost_estimate"]
+        self.assertEqual(Decimal(cost["by_currency"]["USD"]), Decimal("0.000114"))
+        self.assertEqual(cost["unknown_turns"], 1)
+
+    def test_unknown_version_cli_error_does_not_echo_source_body(self):
+        rows = rollout(self.repo)
+        rows[0]["payload"]["cli_version"] = "SENSITIVE_MARKER"
+        write(self.source, rows)
+        errors = io.StringIO()
+        with (
+            patch("reposteward.cli.load_config", return_value=self.config),
+            redirect_stderr(errors),
+        ):
+            self.assertEqual(
+                main(
+                    [
+                        "usage",
+                        "collect",
+                        self.run,
+                        "--codex-session",
+                        str(self.source),
+                        "--turn-id",
+                        "chosen",
+                    ]
+                ),
+                2,
+            )
+        self.assertNotIn("SENSITIVE_MARKER", errors.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

Closes #139

## 问题与改动

现有用量台账主要覆盖 RepoSteward 启动的 Harness，外部 Codex 开发没有对应计数。本 PR 将显式选择的 Codex 会话轮次关联到已有外部任务或 adopted workspace 的 WorkItem。

- 新增 `usage collect RUN_ID`：首次指定会话文件和轮次，随后刷新已绑定来源；重复采集与同一任务续接不重复累计。
- 根据轮次前后的累计计数计算输入、缓存、输出和推理消耗，处理恢复、重复事件、缺失指标及未完成尾行；来源改写、计数回退和跨项目/任务归属冲突会拒绝更新。
- 新增本地 `usage external-report`，按项目、WorkItem、Issue 或模型汇总。计数、采集时间、完成状态与配置价格估算分别展示，缺失值保持 unknown。
- 独立 schema-v1 采集库仅保存来源身份、摘要、计数和归属记录，不存储会话正文；原有 Harness 报告保持兼容。

## 验证

以下完整检查均在 DockerVerifier 隔离容器内通过，测试阶段无网络：

```text
uvx ruff check .
uvx ruff format --check .
uv run --python 3.12 python -W error::ResourceWarning -m unittest discover -s tests -v
uv run reposteward --help
uv build
```

共 602 项测试通过，其中新增 20 项专项回归。验证后的独立安装已用 RepoSteward 自身的真实开发轮次完成采集和重复刷新；确认没有重复计数，核心任务库、项目库及配置未被采集操作改写。

## 风险与兼容性

本地 rollout 是客户端内部格式，首版明确支持经过核对的 Codex CLI 0.153.0；其他版本需适配后接入。正在进行的轮次只代表采集时的部分消耗；缺少基线时不假定从零开始。来源摘要用于本地完整性检查，不是供应商账单证明。

采集命令无需 GitHub 认证，不启动 Agent，不自动扫描全部会话历史。核心数据库无需迁移。当前需要手动刷新；P2 收益对比及其他 Agent 适配等待后续真实使用数据。

## 自动化辅助

Codex 辅助实现、回归与流程操作；已检查完整 diff、敏感数据边界、任务归属、计数口径、兼容性和隔离验证记录。按已配置的单维护者审阅与原生发布/合并门禁交付。

## Checklist

- [x] 聚焦一个已审核 Issue，未捆绑其他能力。
- [x] 完整 diff 不包含凭据、缓存、数据库、运行日志或本机路径。
- [x] 相关测试、完整测试、lint、格式检查和构建通过。
- [x] 新行为有回归测试，文档与兼容边界已同步。
- [x] 保留提交确认、身份校验和隔离验证门禁。
