### PR TITLE
fix(benchmark): handle non-object baseline validation

### DIFF
--- a/src/reposteward/benchmark.py
+++ b/src/reposteward/benchmark.py
@@ -37,6 +37,10 @@ ScenarioResult = dict[str, dict[str, Any]]
 Scenario = Callable[[], ScenarioResult]
 
 
+class BenchmarkReportError(ValueError):
+    pass
+
+
 def _canonical_json(value: object) -> str:
     return json.dumps(
         value,
@@ -933,7 +937,7 @@ def run_benchmark(
 def load_benchmark_report(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
-        raise TypeError("baseline benchmark report must be an object")
+        raise BenchmarkReportError("baseline benchmark report must be an object")
     validate_benchmark_report(value)
     return value
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -4,7 +4,7 @@ import hashlib
 import io
 import json
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -103,6 +103,58 @@ class RepoStewardBenchTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(printed, saved)
         self.assertEqual(printed["summary"]["scenario_count"], 1)
+
+    def test_cli_rejects_non_object_baseline_without_traceback(self) -> None:
+        with TemporaryDirectory() as directory:
+            baseline_path = Path(directory) / "baseline.json"
+            baseline_path.write_text("[]\n", encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = main(
+                    [
+                        "benchmark",
+                        "run",
+                        "--scenario",
+                        "context.utf8_estimate",
+                        "--baseline",
+                        str(baseline_path),
+                    ]
+                )
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(
+            stderr.getvalue(),
+            "reposteward: baseline benchmark report must be an object\n",
+        )
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_cli_accepts_valid_baseline(self) -> None:
+        with TemporaryDirectory() as directory:
+            baseline_path = Path(directory) / "baseline.json"
+            baseline_path.write_text(
+                json.dumps(run_benchmark(scenario_ids=("context.utf8_estimate",))),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "benchmark",
+                        "run",
+                        "--scenario",
+                        "context.utf8_estimate",
+                        "--baseline",
+                        str(baseline_path),
+                    ]
+                )
+
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(report["baseline_comparison"]["matched_scenarios"], 1)
 
     def test_invalid_repeat_and_empty_selection_fail_before_running(self) -> None:
         with self.assertRaisesRegex(ValueError, "repeat"):


### PR DESCRIPTION
## 关联 Issue

Closes #144

## 问题与改动

当 baseline 文件是合法 JSON、但顶层不是 object（例如 `[]`）时，`load_benchmark_report()` 原本会抛出未被 CLI 捕获的 `TypeError`，导致命令显示 Python traceback。

本 PR：

- 新增继承 `ValueError` 的 `BenchmarkReportError`；
- 对非 object baseline 抛出该异常，使其进入现有 CLI 错误处理；
- 保留合法 baseline 的现有行为；
- 增加非法和合法 baseline 的回归测试。

使用专用异常可以避免在 CLI 最外层捕获所有 `TypeError`，从而掩盖其他程序错误。

## 验证

```text
$ uv run python -m unittest discover -s tests -p 'test_benchmark.py' -v
Ran 9 tests
OK

$ uv run python -m unittest discover -s tests -v
Ran 609 tests
OK (skipped=1)

$ uvx ruff check .
All checks passed!

$ uvx ruff format --check .
140 files already formatted

$ uv run reposteward --help
通过

$ uv build
成功构建源码包和 wheel
```

非法 baseline 现在返回退出码 `2`，并输出：

```text
reposteward: baseline benchmark report must be an object
```

不再显示 traceback。

## 风险与兼容性

风险较低。修改仅影响 benchmark baseline 顶层类型错误的异常分类，合法 baseline 的读取和比较行为保持不变。

不涉及数据库迁移、Schema、依赖、凭据、GitHub 写入、Harness、Runner 或性能变化。

## 自动化辅助

使用 Codex 辅助问题定位、代码实现和测试准备。我已理解相关调用链，检查完整 diff，并确认修复前后的复现结果和测试结果。

## Checklist

- [x] PR 只解决一个已讨论的 Issue，没有捆绑无关改动。
- [x] 我已检查完整 diff，且没有凭据、账号缓存、数据库、运行日志或本机路径。
- [x] 我已运行相关测试、完整测试、lint、格式检查和构建，或准确说明未运行项。
- [x] 新行为有回归测试；无法自动测试时已说明原因。
- [x] 文档、示例、JSON Schema 和迁移已与行为同步，或不适用。
- [x] 没有绕过人工提交确认、GitHub 身份校验或隔离验证边界。